### PR TITLE
Add compactness-enabled deblend sources

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -64,3 +64,4 @@ This checklist tracks tasks for building the Standalone Photometry Pipeline usin
 - [x] Added custom deblending using max-tree and SEP steepest-descent
 - [x] Added colour-aware deblending with chi² detection
 - [x] Implemented symmetry-based deblender
+- [x] Added compactness parameter in photutils-based deblender

--- a/src/mophongo/__init__.py
+++ b/src/mophongo/__init__.py
@@ -2,6 +2,7 @@ from .templates import Template, TemplateOld
 from .fit import FitConfig, SparseFitter
 from .catalog import Catalog
 from .deblender import deblend_sources_symmetry
+from .photutils_deblend import deblend_sources
 
 __all__ = [
     "Template",
@@ -10,4 +11,5 @@ __all__ = [
     "SparseFitter",
     "Catalog",
     "deblend_sources_symmetry",
+    "deblend_sources",
 ]

--- a/src/mophongo/catalog.py
+++ b/src/mophongo/catalog.py
@@ -16,9 +16,9 @@ from astropy.stats import SigmaClip
 from photutils.segmentation import (
     SourceCatalog,
     detect_sources,
-    deblend_sources,
     SegmentationImage,
 )
+from .photutils_deblend import deblend_sources
 from skimage.morphology import dilation, disk, max_tree
 from skimage.segmentation import watershed
 from skimage.measure import label
@@ -265,6 +265,7 @@ def deblend_sources_color(
     contrast: float = 1e-4,
     color_thresh: float = 0.3,
     nsigma: float = 3.0,
+    compactness: float = 0.0,
 ) -> SegmentationImage:
     """Chi² detection and colour-aware deblending.
 
@@ -292,6 +293,7 @@ def deblend_sources_color(
         mode='exponential',
         contrast=contrast,
         progress_bar=False,
+        compactness=compactness,
     )
 
     print(f"Initial detection: {len(seg_det.labels)} sources")
@@ -471,6 +473,7 @@ class Catalog:
             "deblend_mode": "exponential",
             "deblend_nlevels": 64,
             "deblend_contrast": 1e-3,
+            "deblend_compactness": 0.0,
         }
         defaults.update(self.params)
         self.params = defaults
@@ -503,6 +506,7 @@ class Catalog:
             contrast=float(self.params["deblend_contrast"]),
             connectivity=8,
             progress_bar=False,
+            compactness=float(self.params.get("deblend_compactness", 0.0)),
         )
         self.segmap = seg
         self.det_catalog = SourceCatalog(

--- a/src/mophongo/photutils_deblend.py
+++ b/src/mophongo/photutils_deblend.py
@@ -1,0 +1,240 @@
+"""Photutils deblend wrapper with compactness option."""
+
+from __future__ import annotations
+
+import warnings
+from multiprocessing import cpu_count, get_context
+from typing import Iterable
+
+import numpy as np
+from astropy.units import Quantity
+from astropy.utils.exceptions import AstropyUserWarning
+from photutils.segmentation import SegmentationImage
+from photutils.segmentation.utils import _make_binary_structure
+from photutils.utils._progress_bars import add_progress_bar
+from photutils.segmentation.deblend import _Deblender
+
+__all__ = ["deblend_sources"]
+
+
+class _CompactnessDeblender(_Deblender):
+    """Deblender using watershed with compactness."""
+
+    def __init__(
+        self,
+        source_data: np.ndarray,
+        source_segment: SegmentationImage,
+        npixels: int,
+        footprint: np.ndarray,
+        nlevels: int,
+        contrast: float,
+        mode: str,
+        *,
+        compactness: float = 0.0,
+    ) -> None:
+        super().__init__(source_data, source_segment, npixels, footprint, nlevels, contrast, mode)
+        self.compactness = compactness
+
+    def apply_watershed(self, markers: Iterable[SegmentationImage]) -> np.ndarray:
+        from scipy.ndimage import sum_labels
+        from skimage.segmentation import watershed
+
+        markers = markers[-1].data
+        remove_marker = True
+        while remove_marker:
+            markers = watershed(
+                -self.source_data,
+                markers,
+                mask=self.segment_mask,
+                connectivity=self.footprint,
+                compactness=self.compactness,
+            )
+            labels = np.unique(markers[markers != 0])
+            if labels.size == 1:
+                remove_marker = False
+            else:
+                flux_frac = sum_labels(self.source_data, markers, index=labels) / self.source_sum
+                remove_marker = any(flux_frac < self.contrast)
+                if remove_marker:
+                    markers[markers == labels[np.argmin(flux_frac)]] = 0.0
+        return markers
+
+
+def _deblend_source_compact(
+    source_data: np.ndarray,
+    source_segment: SegmentationImage,
+    npixels: int,
+    footprint: np.ndarray,
+    nlevels: int,
+    contrast: float,
+    mode: str,
+    compactness: float,
+) -> SegmentationImage | None:
+    deblender = _CompactnessDeblender(
+        source_data,
+        source_segment,
+        npixels,
+        footprint,
+        nlevels,
+        contrast,
+        mode,
+        compactness=compactness,
+    )
+    return deblender.deblend_source()
+
+
+def deblend_sources(
+    data: np.ndarray,
+    segment_img: SegmentationImage,
+    npixels: int,
+    *,
+    labels: int | Iterable[int] | None = None,
+    nlevels: int = 32,
+    contrast: float = 0.001,
+    mode: str = "exponential",
+    connectivity: int = 8,
+    relabel: bool = True,
+    nproc: int = 1,
+    progress_bar: bool = True,
+    compactness: float = 0.0,
+) -> SegmentationImage:
+    """Deblend sources using photutils with watershed compactness."""
+
+    if isinstance(data, Quantity):
+        data = data.value
+
+    if not isinstance(segment_img, SegmentationImage):
+        raise ValueError("segment_img must be a SegmentationImage")
+
+    if segment_img.shape != data.shape:
+        raise ValueError("The data and segmentation image must have the same shape")
+
+    if nlevels < 1:
+        raise ValueError("nlevels must be >= 1")
+    if contrast < 0 or contrast > 1:
+        raise ValueError("contrast must be >= 0 and <= 1")
+
+    if contrast == 1:
+        return segment_img.copy()
+
+    if mode not in ("exponential", "linear", "sinh"):
+        raise ValueError('mode must be "exponential", "linear", or "sinh"')
+
+    if labels is None:
+        labels = segment_img.labels
+    else:
+        labels = np.atleast_1d(labels)
+        segment_img.check_labels(labels)
+
+    mask = segment_img.areas[segment_img.get_indices(labels)] >= (npixels * 2)
+    labels = labels[mask]
+
+    footprint = _make_binary_structure(data.ndim, connectivity)
+
+    if nproc is None:
+        nproc = cpu_count()
+
+    segm_deblended = object.__new__(SegmentationImage)
+    segm_deblended._data = np.copy(segment_img.data)
+    last_label = segment_img.max_label
+    indices = segment_img.get_indices(labels)
+
+    all_source_data = []
+    all_source_segments = []
+    all_source_slices = []
+    for label, idx in zip(labels, indices):
+        source_slice = segment_img.slices[idx]
+        source_data = data[source_slice]
+        source_segment = object.__new__(SegmentationImage)
+        source_segment._data = segment_img.data[source_slice]
+        source_segment.keep_labels(label)
+        all_source_data.append(source_data)
+        all_source_segments.append(source_segment)
+        all_source_slices.append(source_slice)
+
+    if nproc == 1:
+        if progress_bar:
+            desc = "Deblending"
+            all_source_data = add_progress_bar(all_source_data, desc=desc)
+
+        all_source_deblends = []
+        for source_data, source_segment in zip(all_source_data, all_source_segments):
+            deblender = _CompactnessDeblender(
+                source_data,
+                source_segment,
+                npixels,
+                footprint,
+                nlevels,
+                contrast,
+                mode,
+                compactness=compactness,
+            )
+            source_deblended = deblender.deblend_source()
+            all_source_deblends.append(source_deblended)
+    else:
+        nlabels = len(labels)
+        args_all = zip(
+            all_source_data,
+            all_source_segments,
+            (npixels,) * nlabels,
+            (footprint,) * nlabels,
+            (nlevels,) * nlabels,
+            (contrast,) * nlabels,
+            (mode,) * nlabels,
+            (compactness,) * nlabels,
+        )
+
+        if progress_bar:
+            desc = "Deblending"
+            args_all = add_progress_bar(args_all, total=nlabels, desc=desc)
+
+        with get_context("spawn").Pool(processes=nproc) as executor:
+            all_source_deblends = executor.starmap(_deblend_source_compact, args_all)
+
+    nonposmin_labels = []
+    nmarkers_labels = []
+    for label, source_deblended, source_slice in zip(labels, all_source_deblends, all_source_slices):
+        if source_deblended is not None:
+            segment_mask = source_deblended.data > 0
+            segm_deblended._data[source_slice][segment_mask] = (
+                source_deblended.data[segment_mask] + last_label
+            )
+            last_label += source_deblended.nlabels
+
+            if hasattr(source_deblended, "warnings"):
+                if source_deblended.warnings.get("nonposmin", None) is not None:
+                    nonposmin_labels.append(label)
+                if source_deblended.warnings.get("nmarkers", None) is not None:
+                    nmarkers_labels.append(label)
+
+    if nonposmin_labels or nmarkers_labels:
+        segm_deblended.info = {"warnings": {}}
+        warnings.warn(
+            "The deblending mode of one or more source labels from "
+            "the input segmentation image was changed from "
+            f"{mode!r} to 'linear'. See the 'info' attribute "
+            "for the list of affected input labels.",
+            AstropyUserWarning,
+        )
+
+        if nonposmin_labels:
+            warn = {
+                "message": f"Deblending mode changed from {mode} to "
+                "linear due to non-positive minimum data values.",
+                "input_labels": np.array(nonposmin_labels),
+            }
+            segm_deblended.info["warnings"]["nonposmin"] = warn
+
+        if nmarkers_labels:
+            warn = {
+                "message": f"Deblending mode changed from {mode} to "
+                "linear due to too many potential deblended sources.",
+                "input_labels": np.array(nmarkers_labels),
+            }
+            segm_deblended.info["warnings"]["nmarkers"] = warn
+
+    if relabel:
+        segm_deblended.relabel_consecutive()
+
+    return segm_deblended
+

--- a/tests/test_photutils_deblend.py
+++ b/tests/test_photutils_deblend.py
@@ -1,0 +1,21 @@
+import numpy as np
+from photutils.segmentation import detect_sources, SegmentationImage
+from mophongo.photutils_deblend import deblend_sources
+
+
+def _make_simple_blend():
+    size = 31
+    y, x = np.mgrid[0:size, 0:size]
+    g1 = np.exp(-((x - 12) ** 2 + (y - 15) ** 2) / 4.0)
+    g2 = np.exp(-((x - 18) ** 2 + (y - 15) ** 2) / 4.0)
+    img = g1 + g2
+    seg = detect_sources(img, 0.1, npixels=5)
+    return img, seg
+
+
+def test_deblend_compactness():
+    img, seg = _make_simple_blend()
+    seg_deb = deblend_sources(img, seg, npixels=5, compactness=1.0, progress_bar=False)
+    assert isinstance(seg_deb, SegmentationImage)
+    assert seg_deb.nlabels >= 2
+    assert seg_deb.data.shape == img.shape

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,7 +8,8 @@ from mophongo.catalog import safe_dilate_segmentation
 
 import matplotlib.pyplot as plt
 from astropy.modeling.models import Gaussian2D
-from photutils.segmentation import detect_sources, deblend_sources
+from photutils.segmentation import detect_sources
+from mophongo.photutils_deblend import deblend_sources
 from photutils.datasets import make_model_image, make_model_params
 from skimage.morphology import dilation, disk, max_tree
 
@@ -114,7 +115,13 @@ def make_simple_data(
         seg.data = safe_dilate_segmentation(seg.data, selem=disk(ndilate))
 
     segm = deblend_sources(
-        detimg, seg, npixels=5, nlevels=64, contrast=0.000001, progress_bar=False,
+        detimg,
+        seg,
+        npixels=5,
+        nlevels=64,
+        contrast=0.000001,
+        progress_bar=False,
+        compactness=0.0,
     )
     segdata = segm.data
     segmap = np.zeros_like(segdata, dtype=int)


### PR DESCRIPTION
## Summary
- implement photutils-based `deblend_sources` with `compactness` parameter
- expose new deblender via package ``__init__``
- allow `Catalog` to control `deblend_compactness`
- update helpers and tests to use new routine
- add regression test for compactness option

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68746110f7e08325b438d9d5f6eb884c