### PR TITLE
Add pipeline orchestrator and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Mophongo
+
+A lightweight photometry pipeline.
+
+## Usage
+
+```python
+from astropy.io import fits
+from astropy.table import Table
+
+from mophongo.pipeline import run_photometry
+
+images = [fits.getdata("image1.fits"), fits.getdata("image2.fits")]
+segmap = fits.getdata("segmap.fits")
+catalog = Table.read("catalog.fits")
+psfs = [fits.getdata("psf1.fits"), fits.getdata("psf2.fits")]
+
+flux_table, residual = run_photometry(images, segmap, catalog, psfs)
+```
+
+The function returns the catalog with new flux columns and the residual image
+from the fit.

--- a/src/mophongo/pipeline.py
+++ b/src/mophongo/pipeline.py
@@ -1,0 +1,59 @@
+"""Simple pipeline orchestrator.
+
+This module exposes the :func:`run_photometry` function which ties together the
+high level steps of the photometry pipeline. The actual implementation of the
+template extraction and sparse fitting are delegated to the ``templates`` and
+``fit`` modules which will be implemented separately.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+from astropy.table import Table
+
+# The ``templates`` and ``fit`` modules are expected to provide the following
+# functions. They are imported lazily inside :func:`run_photometry` so that this
+# module can be imported even if those modules are not yet implemented.
+
+def run_photometry(
+    images: Sequence[np.ndarray],
+    segmap: np.ndarray,
+    catalog: Table,
+    psfs: Sequence[np.ndarray],
+) -> tuple[Table, np.ndarray]:
+    """Run photometry on a set of images.
+
+    Parameters
+    ----------
+    images
+        Sequence of image arrays to be fit.
+    segmap
+        Segmentation map aligned with the images.
+    catalog
+        Source catalog. New flux columns will be added to a copy of this table.
+    psfs
+        Point-spread functions matching each image.
+
+    Returns
+    -------
+    Table
+        Table containing the input catalog columns plus measured fluxes.
+    ndarray
+        Residual image after subtracting the model from the data.
+    """
+
+    if len(images) != len(psfs):
+        raise ValueError("Number of images and PSFs must match")
+
+    # Lazy imports so this module can be imported without the heavy dependencies
+    from . import templates, fit
+
+    # Build PSF-matched templates for each object
+    templates_list = templates.extract_templates(images, segmap, catalog, psfs)
+
+    # Solve for object fluxes using a sparse linear solver
+    flux_table, residual = fit.sparse_fit(images, templates_list, catalog, psfs)
+
+    return flux_table, residual


### PR DESCRIPTION
## Summary
- implement a `run_photometry` helper under `src/mophongo/pipeline.py`
- document pipeline usage in README
- fix unused import

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6867875470b0832583e7ce9f44ae0608