### PR TITLE
Implement PSF utilities

### DIFF
--- a/src/mophongo/psf.py
+++ b/src/mophongo/psf.py
@@ -1,0 +1,165 @@
+"""Point spread function utilities.
+
+This module provides a :class:`PSF` class which wraps a pixel grid
+representation of a point spread function. Instances can be created from
+analytic profiles (Moffat, Gaussian) or directly from a user supplied
+array. A method is included to compute a matching kernel between two PSFs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+def _moffat_psf(
+    size: int | tuple[int, int], fwhm_x: float, fwhm_y: float, beta: float, theta: float = 0.0
+) -> np.ndarray:
+    """Return a 2-D elliptical Moffat PSF normalized to unit sum."""
+    if isinstance(size, int):
+        ny = nx = size
+    else:
+        ny, nx = size
+
+    y, x = np.mgrid[:ny, :nx]
+    cy = (ny - 1) / 2
+    cx = (nx - 1) / 2
+    x = x - cx
+    y = y - cy
+
+    cos_t = np.cos(theta)
+    sin_t = np.sin(theta)
+
+    xr = x * cos_t + y * sin_t
+    yr = -x * sin_t + y * cos_t
+
+    factor = 2 ** (1 / beta) - 1
+    alpha_x = fwhm_x / (2 * np.sqrt(factor))
+    alpha_y = fwhm_y / (2 * np.sqrt(factor))
+
+    r2 = (xr / alpha_x) ** 2 + (yr / alpha_y) ** 2
+    psf = (1 + r2) ** (-beta)
+    psf /= psf.sum()
+    return psf
+
+
+def _gaussian_psf(
+    size: int | tuple[int, int], fwhm_x: float, fwhm_y: float, theta: float = 0.0
+) -> np.ndarray:
+    """Return a 2-D elliptical Gaussian PSF normalized to unit sum."""
+    if isinstance(size, int):
+        ny = nx = size
+    else:
+        ny, nx = size
+
+    y, x = np.mgrid[:ny, :nx]
+    cy = (ny - 1) / 2
+    cx = (nx - 1) / 2
+    x = x - cx
+    y = y - cy
+
+    cos_t = np.cos(theta)
+    sin_t = np.sin(theta)
+
+    xr = x * cos_t + y * sin_t
+    yr = -x * sin_t + y * cos_t
+
+    sigma_x = fwhm_x / (2 * np.sqrt(2 * np.log(2)))
+    sigma_y = fwhm_y / (2 * np.sqrt(2 * np.log(2)))
+
+    r2 = (xr / sigma_x) ** 2 + (yr / sigma_y) ** 2
+    psf = np.exp(-0.5 * r2)
+    psf /= psf.sum()
+    return psf
+
+
+@dataclass
+class PSF:
+    """Discrete point spread function."""
+
+    array: np.ndarray
+
+    def __post_init__(self) -> None:
+        arr = np.asarray(self.array, dtype=float)
+        s = arr.sum()
+        if s != 0:
+            arr = arr / s
+        self.array = arr
+
+    @classmethod
+    def moffat(
+        cls,
+        size: int | tuple[int, int],
+        fwhm_x: float,
+        fwhm_y: float,
+        beta: float,
+        theta: float = 0.0,
+    ) -> "PSF":
+        """Create a normalized Moffat PSF."""
+        return cls(_moffat_psf(size, fwhm_x, fwhm_y, beta, theta))
+
+    @classmethod
+    def gaussian(
+        cls,
+        size: int | tuple[int, int],
+        fwhm_x: float,
+        fwhm_y: float,
+        theta: float = 0.0,
+    ) -> "PSF":
+        """Create a normalized Gaussian PSF."""
+        return cls(_gaussian_psf(size, fwhm_x, fwhm_y, theta))
+
+    @classmethod
+    def from_array(cls, array: np.ndarray) -> "PSF":
+        """Create a PSF from an arbitrary pixel array."""
+        return cls(array)
+
+    def matching_kernel(self, other: "PSF", reg: float = 1e-3) -> np.ndarray:
+        """Return the convolution kernel that matches ``self`` to ``other``."""
+        return psf_matching_kernel(self.array, other.array, reg)
+
+
+def moffat_psf(
+    size: int | tuple[int, int],
+    fwhm_x: float,
+    fwhm_y: float,
+    beta: float,
+    theta: float = 0.0,
+) -> np.ndarray:
+    """Return a normalized Moffat PSF array.
+
+    This is a convenience wrapper around ``PSF.moffat`` returning the pixel
+    array directly.
+    """
+    return PSF.moffat(size, fwhm_x, fwhm_y, beta, theta).array
+
+
+def psf_matching_kernel(psf_hi: np.ndarray, psf_lo: np.ndarray, reg: float = 1e-3) -> np.ndarray:
+    """Compute a convolution kernel matching ``psf_hi`` to ``psf_lo``.
+
+    The kernel ``k`` is defined such that ``psf_hi * k \approx psf_lo`` when
+    convolved. The computation is done in the Fourier domain with a small
+    regularization term to avoid division by zero.
+
+    Parameters
+    ----------
+    psf_hi, psf_lo:
+        High- and low-resolution PSF arrays of identical shape. They must be
+        normalized to unit sum.
+    reg:
+        Regularization parameter added to the denominator in Fourier space.
+
+    Returns
+    -------
+    kernel: ``np.ndarray``
+        Convolution kernel with the same shape as the input PSFs.
+    """
+    if psf_hi.shape != psf_lo.shape:
+        raise ValueError("Input PSFs must have the same shape")
+
+    f_hi = np.fft.fft2(psf_hi)
+    f_lo = np.fft.fft2(psf_lo)
+    kernel_freq = f_lo / (f_hi + reg)
+    kernel = np.fft.ifft2(kernel_freq).real
+    return kernel

--- a/tests/test_psf.py
+++ b/tests/test_psf.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from mophongo.psf import PSF
+
+
+def test_moffat_psf_shape_and_normalization():
+    psf = PSF.moffat(11, fwhm_x=3.0, fwhm_y=3.0, beta=2.5)
+    assert psf.array.shape == (11, 11)
+    np.testing.assert_allclose(psf.array.sum(), 1.0, rtol=1e-6)
+
+
+def test_psf_matching_kernel_properties():
+    size = 15
+    psf_hi = PSF.moffat(size, 2.0, 2.0, beta=2.5)
+    psf_lo = PSF.moffat(size, 3.0, 3.0, beta=2.5)
+    kernel = psf_hi.matching_kernel(psf_lo)
+    assert kernel.shape == psf_hi.array.shape
+    conv = np.fft.ifft2(np.fft.fft2(psf_hi.array) * np.fft.fft2(kernel)).real
+    # kernel should transform psf_hi approximately into psf_lo
+    np.testing.assert_allclose(conv, psf_lo.array, rtol=1e-2, atol=5e-4)


### PR DESCRIPTION
## Summary
- add `PSF` dataclass with Moffat, Gaussian, and array constructors
- provide `matching_kernel` method and wrapper functions
- update tests to use the new class interface

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68678752a3c4832591af416c5c67b2e1