### PR TITLE
Fix template extraction padding

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -56,3 +56,4 @@ This checklist tracks tasks for building the Standalone Photometry Pipeline usin
 - [x] Implement template extension methods (Moffat fit and PSF dilation)
 - [x] Added selectable template extension method in `run_photometry` and consolidated analytic profiles
 - [x] Benchmarked key pipeline steps in `tests/test_benchmark.py`
+- [x] Introduced Cutout2D-based template extraction and normal matrix helpers

--- a/src/mophongo/__init__.py
+++ b/src/mophongo/__init__.py
@@ -1,8 +1,10 @@
-from .templates import Template
+from .templates import Template, TemplateNew, extract_templates_new
 from .fit import FitConfig, SparseFitter
 
 __all__ = [
     "Template",
+    "TemplateNew",
+    "extract_templates_new",
     "FitConfig",
     "SparseFitter",
 ]


### PR DESCRIPTION
## Summary
- avoid clipping in `extract_templates_new`
- convolve only valid region and embed result back in padded cutout

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d3a68767c832595f310c22373d48b