### PR TITLE
Implement sparse error propagation

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -34,6 +34,7 @@ This checklist tracks tasks for building the Standalone Photometry Pipeline usin
   - don't implement source detection just yet: assume detection + segmentation image + catalog are available.
   - Load or receive arrays for the images, catalog, and PSFs.
   - Call template builder, construct sparse system, solve for fluxes, and return a table of measurements plus residuals.
+  - [x] Propagate RMS images as weights to compute flux uncertainties
  - [x] **Simulation utilities for tests** (`tests/utils.py`)
   - [x] Create fake catalogs and images with Moffat sources of varying size and ellipticity. positions are ra,dec
   - Produce matching high‑res and low‑res PSFs, with low res PSF at least 5x high res PSF.
@@ -49,4 +50,5 @@ This checklist tracks tasks for building the Standalone Photometry Pipeline usin
 - [x] Run `pytest` to ensure all tests pass
 - [x] Save diagnostic plot during pipeline test
 - [x] Save diagnostic plots for PSF, fitter and template tests
+- [x] Save output catalog to disk during pipeline test
 

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -11,7 +11,7 @@ from utils import make_simple_data, save_fit_diagnostic
 
 
 def test_flux_recovery(tmp_path):
-    images, segmap, catalog, psfs, truth_img = make_simple_data()
+    images, segmap, catalog, psfs, truth_img, rms = make_simple_data()
 
     psf_hi = PSF.from_array(psfs[0])
     psf_lo = PSF.from_array(psfs[1])
@@ -20,7 +20,7 @@ def test_flux_recovery(tmp_path):
     tmpls = Templates.from_image(
         images[0], segmap, list(zip(catalog["y"], catalog["x"])), kernel
     )
-    fitter = SparseFitter(list(tmpls), images[1], np.ones_like(images[1]), FitConfig())
+    fitter = SparseFitter(list(tmpls), images[1], 1.0 / rms[1] ** 2, FitConfig())
     fitter.build_normal_matrix()
     x, info = fitter.solve()
 
@@ -34,7 +34,7 @@ def test_flux_recovery(tmp_path):
 
 
 def test_ata_symmetry():
-    images, segmap, catalog, psfs, _ = make_simple_data()
+    images, segmap, catalog, psfs, _, rms = make_simple_data()
 
     psf_hi = PSF.from_array(psfs[0])
     psf_lo = PSF.from_array(psfs[1])
@@ -43,7 +43,7 @@ def test_ata_symmetry():
     tmpls = Templates.from_image(
         images[0], segmap, list(zip(catalog["y"], catalog["x"])), kernel
     )
-    fitter = SparseFitter(list(tmpls), images[1], np.ones_like(images[1]), FitConfig())
+    fitter = SparseFitter(list(tmpls), images[1], 1.0 / rms[1] ** 2, FitConfig())
     fitter.build_normal_matrix()
     ata = fitter.ata.toarray()
     assert np.allclose(ata, ata.T)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -7,14 +7,19 @@ sys.path.insert(0, current)
 
 import numpy as np
 import matplotlib.pyplot as plt
+from astropy.table import Table
 
 from mophongo.pipeline import run_photometry
-from utils import make_simple_data, save_diagnostic_image, save_flux_vs_truth_plot
+from utils import (
+    make_simple_data,
+    save_diagnostic_image,
+    save_flux_vs_truth_plot,
+)
 
 
 def test_pipeline_flux_recovery(tmp_path):
-    images, segmap, catalog, psfs, truth_img = make_simple_data()
-    table, resid = run_photometry(images, segmap, catalog, psfs)
+    images, segmap, catalog, psfs, truth_img, rms = make_simple_data()
+    table, resid = run_photometry(images, segmap, catalog, psfs, rms)
 
     table["flux_true"] = catalog["flux_true"]  # add flux_true to the table
 
@@ -67,5 +72,25 @@ def test_pipeline_flux_recovery(tmp_path):
         print(f"flux_{idx}/flux_true percentiles: 5th={np.percentile(ratio,5):.2f}, "
               f"16th={np.percentile(ratio,16):.2f}, 50th={np.percentile(ratio,50):.2f}, "
               f"84th={np.percentile(ratio,84):.2f}, 95th={np.percentile(ratio,95):.2f}")
+
+    # sanity check on propagated errors for low-res image
+    from mophongo.psf import PSF
+    from mophongo.templates import Templates
+    psf_hi = PSF.from_array(psfs[0])
+    psf_lo = PSF.from_array(psfs[1])
+    kernel = psf_hi.matching_kernel(psf_lo)
+    tmpls = Templates.from_image(images[0], segmap, list(zip(catalog["y"], catalog["x"])), kernel)
+    noise_std = rms[1][0, 0]
+    err_pred = np.array([noise_std / np.sqrt((t.array**2).sum()) for t in tmpls])
+    ratio_err = table["err_1"] / err_pred
+    assert np.allclose(np.mean(ratio_err), 1.0, atol=0.2)
+
+    table["err_pred"] = err_pred
+    cat_file = tmp_path / "photometry.cat"
+    table.write(cat_file, format="ascii.commented_header")
+    assert cat_file.exists()
+
+    loaded = Table.read(cat_file, format="ascii.commented_header")
+    assert len(loaded) == len(table)
 
     assert resid.shape[0] == len(images)

--- a/tests/test_psf.py
+++ b/tests/test_psf.py
@@ -17,7 +17,7 @@ def test_moffat_psf_shape_and_normalization():
 
 
 def test_psf_matching_kernel_properties(tmp_path):
-    _, _, _, psfs, _ = make_simple_data()
+    _, _, _, psfs, _, _ = make_simple_data()
     psf_hi = PSF.from_array(psfs[0])
     psf_lo = PSF.from_array(psfs[1])
     kernel = psf_hi.matching_kernel(psf_lo)

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -4,7 +4,7 @@ from mophongo.templates import Templates
 from utils import make_simple_data, save_template_diagnostic
 
 def test_extract_templates_sizes_and_norm(tmp_path):
-    images, segmap, catalog, psfs, truth_img = make_simple_data()
+    images, segmap, catalog, psfs, truth_img, _ = make_simple_data()
     psf_hi = PSF.from_array(psfs[0])
     psf_lo = PSF.from_array(psfs[1])
     kernel = psf_hi.matching_kernel(psf_lo)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -19,7 +19,7 @@ def make_simple_data(
     seed: int = 1001,
     nsrc: int = 15,
 ) -> tuple[
-    list[np.ndarray], np.ndarray, Table, list[np.ndarray], np.ndarray
+    list[np.ndarray], np.ndarray, Table, list[np.ndarray], np.ndarray, list[np.ndarray]
 ]:
     """Create a synthetic dataset with ``nsrc`` sources.
 
@@ -78,6 +78,8 @@ def make_simple_data(
     noise_std = amp_min / 50.0
     hires += rng.normal(scale=noise_std, size=hires.shape)
     lowres += rng.normal(scale=noise_std, size=lowres.shape)
+    rms_hi = np.ones_like(hires) * noise_std
+    rms_lo = np.ones_like(lowres) * noise_std
 
     threshold = noise_std * 5.0
     seg_detect = detect_sources(hires, threshold, npixels=5)
@@ -110,7 +112,14 @@ def make_simple_data(
         "flux_true": flux_true,
     })
 
-    return [hires, lowres], segmap, catalog, [psf_hi.array, psf_lo.array], truth
+    return (
+        [hires, lowres],
+        segmap,
+        catalog,
+        [psf_hi.array, psf_lo.array],
+        truth,
+        [rms_hi, rms_lo],
+    )
 
 
 def save_diagnostic_image(


### PR DESCRIPTION
## Summary
- implement `flux_errors` using sparse LU decomposition
- keep photometry pipeline's RMS weighting and error reporting
- compute predicted per-template error and persist output catalog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868a597528c83259afacf25b0a69486