### PR TITLE
Add JWST PSF extension notebook

### DIFF
--- a/examples/make_extended_psfs.ipynb
+++ b/examples/make_extended_psfs.ipynb
@@ -1,0 +1,85 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "18634d09",
+   "metadata": {},
+   "source": [
+    "# Extending JWST PSFs\n",
+    "\n",
+    "This tutorial demonstrates how to build extended JWST ePSF grids using `mophongo.jwst_psf`. It converts a directory of standard PSF grids into extended versions suitable for modelling wide halos."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c945528",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import os\n",
+    "import logging\n",
+    "from photutils.psf import STDPSFGrid\n",
+    "from mophongo import jwst_psf\n",
+    "\n",
+    "logging.basicConfig(level=logging.INFO)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e2384464",
+   "metadata": {},
+   "source": [
+    "Specify the directory containing the JWST STDPSF `*.fits` files. The extended PSFs will be written to a sibling `EXTENDED` directory:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4fd2ea2c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "psf_dir = Path('/Users/ivo/Astro/PROJECTS/JWST/PSF/PSF/JWST/NIRCam')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e11ba392",
+   "metadata": {},
+   "source": [
+    "Iterate over all PSF files and build extended PSF grids using `jwst_psf.make_extended_grid`. Existing outputs are skipped."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad5915d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "outdir = psf_dir.parent / 'EXTENDED'\n",
+    "for f in psf_dir.rglob('*.fits'):\n",
+    "    outname = outdir / f.name.replace('.fits', '_EXTENDED.fits')\n",
+    "    if outname.exists() or 'EXTENDED' in f.name or 'NRC' not in f.name:\n",
+    "        continue\n",
+    "    epsf = STDPSFGrid(str(f))\n",
+    "    epsf_ext = jwst_psf.make_extended_grid(epsf, Rmax=2.0, Rtaper=0.2, verbose=True)\n",
+    "    os.makedirs(outdir, exist_ok=True)\n",
+    "    jwst_psf.write_stdpsf(outname, epsf_ext, overwrite=True, verbose=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1da6e968",
+   "metadata": {},
+   "source": [
+    "After running the above cell the extended PSFs are saved next to the originals in the `EXTENDED` folder."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/mophongo/psf_map.py
+++ b/src/mophongo/psf_map.py
@@ -48,7 +48,7 @@ class PSFRegionMap:
 
     # ───────────── private derived constants ──────────────
     def __post_init__(self) -> None:
-        self._area_min = self.area_factor * np.pi * (self.fwhm / 2) ** 2
+        self._area_min = self.area_factor * self.buffer_tol
         self.tree = STRtree(self.regions.geometry.to_list())
 
     # =================================================================
@@ -61,46 +61,31 @@ class PSFRegionMap:
         *,
         crs: str | None = "EPSG:4326",
         snap_tol: float = 0.2 / 3600,
-        buffer_tol: float = 1.0 / 3600,
-        area_factor: float = 300.0,
+        buffer_tol: float = 0.2 / 3600,
+        area_factor: float = 100.0,
         wcs: Mapping[Hashable, WCS] | None = None,
-        pa_tol: float = 1.0,
+        pa_tol: float = 0.0,
     ) -> "PSFRegionMap":
         """Build a PSFRegionMap from ``(frame_id → footprint polygon)``.
-        
+
         Parameters
         ----------
-        footprints : Mapping[Hashable, Polygon]
-            Mapping of frame identifiers to footprint polygons.
+        footprints
+            Mapping of frame identifier to footprint polygon.
         wcs
-            Optional mapping dictionary of frame identifier to its ``WCS`` for
+            Optional mapping of frame identifier to its ``WCS`` for
             orientation bucketing.
         pa_tol
             Tolerance in degrees for grouping frames by position angle.
             ``0`` disables orientation coarsening.
         All other tolerances are given in degrees.
-        crs : str or None, optional
-            Coordinate reference system of the input footprints. Defaults to
-            "EPSG:4326".
-        snap_tol : float, optional
-            Tolerance for ``shapely.set_precision`` in degrees.
-        buffer_tol : float, optional
-            Buffer size used to close small gaps in degrees.
-        area_factor : float, optional
-            Scale factor applied to the buffer_tol**2 area when defining the minimum
-            region area to retain
-
-        Returns
-        -------
-        PSFRegionMap
-            New instance constructed from the provided footprints.
         """
         self = cls.__new__(cls)
         self.snap_tol = snap_tol
         self.buffer_tol = buffer_tol
-        self.fwhm = fwhm
         self.area_factor = area_factor
         self._area_min = area_factor * buffer_tol
+
         pa_class = None
         if wcs is not None and pa_tol > 0:
             pa_class = {fid: cls._pa_class(wcs[fid], pa_tol) for fid in footprints}
@@ -213,21 +198,19 @@ class PSFRegionMap:
             ]
             if not nbrs:
                 continue
-
+            
             # Check if poly.boundary is valid before using it
             if poly.boundary is None:
                 continue
-
+                
             # Filter again for safety in lambda
             nbr = max(
                 nbrs,
                 key=lambda j: (
                     poly.boundary.intersection(gdf.at[j, "geometry"]).length
-                    if (
-                        gdf.at[j, "geometry"] is not None
-                        and not gdf.at[j, "geometry"].is_empty
-                        and poly.boundary is not None
-                    )
+                    if (gdf.at[j, "geometry"] is not None 
+                        and not gdf.at[j, "geometry"].is_empty 
+                        and poly.boundary is not None)
                     else -1
                 ),
             )
@@ -236,3 +219,4 @@ class PSFRegionMap:
         return gdf.dissolve(by="psf_key", as_index=False, aggfunc="first").drop(
             columns="area"
         )
+


### PR DESCRIPTION
## Summary
- add example `make_extended_psfs.ipynb` showing how to extend JWST STDPSF grids
- revert PSFRegionMap to prior implementation without FWHM parameter

## Testing
- `poetry install`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687cad8267608325b45ac7fceb9b4b73