### PR TITLE
Implement Fourier basis kernel matching

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -25,6 +25,7 @@ This checklist tracks tasks for building the Standalone Photometry Pipeline usin
   - [x] Added `PSF.delta` for symmetric delta-function PSFs
   - [x] Added `PSF.from_star` constructor for extracting PSFs from images
   - [x] Added `PSF.gaussian_matching_kernel` and `DrizzlePSF.register`
+  - [x] Added `matching_kernel_basis` with Gauss–Hermite and multi-Gaussian basis sets
 - [x] **Template builder** (`src/mophongo/templates.py`)
   - `extract_templates` to create PSF-matched templates
   - Extract per-object cutouts from the high‑res image using the detection segmentation.

--- a/src/mophongo/psf.py
+++ b/src/mophongo/psf.py
@@ -27,7 +27,14 @@ from photutils.psf import matching
 from photutils.psf.matching import TukeyWindow
 from photutils.centroids import centroid_quadratic
 
-from .utils import measure_shape, get_wcs_pscale, get_slice_wcs, to_header, read_wcs_csv
+from .utils import (
+    measure_shape,
+    get_wcs_pscale,
+    get_slice_wcs,
+    to_header,
+    read_wcs_csv,
+    fit_kernel_fourier,
+)
 from astropy.nddata import Cutout2D
 from astropy.coordinates import SkyCoord
 
@@ -275,6 +282,42 @@ class PSF:
                                      recenter=recenter)
         return kernel
 
+    def matching_kernel_basis(
+        self,
+        other: "PSF" | np.ndarray,
+        basis: np.ndarray,
+        *,
+        recenter: bool = True,
+    ) -> np.ndarray:
+        """Return convolution kernel using a Fourier basis fit."""
+
+        psf_hi = self.array
+        psf_lo = other.array if isinstance(other, PSF) else np.asarray(other, dtype=float)
+        if psf_lo.sum() != 0:
+            psf_lo = psf_lo / psf_lo.sum()
+
+        if psf_hi.shape != psf_lo.shape:
+            ny = max(psf_hi.shape[0], psf_lo.shape[0])
+            nx = max(psf_hi.shape[1], psf_lo.shape[1])
+            shape = (ny, nx)
+            psf_hi = pad_to_shape(psf_hi, shape)
+            psf_lo = pad_to_shape(psf_lo, shape)
+
+        if basis.shape[:2] != psf_hi.shape:
+            basis = np.stack(
+                [pad_to_shape(basis[:, :, i], psf_hi.shape) for i in range(basis.shape[2])],
+                axis=2,
+            )
+
+        kernel, _ = fit_kernel_fourier(psf_hi, psf_lo, basis)
+        if recenter:
+            ycen, xcen = centroid_quadratic(kernel, fit_boxsize=5)
+            if not np.isnan(ycen) and not np.isnan(xcen):
+                cy = (kernel.shape[0] - 1) / 2
+                cx = (kernel.shape[1] - 1) / 2
+                kernel = nd_shift(kernel, (cy - ycen, cx - xcen), order=3, mode="nearest")
+        return kernel
+
     def _fit_profile(self, model_func, default_params, free_params, xc=None, yc=None, result_class=None):
         """Shared fitting logic for both Gaussian and Moffat profiles."""
         from scipy.optimize import least_squares
@@ -508,6 +551,25 @@ def psf_matching_kernel(
         cy = (kernel.shape[0] - 1) / 2
         cx = (kernel.shape[1] - 1) / 2
         kernel = nd_shift(kernel, (cy - ycen, cx - xcen), order=3, mode="nearest")
+    return kernel
+
+
+def psf_matching_kernel_basis(
+    psf_hi: np.ndarray,
+    psf_lo: np.ndarray,
+    basis: np.ndarray,
+    *,
+    recenter: bool = True,
+) -> np.ndarray:
+    """Match ``psf_hi`` to ``psf_lo`` using basis function fitting."""
+
+    kernel, _ = fit_kernel_fourier(psf_hi, psf_lo, basis)
+    if recenter:
+        ycen, xcen = centroid_quadratic(kernel, fit_boxsize=5)
+        if not np.isnan(ycen) and not np.isnan(xcen):
+            cy = (kernel.shape[0] - 1) / 2
+            cx = (kernel.shape[1] - 1) / 2
+            kernel = nd_shift(kernel, (cy - ycen, cx - xcen), order=3, mode="nearest")
     return kernel
 
 

--- a/tests/test_psf.py
+++ b/tests/test_psf.py
@@ -101,3 +101,17 @@ def test_gaussian_matching_kernel_method():
     conv = _convolve2d(psf_model.array, kernel)
     np.testing.assert_allclose(conv, data, rtol=0, atol=1e-2)  # <-- Relaxed tolerance
     np.testing.assert_allclose(fwhm_k, np.sqrt(2.5**2 - 2.0**2), atol=0.1)
+
+
+def test_matching_kernel_basis(tmp_path):
+    psf_hi = PSF.gaussian(51, 2.0, 2.0)
+    psf_lo = PSF.gaussian(51, 4.0, 4.0)
+    from mophongo.utils import multi_gaussian_basis
+
+    basis = multi_gaussian_basis([1.0, 2.0, 3.0], 51)
+    kernel = psf_hi.matching_kernel_basis(psf_lo, basis)
+    conv = _convolve2d(psf_hi.array, kernel)
+    np.testing.assert_allclose(conv, psf_lo.array, rtol=0, atol=4e-2)
+    fname = tmp_path / "psf_kernel_basis.png"
+    save_psf_diagnostic(fname, psf_hi.array, psf_lo.array, kernel)
+    assert fname.exists()


### PR DESCRIPTION
## Summary
- add gauss–hermite and multi‑gaussian basis utilities
- implement `matching_kernel_basis` in psf module using Fourier domain fit
- expose Fourier kernel fit helper in utils
- test new matching routine
- record feature in CHECKLIST

## Testing
- `poetry run pytest tests/test_psf.py::test_matching_kernel_basis -q`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68799e7f341c83258458a67f332fe489