### PR TITLE
Implement PSF kernel recentering

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -20,6 +20,7 @@ This checklist tracks tasks for building the Standalone Photometry Pipeline usin
 - [x] **PSF utilities** (`src/mophongo/psf.py`)
   - `moffat_psf` Generate Moffat PSF images (ellipticity/FWHM/beta parameters).
   - `psf_matching_kernel` to Compute convolution kernels to transform the high‑resolution PSF into the low‑resolution PSF (Fourier domain or direct numerical solution)
+  - [x] Added `recenter` option to `psf_matching_kernel` to shift kernels to their centroid
   - [x] Add methods to fit Moffat and Gaussian profiles to existing PSF arrays
   - [x] Added `PSF.delta` for symmetric delta-function PSFs
   - [x] Added `PSF.from_star` constructor for extracting PSFs from images


### PR DESCRIPTION
## Summary
- add optional kernel recentring to `PSF.matching_kernel` and `psf_matching_kernel`
- expose centroid-based shift using bicubic interpolation
- test new behaviour in `test_psf.py`
- update checklist

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874a1189e908325899c77f8116ba37a