### PR TITLE
Add PSF.from_star constructor

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -22,6 +22,7 @@ This checklist tracks tasks for building the Standalone Photometry Pipeline usin
   - `psf_matching_kernel` to Compute convolution kernels to transform the high‑resolution PSF into the low‑resolution PSF (Fourier domain or direct numerical solution)
   - [x] Add methods to fit Moffat and Gaussian profiles to existing PSF arrays
   - [x] Added `PSF.delta` for symmetric delta-function PSFs
+  - [x] Added `PSF.from_star` constructor for extracting PSFs from images
 - [x] **Template builder** (`src/mophongo/templates.py`)
   - `extract_templates` to create PSF-matched templates
   - Extract per-object cutouts from the high‑res image using the detection segmentation.

--- a/tests/test_psf.py
+++ b/tests/test_psf.py
@@ -59,3 +59,18 @@ def test_delta_psf_default():
     assert psf.array.shape == (3, 3)
     assert psf.array[1, 1] == 1.0
     np.testing.assert_allclose(psf.array.sum(), 1.0)
+
+
+def test_psf_from_star():
+    from mophongo.utils import gaussian
+
+    image = gaussian((61, 61), 2.5, 2.5, x0=30.3, y0=29.7)
+    psf = PSF.from_star(image, (30.3, 29.7))
+
+    assert psf.array.shape == (51, 51)
+    np.testing.assert_allclose(psf.array.sum(), 1.0, rtol=0, atol=2e-3)
+
+    cy = psf.array.shape[0] // 2
+    cx = psf.array.shape[1] // 2
+    maxpos = np.unravel_index(np.argmax(psf.array), psf.array.shape)
+    assert maxpos == (cy, cx)


### PR DESCRIPTION
## Summary
- add `PSF.from_star` constructor that performs quadratic centroiding and Cutout2D extraction
- test the new constructor in `tests/test_psf.py`
- update checklist

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68749123ad64832591b1da040fe97b52