### PR TITLE
Clip template bbox extents

### DIFF
--- a/src/mophongo/templates.py
+++ b/src/mophongo/templates.py
@@ -97,6 +97,12 @@ class Templates:
             x0_ext = bbox.ixmin - pad_x
             x1_ext = bbox.ixmax + pad_x
 
+            ny, nx = hires_image.shape
+            y0_ext = max(0, y0_ext)
+            y1_ext = min(ny, y1_ext)
+            x0_ext = max(0, x0_ext)
+            x1_ext = min(nx, x1_ext)
+
             height = y1_ext - y0_ext
             width = x1_ext - x0_ext
             center = ((x0_ext + x1_ext) / 2.0, (y0_ext + y1_ext) / 2.0)

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -32,8 +32,8 @@ def test_extract_templates_sizes_and_norm():
     assert t1.bbox == (1, 6, 1, 6)
     np.testing.assert_allclose(t1.array.sum(), 1.0, rtol=1e-6)
 
-    # template 2 bounding box expected (4,8,4,8) -> size 4x4 (extends beyond image)
+    # template 2 bounding box expected to be clipped -> (4,7,4,7) -> size 3x3
     t2 = templates[1]
-    assert t2.array.shape == (4, 4)
-    assert t2.bbox == (4, 8, 4, 8)
-    np.testing.assert_allclose(t2.array.sum(), 1.0, rtol=1e-6)
+    assert t2.array.shape == (3, 3)
+    assert t2.bbox == (4, 7, 4, 7)
+    np.testing.assert_allclose(t2.array.sum(), 0.875, rtol=1e-6)


### PR DESCRIPTION
## Summary
- ensure extracted template bounding boxes stay within the image
- update tests for new clipped behaviour

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867ce8121d88325a9c2365f06872a12