### PR TITLE
Add analytic utilities and extension options

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -53,3 +53,4 @@ This checklist tracks tasks for building the Standalone Photometry Pipeline usin
 - [x] Save output catalog to disk during pipeline test
 
 - [x] Implement template extension methods (Moffat fit and PSF dilation)
+- [x] Added selectable template extension method in `run_photometry` and consolidated analytic profiles

--- a/src/mophongo/pipeline.py
+++ b/src/mophongo/pipeline.py
@@ -23,6 +23,8 @@ def run_photometry(
     catalog: Table,
     psfs: Sequence[np.ndarray],
     rms_images: Sequence[np.ndarray] | None = None,
+    *,
+    extend_templates: str | None = None,
 ) -> tuple[Table, np.ndarray]:
     """Run photometry on a set of images.
 
@@ -75,6 +77,10 @@ def run_photometry(
             kernel = hires_psf.matching_kernel(psf)
      
         tmpls = Templates.from_image(hires_image, segmap, positions, kernel)
+        if extend_templates == "psf_dilation":
+            tmpls.extend_with_psf_dilation(psf.array, kernel)
+        elif extend_templates == "2d_moffat":
+            tmpls.extend_with_moffat(kernel)
 
         weights = None
         if rms_images is not None and rms_images[idx] is not None:

--- a/src/mophongo/psf.py
+++ b/src/mophongo/psf.py
@@ -14,6 +14,9 @@ import numpy as np
 from photutils.psf import matching
 from photutils.psf.matching import TukeyWindow
 
+from .utils import elliptical_gaussian, elliptical_moffat
+
+
 def _moffat_psf(
     size: int | tuple[int, int], fwhm_x: float, fwhm_y: float, beta: float, theta: float = 0.0
 ) -> np.ndarray:
@@ -26,21 +29,17 @@ def _moffat_psf(
     y, x = np.mgrid[:ny, :nx]
     cy = (ny - 1) / 2
     cx = (nx - 1) / 2
-    x = x - cx
-    y = y - cy
-
-    cos_t = np.cos(theta)
-    sin_t = np.sin(theta)
-
-    xr = x * cos_t + y * sin_t
-    yr = -x * sin_t + y * cos_t
-
-    factor = 2 ** (1 / beta) - 1
-    alpha_x = fwhm_x / (2 * np.sqrt(factor))
-    alpha_y = fwhm_y / (2 * np.sqrt(factor))
-
-    r2 = (xr / alpha_x) ** 2 + (yr / alpha_y) ** 2
-    psf = (1 + r2) ** (-beta)
+    psf = elliptical_moffat(
+        y,
+        x,
+        1.0,
+        fwhm_x,
+        fwhm_y,
+        beta,
+        theta,
+        cx,
+        cy,
+    )
     psf /= psf.sum()
     return psf
 
@@ -57,20 +56,16 @@ def _gaussian_psf(
     y, x = np.mgrid[:ny, :nx]
     cy = (ny - 1) / 2
     cx = (nx - 1) / 2
-    x = x - cx
-    y = y - cy
-
-    cos_t = np.cos(theta)
-    sin_t = np.sin(theta)
-
-    xr = x * cos_t + y * sin_t
-    yr = -x * sin_t + y * cos_t
-
-    sigma_x = fwhm_x / (2 * np.sqrt(2 * np.log(2)))
-    sigma_y = fwhm_y / (2 * np.sqrt(2 * np.log(2)))
-
-    r2 = (xr / sigma_x) ** 2 + (yr / sigma_y) ** 2
-    psf = np.exp(-0.5 * r2)
+    psf = elliptical_gaussian(
+        y,
+        x,
+        1.0,
+        fwhm_x,
+        fwhm_y,
+        theta,
+        cx,
+        cy,
+    )
     psf /= psf.sum()
     return psf
 

--- a/src/mophongo/templates.py
+++ b/src/mophongo/templates.py
@@ -6,6 +6,8 @@ from astropy.nddata import Cutout2D
 from photutils.segmentation import SegmentationImage
 from skimage.morphology import binary_erosion, dilation, disk, footprint_rectangle
 
+from .utils import elliptical_moffat, measure_shape
+
 
 def _convolve2d(image: np.ndarray, kernel: np.ndarray) -> np.ndarray:
     """Convolve ``image`` with ``kernel`` using direct sliding windows."""
@@ -141,27 +143,6 @@ class Templates:
 
         return self._templates
 
-    @staticmethod
-    def _elliptical_moffat(
-        y: np.ndarray,
-        x: np.ndarray,
-        amplitude: float,
-        fwhm_x: float,
-        fwhm_y: float,
-        beta: float,
-        theta: float,
-        x0: float,
-        y0: float,
-    ) -> np.ndarray:
-        cos_t = np.cos(theta)
-        sin_t = np.sin(theta)
-        xr = (x - x0) * cos_t + (y - y0) * sin_t
-        yr = -(x - x0) * sin_t + (y - y0) * cos_t
-        factor = 2 ** (1 / beta) - 1
-        alpha_x = fwhm_x / (2 * np.sqrt(factor))
-        alpha_y = fwhm_y / (2 * np.sqrt(factor))
-        r2 = (xr / alpha_x) ** 2 + (yr / alpha_y) ** 2
-        return amplitude * (1 + r2) ** (-beta)
 
     def extend_with_moffat(
         self,
@@ -182,63 +163,40 @@ class Templates:
                 new_templates.append(tmpl_hi)
                 continue
 
-            y_idx, x_idx = np.indices(data.shape)
             flux = data[mask].sum()
-            y_c = (y_idx[mask] * data[mask]).sum() / flux
-            x_c = (x_idx[mask] * data[mask]).sum() / flux
-
-            y_rel = y_idx - y_c
-            x_rel = x_idx - x_c
-            cov_xx = (data[mask] * x_rel[mask] ** 2).sum() / flux
-            cov_yy = (data[mask] * y_rel[mask] ** 2).sum() / flux
-            cov_xy = (data[mask] * x_rel[mask] * y_rel[mask]).sum() / flux
-            cov = np.array([[cov_xx, cov_xy], [cov_xy, cov_yy]])
-            vals, vecs = np.linalg.eigh(cov)
-            order = np.argsort(vals)[::-1]
-            vals = vals[order]
-            vecs = vecs[:, order]
-            sigma_x = np.sqrt(vals[0])
-            sigma_y = np.sqrt(vals[1])
-            theta = np.arctan2(vecs[1, 0], vecs[0, 0])
+            x_c, y_c, sigma_x, sigma_y, theta = measure_shape(data, mask)
 
             fwhm_x = 2.355 * sigma_x
             fwhm_y = 2.355 * sigma_y
             beta_val = beta if beta is not None else 2.5
 
-            moffat_unit = self._elliptical_moffat(
-                y_idx,
-                x_idx,
-                1.0,
-                fwhm_x,
-                fwhm_y,
-                beta_val,
-                theta,
-                x_c,
-                y_c,
-            )
-            amp = flux / moffat_unit[mask].sum()
-
-            rmax = radius_factor * max(fwhm_x, fwhm_y)
-            size = int(np.ceil(2 * rmax)) + 1
+            # bounding box size accounting for ellipticity and angle
+            a = radius_factor * fwhm_x
+            b = radius_factor * fwhm_y
+            half_width = np.sqrt((a * np.cos(theta)) ** 2 + (b * np.sin(theta)) ** 2)
+            half_height = np.sqrt((a * np.sin(theta)) ** 2 + (b * np.cos(theta)) ** 2)
 
             cy_global = tmpl_hi.bbox[0] + y_c
             cx_global = tmpl_hi.bbox[2] + x_c
 
-            y0 = int(round(cy_global - size / 2))
-            x0 = int(round(cx_global - size / 2))
+            y0 = int(np.floor(cy_global - half_height))
+            x0 = int(np.floor(cx_global - half_width))
+            y1 = int(np.ceil(cy_global + half_height))
+            x1 = int(np.ceil(cx_global + half_width))
+
             y0 = max(0, y0)
             x0 = max(0, x0)
-            y1 = min(self.hires_shape[0], y0 + size)
-            x1 = min(self.hires_shape[1], x0 + size)
+            y1 = min(self.hires_shape[0], y1)
+            x1 = min(self.hires_shape[1], x1)
 
             ny = y1 - y0
             nx = x1 - x0
             y_grid, x_grid = np.indices((ny, nx))
 
-            moffat_ext = self._elliptical_moffat(
+            moffat_unit = elliptical_moffat(
                 y_grid,
                 x_grid,
-                amp,
+                1.0,
                 fwhm_x,
                 fwhm_y,
                 beta_val,
@@ -247,37 +205,23 @@ class Templates:
                 cy_global - y0,
             )
 
-            # Create extended template with original data preserved
-            extended_template = np.zeros_like(moffat_ext)
-            
-            # Map original template coordinates to extended template coordinates
+            # map original template region into extended grid
             orig_y0 = tmpl_hi.bbox[0] - y0
-            orig_y1 = tmpl_hi.bbox[1] - y0
             orig_x0 = tmpl_hi.bbox[2] - x0
-            orig_x1 = tmpl_hi.bbox[3] - x0
-            
-            # Ensure coordinates are within bounds
-            orig_y0 = max(0, orig_y0)
-            orig_y1 = min(ny, orig_y1)
-            orig_x0 = max(0, orig_x0)
-            orig_x1 = min(nx, orig_x1)
-            
-            # Use original data where the segment exists
+            orig_y1 = orig_y0 + data.shape[0]
+            orig_x1 = orig_x0 + data.shape[1]
+
+            amp = flux / moffat_unit[orig_y0:orig_y1, orig_x0:orig_x1][mask].sum()
+
+            moffat_ext = moffat_unit * amp
+
+            # Create extended template with original data preserved
+            extended_template = moffat_ext.copy()
+
             if orig_y1 > orig_y0 and orig_x1 > orig_x0:
-                # Calculate the slice of original data that fits in the extended template
-                data_y0 = max(0, y0 - tmpl_hi.bbox[0])
-                data_y1 = data_y0 + (orig_y1 - orig_y0)
-                data_x0 = max(0, x0 - tmpl_hi.bbox[2])
-                data_x1 = data_x0 + (orig_x1 - orig_x0)
-                
-                extended_template[orig_y0:orig_y1, orig_x0:orig_x1] = data[data_y0:data_y1, data_x0:data_x1]
-                
-                # Use Moffat profile only where original data is zero (outside segment)
-                original_mask = extended_template > 0
-                extended_template[~original_mask] = moffat_ext[~original_mask]
-            else:
-                # If no overlap, use full Moffat profile
-                extended_template = moffat_ext
+                data_slice = extended_template[orig_y0:orig_y1, orig_x0:orig_x1]
+                data_slice[mask] = data[mask]
+                extended_template[orig_y0:orig_y1, orig_x0:orig_x1] = data_slice
 
             conv = _convolve2d(extended_template, kernel)
             if conv.sum() != 0:

--- a/src/mophongo/utils.py
+++ b/src/mophongo/utils.py
@@ -1,0 +1,80 @@
+"""Utility functions for analytic profiles and shape measurements."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def elliptical_moffat(
+    y: np.ndarray,
+    x: np.ndarray,
+    amplitude: float,
+    fwhm_x: float,
+    fwhm_y: float,
+    beta: float,
+    theta: float,
+    x0: float,
+    y0: float,
+) -> np.ndarray:
+    """Return an elliptical Moffat profile evaluated on ``x`` and ``y`` grids."""
+    cos_t = np.cos(theta)
+    sin_t = np.sin(theta)
+    xr = (x - x0) * cos_t + (y - y0) * sin_t
+    yr = -(x - x0) * sin_t + (y - y0) * cos_t
+    factor = 2 ** (1 / beta) - 1
+    alpha_x = fwhm_x / (2 * np.sqrt(factor))
+    alpha_y = fwhm_y / (2 * np.sqrt(factor))
+    r2 = (xr / alpha_x) ** 2 + (yr / alpha_y) ** 2
+    return amplitude * (1 + r2) ** (-beta)
+
+
+def elliptical_gaussian(
+    y: np.ndarray,
+    x: np.ndarray,
+    amplitude: float,
+    fwhm_x: float,
+    fwhm_y: float,
+    theta: float,
+    x0: float,
+    y0: float,
+) -> np.ndarray:
+    """Return an elliptical Gaussian profile evaluated on ``x`` and ``y`` grids."""
+    cos_t = np.cos(theta)
+    sin_t = np.sin(theta)
+    xr = (x - x0) * cos_t + (y - y0) * sin_t
+    yr = -(x - x0) * sin_t + (y - y0) * cos_t
+    sigma_x = fwhm_x / (2 * np.sqrt(2 * np.log(2)))
+    sigma_y = fwhm_y / (2 * np.sqrt(2 * np.log(2)))
+    r2 = (xr / sigma_x) ** 2 + (yr / sigma_y) ** 2
+    return amplitude * np.exp(-0.5 * r2)
+
+
+def measure_shape(data: np.ndarray, mask: np.ndarray) -> tuple[float, float, float, float, float]:
+    """Return ``x_c``, ``y_c``, ``sigma_x``, ``sigma_y``, and ``theta`` of ``data``.
+
+    Parameters
+    ----------
+    data : ndarray
+        Pixel data.
+    mask : ndarray
+        Boolean mask selecting the object pixels.
+    """
+    y_idx, x_idx = np.indices(data.shape)
+    flux = float(data[mask].sum())
+    y_c = float((y_idx[mask] * data[mask]).sum() / flux)
+    x_c = float((x_idx[mask] * data[mask]).sum() / flux)
+    y_rel = y_idx - y_c
+    x_rel = x_idx - x_c
+    cov_xx = float((data[mask] * x_rel[mask] ** 2).sum() / flux)
+    cov_yy = float((data[mask] * y_rel[mask] ** 2).sum() / flux)
+    cov_xy = float((data[mask] * x_rel[mask] * y_rel[mask]).sum() / flux)
+    cov = np.array([[cov_xx, cov_xy], [cov_xy, cov_yy]])
+    vals, vecs = np.linalg.eigh(cov)
+    order = np.argsort(vals)[::-1]
+    vals = vals[order]
+    vecs = vecs[:, order]
+    sigma_x = float(np.sqrt(vals[0]))
+    sigma_y = float(np.sqrt(vals[1]))
+    theta = float(np.arctan2(vecs[1, 0], vecs[0, 0]))
+    return x_c, y_c, sigma_x, sigma_y, theta
+


### PR DESCRIPTION
## Summary
- provide `elliptical_moffat`, `elliptical_gaussian` and `measure_shape` helpers
- use helpers in PSF and template code
- extend templates with Moffat using single profile evaluation
- add template extension option to `run_photometry`
- update checklist

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b52c713408325b3a2371d3c48cabb