### PR TITLE
Implement template extraction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "numpy (>=2.3.1,<3.0.0)"
+    , "astropy (>=6.0,<7.0)"
+    , "photutils (>=1.9,<2.0)"
 ]
 
 [tool.poetry]

--- a/src/mophongo/templates.py
+++ b/src/mophongo/templates.py
@@ -1,0 +1,95 @@
+from dataclasses import dataclass
+from typing import Iterable, List, Tuple
+import numpy as np
+from astropy.nddata import Cutout2D
+from photutils.segmentation import SegmentationImage
+
+
+def _convolve2d(image: np.ndarray, kernel: np.ndarray) -> np.ndarray:
+    """Convolve ``image`` with ``kernel`` using direct sliding windows."""
+    ky, kx = kernel.shape
+    pad_y, pad_x = ky // 2, kx // 2
+    pad_before = (pad_y, pad_x)
+    pad_after = (ky - 1 - pad_y, kx - 1 - pad_x)
+    padded = np.pad(image, (pad_before, pad_after), mode="constant")
+    # Use sliding windows for convolution
+    from numpy.lib.stride_tricks import sliding_window_view
+    windows = sliding_window_view(padded, kernel.shape)
+    return np.einsum("ijkl,kl->ij", windows, kernel)
+
+
+@dataclass
+class Template:
+    array: np.ndarray
+    bbox: Tuple[int, int, int, int]
+
+
+def extract_templates(
+    hires_image: np.ndarray,
+    segmap: np.ndarray,
+    positions: Iterable[Tuple[float, float]],
+    kernel: np.ndarray,
+) -> List[Template]:
+    """Extract PSF-matched templates for a list of source positions.
+
+    Parameters
+    ----------
+    hires_image : np.ndarray
+        High-resolution image array.
+    segmap : np.ndarray
+        Segmentation map with integer labels identifying sources.
+    positions : iterable of tuple
+        List of (y, x) positions corresponding to objects.
+    kernel : np.ndarray
+        Convolution kernel to match the high-resolution PSF to the low-resolution PSF.
+
+    Returns
+    -------
+    templates : list of Template
+        Each template contains the PSF-matched cutout and its bounding box as
+        (y0, y1, x0, x1) in the high-resolution image coordinates.
+    """
+    if hires_image.shape != segmap.shape:
+        raise ValueError("hires_image and segmap must have the same shape")
+
+    templates: List[Template] = []
+    kernel = kernel / kernel.sum()
+
+    segm = SegmentationImage(segmap)
+
+    for pos in positions:
+        y, x = int(round(pos[0])), int(round(pos[1]))
+        if y < 0 or y >= segm.data.shape[0] or x < 0 or x >= segm.data.shape[1]:
+            continue
+        label = segm.data[y, x]
+        if label == 0:
+            continue
+
+        idx = segm.get_index(label)
+        bbox = segm.bbox[idx]
+
+        ky, kx = kernel.shape
+        pad_y, pad_x = ky // 2, kx // 2
+
+        y0_ext = bbox.iymin - pad_y
+        y1_ext = bbox.iymax + pad_y
+        x0_ext = bbox.ixmin - pad_x
+        x1_ext = bbox.ixmax + pad_x
+
+        height = y1_ext - y0_ext
+        width = x1_ext - x0_ext
+        center = ((x0_ext + x1_ext) / 2.0, (y0_ext + y1_ext) / 2.0)
+
+        cut = Cutout2D(hires_image, center, (height, width), mode="partial", fill_value=0.0)
+        mask_cut = Cutout2D((segm.data == label).astype(hires_image.dtype), center, (height, width), mode="partial", fill_value=0.0)
+        cutout = cut.data * mask_cut.data
+
+        flux = cutout.sum()
+        if flux == 0:
+            continue
+
+        cutout_norm = cutout / flux
+        conv = _convolve2d(cutout_norm, kernel)
+        templates.append(Template(conv, (y0_ext, y1_ext, x0_ext, x1_ext)))
+
+    return templates

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,38 @@
+import numpy as np
+from mophongo.templates import extract_templates
+
+
+def test_extract_templates_sizes_and_norm():
+    # simple 7x7 high-res image with two sources
+    hires = np.zeros((7, 7))
+    segmap = np.zeros_like(hires, dtype=int)
+
+    # source 1: 3x3 square around center with flux 9
+    segmap[2:5, 2:5] = 1
+    hires[2:5, 2:5] = 1.0
+
+    # source 2: 2x2 square bottom-right with flux 4
+    segmap[5:7, 5:7] = 2
+    hires[5:7, 5:7] = 2.0
+
+    # kernel normalized to sum 1
+    kernel = np.array([[0.0, 1.0, 0.0], [1.0, 4.0, 1.0], [0.0, 1.0, 0.0]])
+    kernel /= kernel.sum()
+
+    positions = [(3, 3), (5.5, 5.5)]
+    templates = extract_templates(hires, segmap, positions, kernel)
+
+    # check two templates
+    assert len(templates) == 2
+
+    # template 1 bounding box expected (1,6,1,6) -> size 5x5
+    t1 = templates[0]
+    assert t1.array.shape == (5, 5)
+    assert t1.bbox == (1, 6, 1, 6)
+    np.testing.assert_allclose(t1.array.sum(), 1.0, rtol=1e-6)
+
+    # template 2 bounding box expected (4,8,4,8) -> size 4x4 (extends beyond image)
+    t2 = templates[1]
+    assert t2.array.shape == (4, 4)
+    assert t2.bbox == (4, 8, 4, 8)
+    np.testing.assert_allclose(t2.array.sum(), 1.0, rtol=1e-6)


### PR DESCRIPTION
## Summary
- implement `extract_templates` helper for PSF-matched templates
- test template sizes and normalization
- use `Cutout2D` and `SegmentationImage`

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686787529d648325850d9c3975104bb3