### PR TITLE
Add diagnostic image output for pipeline tests

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -45,6 +45,7 @@ This checklist tracks tasks for building the Standalone Photometry Pipeline usin
     
 ## Testing
  - [x] Add simulated data utilities in `tests/utils.py`
- - [x] Create end-to-end tests in `tests/test_pipeline.py`
+- [x] Create end-to-end tests in `tests/test_pipeline.py`
 - [x] Run `pytest` to ensure all tests pass
+- [x] Save diagnostic plot during pipeline test
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -8,10 +8,10 @@ sys.path.insert(0, current)
 import numpy as np
 
 from mophongo.pipeline import run_photometry
-from utils import make_simple_data
+from utils import make_simple_data, save_diagnostic_image
 
 
-def test_pipeline_flux_recovery():
+def test_pipeline_flux_recovery(tmp_path):
     images, segmap, catalog, psfs, truth = make_simple_data()
     table, resid = run_photometry(images, segmap, catalog, psfs)
 
@@ -19,3 +19,8 @@ def test_pipeline_flux_recovery():
         col = f"flux_{idx}"
         assert np.allclose(table[col], truth, rtol=1e-2)
     assert resid.shape[0] == len(images)
+
+    model = images[1] - resid[1]
+    fname = tmp_path / "diagnostic.png"
+    save_diagnostic_image(fname, images[0], images[1], model, resid[1])
+    assert fname.exists()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,6 +3,7 @@ from astropy.table import Table
 
 from mophongo.psf import PSF
 from mophongo.templates import _convolve2d
+import matplotlib.pyplot as plt
 
 
 def make_simple_data():
@@ -30,3 +31,24 @@ def make_simple_data():
     catalog = Table({'y': [p[0] for p in yx], 'x': [p[1] for p in yx]})
 
     return [hires, lowres], segmap, catalog, [psf_hi.array, psf_lo.array], fluxes
+
+
+def save_diagnostic_image(
+    filename: str,
+    hires: np.ndarray,
+    lowres: np.ndarray,
+    model: np.ndarray,
+    residual: np.ndarray,
+) -> None:
+    """Save 2x2 diagnostic plot with grayscale images."""
+    fig, axes = plt.subplots(2, 2, figsize=(6, 6))
+    data = [hires, lowres, model, residual]
+    titles = ["hires", "lowres", "model", "residual"]
+    for ax, img, title in zip(axes.ravel(), data, titles):
+        ax.imshow(img, cmap="gray", origin="lower")
+        ax.set_title(title)
+        ax.set_xticks([])
+        ax.set_yticks([])
+    plt.tight_layout()
+    fig.savefig(filename, dpi=150)
+    plt.close(fig)


### PR DESCRIPTION
## Summary
- update checklist with diagnostic plot tracking
- add diagnostic PNG generator utility
- save pipeline diagnostic during tests

## Testing
- `pip install -e .`
- `pip install matplotlib`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867da182f0083259268f4f0d6a2a7a2