### PR TITLE
Allow configurable detection in Catalog

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -60,3 +60,4 @@ This checklist tracks tasks for building the Standalone Photometry Pipeline usin
 - [x] Introduced Cutout2D-based template extraction and normal matrix helpers
 - [x] Renamed TemplateNew to Template and updated extraction defaults
 - [x] Implemented basic `Catalog` for source detection
+- [x] Added configurable detection parameters in `Catalog`

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -4,6 +4,7 @@ from astropy.io import fits
 
 from mophongo.catalog import Catalog
 from photutils.segmentation import SegmentationImage, SourceCatalog
+from photutils.aperture import CircularAperture, aperture_photometry
 import matplotlib.pyplot as plt
 from utils import lupton_norm, label_segmap
 
@@ -12,9 +13,12 @@ def test_catalog(tmp_path):
     sci = Path('data/uds-test-f444w_sci.fits')
     wht = Path('data/uds-test-f444w_wht.fits')
     out = tmp_path / 'uds-test-f444w_ivar.fits'
-    cat = Catalog.from_fits(sci, wht, ivar_outfile=out)
+    params = {"detect_threshold": 1.5, "detect_npixels": 5}
+    cat = Catalog.from_fits(sci, wht, ivar_outfile=out, params=params)
     cat.catalog["x"] = cat.catalog["xcentroid"]
     cat.catalog["y"] = cat.catalog["ycentroid"]
+
+    assert cat.params["detect_threshold"] == 1.5
 
     assert cat.segmap.shape == cat.sci.shape
     assert cat.ivar.shape == cat.sci.shape


### PR DESCRIPTION
## Summary
- make detection and deblending parameters configurable via `Catalog.params`
- fix bug where catalog table wasn't stored
- adjust tests to exercise new options
- record new checklist item

## Testing
- `poetry run pytest tests/test_catalog.py::test_catalog -q`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872016369dc8325866bf0b75481e2b5