### PR TITLE
Simplify PSF region map API

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -72,4 +72,4 @@ This checklist tracks tasks for building the Standalone Photometry Pipeline usin
 - [x] Added `CircularApertureProfile` utility for radial profile and curve of growth
 - [ ] Implement hybrid deblender with analytic weighting
 - [ ] Implement JWST STDPSF extension utility
-- [ ] Build PSF region map from exposure footprints
+ - [x] Build PSF region map from exposure footprints

--- a/tests/test_psf_map.py
+++ b/tests/test_psf_map.py
@@ -1,54 +1,42 @@
 import matplotlib.pyplot as plt
-from shapely.geometry import Polygon
+import numpy as np
+import shapely.geometry as sgeom
+from shapely.affinity import translate
 
 from mophongo.psf_map import PSFRegionMap
 
+# synthetic 2 × 2 dither with sub-pixel offsets
+base = sgeom.box(0, 0, 1, 1)
+footprints = {
+    "A": base,
+    "B": translate(base, 0.00003, 0.00002),  # ~0.108", 0.072"
+}
 
-def test_psf_region_map(tmp_path):
-    footprints = {
-        ("f1", 1): Polygon([(0, 0), (2, 0), (2, 2), (0, 2)]),
-        ("f2", 1): Polygon([(1, 1), (3, 1), (3, 3), (1, 3)]),
-        ("f3", 1): Polygon([(2, 0), (4, 0), (4, 2), (2, 2)]),
-    }
+def test_region_count():
+    regmap = PSFRegionMap.from_footprints(footprints, crs=None)
+    # With snapping & merge there should be ≤ 3 regions (A, B, A∩B)
+    assert len(regmap.regions) <= 3
 
-    prm = PSFRegionMap.from_footprints(footprints)
+def test_no_tiny_regions():
+    regmap = PSFRegionMap.from_footprints(footprints, crs=None)
+    area_min = regmap.area_factor * np.pi * (regmap.fwhm / 2) ** 2
+    assert (regmap.regions.geometry.area >= area_min).all()
 
-    assert prm.regions.psf_key.nunique() > 1
+def test_lookup():
+    regmap = PSFRegionMap.from_footprints(footprints, crs=None)
+    # pick a point firmly inside footprint 'A' only
+    key = regmap.lookup_key(2.5e-05, 0.5)
+    assert key is not None
+    frames = regmap.regions.query("psf_key == @key").frame_list.iloc[0]
+    assert frames == ("A",)
 
-    key_a = prm.lookup_key(0.5, 0.5)
-    key_b = prm.lookup_key(1.5, 1.5)
-    key_c = prm.lookup_key(2.5, 1.5)
-
-    assert key_a is not None
-    assert key_b is not None
-    assert key_c is not None
-    assert len({key_a, key_b, key_c}) == 3
-
+def test_plot(tmp_path):
+    regmap = PSFRegionMap.from_footprints(footprints, crs=None)
     fig, ax = plt.subplots()
-    prm.regions.plot(column="psf_key", ax=ax, edgecolor="k", cmap="tab20")
+    regmap.regions.plot(column="psf_key", ax=ax, edgecolor="k", cmap="tab20")
     ax.set_xlabel("RA")
     ax.set_ylabel("Dec")
-    out = tmp_path / "psf_region_demo.png"
+    out = tmp_path / "psf_region_map.png"
     fig.savefig(out, dpi=150)
     plt.close(fig)
     assert out.exists()
-
-def test_psf_region_map_from_file(tmp_path):
-    import importlib
-    from pathlib import Path
-    import mophongo.psf
-    importlib.reload(mophongo.psf)
-    from mophongo.psf import DrizzlePSF, PSF
-
-    filt = 'F444W'
-    data_dir = Path(__file__).resolve().parent.parent / "data"
-    drz_file = str(data_dir / f"uds-test-{filt.lower()}_sci.fits")
-    csv_file = str(data_dir / f"uds-test-{filt.lower()}_wcs.csv")
-
-    # The target mosaic and its output WCS doesn't necessarily have to be the same drz_file
-    dpsf = DrizzlePSF(driz_image=drz_file,csv_file=csv_file)
-
-    prm = PSFRegionMap.from_footprints(dpsf.footprint)
-    prm.regions.plot(column="psf_key", ax=ax, edgecolor="k", cmap="tab20")
-
-prm.


### PR DESCRIPTION
## Summary
- refactor PSFRegionMap to use class-level tunables
- integrate preprocessing and sliver merge as methods
- drop Shapely overlay call and keep incremental overlay
- adjust tests for new attributes

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c808475c08325a25bb5f0ff9b3817