### PR TITLE
Update simulation with photutils datasets

### DIFF
--- a/src/mophongo/templates.py
+++ b/src/mophongo/templates.py
@@ -125,6 +125,9 @@ class Templates:
 
             cutout_norm = cutout / flux
             conv = _convolve2d(cutout_norm, kernel)
+            s = conv.sum()
+            if s != 0:
+                conv = conv / s
             self._templates.append(Template(conv, (y0_ext, y1_ext, x0_ext, x1_ext)))
 
         return self._templates


### PR DESCRIPTION
## Summary
- use `photutils.datasets` to generate truth images in tests
- create segmentation maps via `detect_sources` and `deblend_sources`
- normalize templates after convolution
- adjust noise level and detection parameters for stable flux recovery

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68688bc0ecac83259cf1afcc102ff332