### PR TITLE
Add PSF fitting methods

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -20,6 +20,7 @@ This checklist tracks tasks for building the Standalone Photometry Pipeline usin
 - [x] **PSF utilities** (`src/mophongo/psf.py`)
   - `moffat_psf` Generate Moffat PSF images (ellipticity/FWHM/beta parameters).
   - `psf_matching_kernel` to Compute convolution kernels to transform the high‑resolution PSF into the low‑resolution PSF (Fourier domain or direct numerical solution)
+  - [x] Add methods to fit Moffat and Gaussian profiles to existing PSF arrays
 - [x] **Template builder** (`src/mophongo/templates.py`)
   - `extract_templates` to create PSF-matched templates
   - Extract per-object cutouts from the high‑res image using the detection segmentation.

--- a/tests/test_psf.py
+++ b/tests/test_psf.py
@@ -8,7 +8,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from mophongo.psf import PSF, pad_to_shape
 from mophongo.templates import _convolve2d
-from utils import make_simple_data, save_psf_diagnostic
+from utils import make_simple_data, save_psf_diagnostic, save_psf_fit_diagnostic
 
 def test_moffat_psf_shape_and_normalization():
     psf = PSF.moffat(11, fwhm_x=3.0, fwhm_y=3.0, beta=2.5)
@@ -30,3 +30,25 @@ def test_psf_matching_kernel_properties(tmp_path):
     fname = tmp_path / "psf_kernel.png"
     save_psf_diagnostic(fname, hi_pad, psf_lo.array, kernel)
     assert fname.exists()
+
+
+def test_psf_moffat_fit(tmp_path):
+    psf = PSF.moffat(31, fwhm_x=3.2, fwhm_y=4.5, beta=2.8, theta=0.3)
+    params = psf.fit_moffat()
+    assert np.isclose(params.beta, 2.8, rtol=0.1)
+    psf_fit = PSF.moffat(psf.array.shape, params.fwhm_x, params.fwhm_y, params.beta, params.theta)
+    fname = tmp_path / "psf_fit_moffat.png"
+    save_psf_fit_diagnostic(fname, psf.array, psf_fit.array)
+    assert fname.exists()
+    np.testing.assert_allclose(psf_fit.array, psf.array, rtol=0, atol=5e-2)
+
+
+def test_psf_gaussian_fit(tmp_path):
+    psf = PSF.gaussian(31, fwhm_x=2.5, fwhm_y=3.0, theta=0.2)
+    params = psf.fit_gaussian()
+
+    psf_fit = PSF.gaussian(psf.array.shape, params.fwhm_x, params.fwhm_y, params.theta)
+    fname = tmp_path / "psf_fit_gaussian.png"
+    save_psf_fit_diagnostic(fname, psf.array, psf_fit.array)
+    assert fname.exists()
+    np.testing.assert_allclose(psf_fit.array, psf.array, rtol=0, atol=5e-2)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -407,6 +407,26 @@ def save_flux_vs_truth_plot(
     plt.close(fig)
 
 
+def save_psf_fit_diagnostic(filename: str, psf: np.ndarray, model: np.ndarray) -> None:
+    """Save diagnostic image comparing PSF data with a fitted model."""
+    resid = psf - model
+    fig, axes = plt.subplots(1, 3, figsize=(9, 3))
+    images = [psf, model, resid]
+    titles = ["psf", "model", "resid"]
+    for ax, img, title in zip(axes, images, titles):
+        if title == "resid":
+            v = np.max(np.abs(resid))
+            ax.imshow(img, cmap="gray", origin="lower", vmin=-v, vmax=v)
+        else:
+            ax.imshow(img, cmap="gray", origin="lower", norm=lupton_norm(psf))
+        ax.set_title(title)
+        ax.set_xticks([])
+        ax.set_yticks([])
+    plt.tight_layout()
+    fig.savefig(filename, dpi=150)
+    plt.close(fig)
+
+
 def label_segmap(ax, segmap, catalog):
     for idx, (y, x) in enumerate(zip(catalog["y"], catalog["x"]), start=1):
         ax.text(x, y, str(idx), color="white", fontsize=10, ha="center", va="center", weight="bold")


### PR DESCRIPTION
## Summary
- add dataclasses and fitting routines for Moffat/Gaussian PSFs
- support diagnostic plots for PSF fit results
- test PSF fitting accuracy
- update checklist

## Testing
- `poetry install`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b54eb931483258c85c0bbe7d692be