### PR TITLE
Rename template class defaults

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -57,3 +57,4 @@ This checklist tracks tasks for building the Standalone Photometry Pipeline usin
 - [x] Added selectable template extension method in `run_photometry` and consolidated analytic profiles
 - [x] Benchmarked key pipeline steps in `tests/test_benchmark.py`
 - [x] Introduced Cutout2D-based template extraction and normal matrix helpers
+- [x] Renamed TemplateNew to Template and updated extraction defaults

--- a/src/mophongo/__init__.py
+++ b/src/mophongo/__init__.py
@@ -1,10 +1,10 @@
-from .templates import Template, TemplateNew, extract_templates_new
+from .templates import Template, TemplateOld, extract_templates
 from .fit import FitConfig, SparseFitter
 
 __all__ = [
     "Template",
-    "TemplateNew",
-    "extract_templates_new",
+    "TemplateOld",
+    "extract_templates",
     "FitConfig",
     "SparseFitter",
 ]

--- a/src/mophongo/fit.py
+++ b/src/mophongo/fit.py
@@ -106,7 +106,7 @@ class SparseFitter:
         return slice(y0, y1), slice(x0, x1)
 
     def build_normal_matrix_new(self) -> None:
-        """Construct normal matrix using :class:`TemplateNew` objects."""
+        """Construct normal matrix using :class:`Template` objects."""
         n = len(self.templates)
         ata = lil_matrix((n, n))
         atb = np.zeros(n)

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -6,7 +6,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 import numpy as np
 from mophongo.fit import FitConfig, SparseFitter
 from mophongo.psf import PSF
-from mophongo.templates import Templates, TemplateNew, extract_templates_new
+from mophongo.templates import Templates, Template, extract_templates
 from utils import make_simple_data, save_fit_diagnostic
 
 
@@ -59,7 +59,7 @@ def test_build_normal_matrix_new_equivalence():
     old = Templates.from_image(
         images[0], segmap, list(zip(catalog["y"], catalog["x"])), kernel
     )
-    new = extract_templates_new(
+    new = extract_templates(
         images[0], segmap, list(zip(catalog["y"], catalog["x"])), kernel
     )
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,6 +1,6 @@
 import numpy as np
 from mophongo.psf import PSF
-from mophongo.templates import Templates, TemplateNew, extract_templates_new
+from mophongo.templates import Templates, Template, extract_templates
 from utils import make_simple_data, save_template_diagnostic
 import pytest
 
@@ -55,7 +55,7 @@ def test_template_extension_methods(tmp_path):
     )
     assert fname_moff.exists()
 
-    tmpl.extract_templates(images[0], segmap, list(zip(catalog["y"], catalog["x"])), kernel)
+    tmpl.extract_templates_old(images[0], segmap, list(zip(catalog["y"], catalog["x"])), kernel)
     orig_templates_hi = list(tmpl._templates_hires)
     tmpls_dil = tmpl.extend_with_psf_dilation(psf_hi.array, kernel, iterations=2)
     for t in tmpls_dil:
@@ -72,7 +72,7 @@ def test_template_extension_methods(tmp_path):
     assert fname_dil.exists()
 
     # Test simple PSF dilation extension
-    tmpl.extract_templates(images[0], segmap, list(zip(catalog["y"], catalog["x"])), kernel)
+    tmpl.extract_templates_old(images[0], segmap, list(zip(catalog["y"], catalog["x"])), kernel)
     orig_templates_hi = list(tmpl._templates_hires)
     tmpls_simple = tmpl.extend_with_psf_dilation_simple(psf_hi.array, kernel, radius_factor=2.0)
 #    for t in tmpls_simple:
@@ -100,7 +100,7 @@ def test_extract_templates_new_equivalence():
     old = Templates.from_image(
         images[0], segmap, list(zip(catalog["y"], catalog["x"])), kernel
     )
-    new = extract_templates_new(
+    new = extract_templates(
         images[0], segmap, list(zip(catalog["y"], catalog["x"])), kernel
     )
 


### PR DESCRIPTION
## Summary
- rename `TemplateNew` to `Template`
- keep dataclass as `TemplateOld`
- update tests and imports for new names
- document rename in checklist

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d46f4eb688325a619a9a242f476e4