### PR TITLE
Refactor catalog utilities and diagnostics

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -59,4 +59,4 @@ This checklist tracks tasks for building the Standalone Photometry Pipeline usin
 - [x] Benchmarked key pipeline steps in `tests/test_benchmark.py`
 - [x] Introduced Cutout2D-based template extraction and normal matrix helpers
 - [x] Renamed TemplateNew to Template and updated extraction defaults
-- [x] Implemented basic `CatalogBuilder` for source detection
+- [x] Implemented basic `Catalog` for source detection

--- a/src/mophongo/__init__.py
+++ b/src/mophongo/__init__.py
@@ -1,11 +1,11 @@
 from .templates import Template, TemplateOld
 from .fit import FitConfig, SparseFitter
-from .catalog import CatalogBuilder
+from .catalog import Catalog
 
 __all__ = [
     "Template",
     "TemplateOld",
     "FitConfig",
     "SparseFitter",
-    "CatalogBuilder",
+    "Catalog",
 ]

--- a/src/mophongo/catalog.py
+++ b/src/mophongo/catalog.py
@@ -16,71 +16,86 @@ from photutils.segmentation import SourceCatalog, detect_sources, deblend_source
 from skimage.morphology import binary_dilation, disk
 from astropy.nddata import block_reduce, block_replicate
 
-__all__ = ["CatalogBuilder"]
+__all__ = ["Catalog", "estimate_background", "calibrate_wht"]
+
+
+def estimate_background(sci: np.ndarray, nbin: int = 4) -> float:
+    """Estimate image background using sigma-clipped median."""
+    binned = block_reduce(sci, (nbin, nbin), func=np.mean)
+    clipped = SigmaClip(sigma=3.0)(binned)
+    return float(np.median(clipped))
+
+
+def calibrate_wht(
+    sci: np.ndarray,
+    wht: np.ndarray,
+    *,
+    background: float = 0.0,
+    nbin: int = 4,
+    ndilate: int = 2,
+) -> np.ndarray:
+    """Calibrate weight map using noise estimates from the image."""
+    sci_sub = sci - background
+    sci_bin = block_reduce(sci_sub, (nbin, nbin), func=np.mean)
+    wht_bin = block_reduce(wht, (nbin, nbin), func=np.mean)
+    det_bin = sci_bin * np.sqrt(wht_bin)
+    clipped = SigmaClip(sigma=3.0)(det_bin)
+    mask = clipped.mask
+    if ndilate > 0:
+        mask = binary_dilation(mask, disk(ndilate))
+    std = MADStdBackgroundRMS()(det_bin[~mask])
+    sqrt_wht = np.sqrt(wht_bin) / std
+    wht_bin_cal = sqrt_wht**2
+    expanded = block_replicate(wht_bin_cal, (nbin, nbin), conserve_sum=False)
+    ny, nx = sci.shape
+    if expanded.shape[0] < ny or expanded.shape[1] < nx:
+        pad_y = ny - expanded.shape[0]
+        pad_x = nx - expanded.shape[1]
+        expanded = np.pad(expanded, ((0, pad_y), (0, pad_x)), mode="edge")
+    return expanded[:ny, :nx] / (nbin**2)
 
 
 @dataclass
-class CatalogBuilder:
+class Catalog:
     """Create a catalog from a science image and weight map."""
 
     sci: np.ndarray
     wht: np.ndarray
     nbin: int = 4
     ndilate: int = 2
-    estimate_background: bool = True
-    calibrate_wht: bool = True
+    kernel_size: int = 5
+    estimate_background: bool = False
+    calibrate_wht: bool = False
 
     background: float = 0.0
     ivar: np.ndarray | None = None
     segmap: np.ndarray | None = None
     catalog: Table | None = None
-
-    def _estimate_background(self) -> float:
-        binned = block_reduce(self.sci, (self.nbin, self.nbin), func=np.mean)
-        sc = SigmaClip(sigma=3.0)
-        clipped = sc(binned)
-        return float(np.median(clipped))
-
-    def _calibrate_wht(self) -> np.ndarray:
-        sci_sub = self.sci - self.background
-        sci_bin = block_reduce(sci_sub, (self.nbin, self.nbin), func=np.mean)
-        wht_bin = block_reduce(self.wht, (self.nbin, self.nbin), func=np.mean)
-        det_bin = sci_bin * np.sqrt(wht_bin)
-        sc = SigmaClip(sigma=3.0)
-        clipped = sc(det_bin)
-        mask = clipped.mask
-        if self.ndilate > 0:
-            mask = binary_dilation(mask, disk(self.ndilate))
-        std = MADStdBackgroundRMS()(det_bin[~mask])
-        sqrt_wht = np.sqrt(wht_bin) / std
-        wht_bin_cal = sqrt_wht ** 2
-        expanded = block_replicate(wht_bin_cal, (self.nbin, self.nbin), conserve_sum=False)
-        ny, nx = self.sci.shape
-        if expanded.shape[0] < ny or expanded.shape[1] < nx:
-            pad_y = ny - expanded.shape[0]
-            pad_x = nx - expanded.shape[1]
-            expanded = np.pad(expanded, ((0, pad_y), (0, pad_x)), mode="edge")
-        wht_full = expanded[:ny, :nx] / (self.nbin ** 2)
-
-        return wht_full
+    det_img: np.ndarray | None = None
 
     def _detect(self) -> None:
-        det_img = (self.sci - self.background) * np.sqrt(self.ivar)
-        kernel = Gaussian2DKernel(2.0 / 2.355, x_size=5, y_size=5)
+        self.det_img = (self.sci - self.background) * np.sqrt(self.ivar)
+        kernel = Gaussian2DKernel(2.0 / 2.355, x_size=self.kernel_size, y_size=self.kernel_size)
         from astropy.convolution import convolve
-        smooth = convolve(det_img, kernel, normalize_kernel=True)
+        smooth = convolve(self.det_img, kernel, normalize_kernel=True)
         seg = detect_sources(smooth, threshold=2.0, npixels=5)
-        seg = deblend_sources(det_img, seg, npixels=5, nlevels=32, contrast=1.0e-6, progress_bar=False)
+        seg = deblend_sources(self.det_img, seg, npixels=5, nlevels=32, contrast=1.0e-6, progress_bar=False)
         self.segmap = seg.data
         catalog = SourceCatalog(self.sci, seg, error=np.sqrt(1.0 / self.ivar))
         self.catalog = catalog.to_table()
 
     def run(self, ivar_outfile: str | Path | None = None, header: fits.Header | None = None) -> None:
         if self.estimate_background:
-            self.background = self._estimate_background()
+            self.background = estimate_background(self.sci, self.nbin)
             self.sci = self.sci - self.background
         if self.calibrate_wht:
-            self.ivar = self._calibrate_wht()
+            self.ivar = calibrate_wht(
+                self.sci,
+                self.wht,
+                background=self.background,
+                nbin=self.nbin,
+                ndilate=self.ndilate,
+            )
         else:
             self.ivar = self.wht
         if ivar_outfile is not None:
@@ -100,7 +115,7 @@ class CatalogBuilder:
         *,
         ivar_outfile: str | Path | None = None,
         **kwargs,
-    ) -> "CatalogBuilder":
+    ) -> "Catalog":
         sci = fits.getdata(sci_file)
         wht = fits.getdata(wht_file)
         header = fits.getheader(sci_file)

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -2,14 +2,19 @@ import numpy as np
 from pathlib import Path
 from astropy.io import fits
 
-from mophongo.catalog import CatalogBuilder
+from mophongo.catalog import Catalog
+from photutils.segmentation import SegmentationImage, SourceCatalog
+import matplotlib.pyplot as plt
+from utils import lupton_norm, label_segmap
 
 
-def test_catalog_builder(tmp_path):
+def test_catalog(tmp_path):
     sci = Path('data/uds-test-f444w_sci.fits')
     wht = Path('data/uds-test-f444w_wht.fits')
     out = tmp_path / 'uds-test-f444w_ivar.fits'
-    cat = CatalogBuilder.from_fits(sci, wht, ivar_outfile=out)
+    cat = Catalog.from_fits(sci, wht, ivar_outfile=out)
+    cat.catalog["x"] = cat.catalog["xcentroid"]
+    cat.catalog["y"] = cat.catalog["ycentroid"]
 
     assert cat.segmap.shape == cat.sci.shape
     assert cat.ivar.shape == cat.sci.shape
@@ -18,3 +23,18 @@ def test_catalog_builder(tmp_path):
     assert out.exists()
     hdr = fits.getheader(out)
     assert 'CRPIX1' in hdr
+
+    fig, ax = plt.subplots(figsize=(6, 6))
+    ax.imshow(cat.det_img, origin="lower", cmap="gray", norm=lupton_norm(cat.det_img))
+    ax.imshow(cat.segmap, origin="lower", cmap="nipy_spectral", alpha=0.3)
+    label_segmap(ax, cat.segmap, cat.catalog)
+
+    seg = SegmentationImage(cat.segmap)
+    scat = SourceCatalog(cat.sci, seg, error=np.sqrt(1.0 / cat.ivar))
+    for aper in scat.kron_aperture:
+        aper.plot(ax=ax, color="white", lw=0.5)
+
+    diag = tmp_path / "catalog_diagnostic.png"
+    fig.savefig(diag, dpi=150)
+    plt.close(fig)
+    assert diag.exists()


### PR DESCRIPTION
## Summary
- expose `estimate_background` and `calibrate_wht` as module functions
- rename `CatalogBuilder` class to `Catalog`
- allow configurable detection kernel size and store detection image
- default background and weight calibration to off
- generate diagnostic plot in `test_catalog`
- update checklist

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871c8d2dc8083259c4b17a7e756388b