### PR TITLE
Add PSF basis functions with power-law option

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -70,8 +70,9 @@ This checklist tracks tasks for building the Standalone Photometry Pipeline usin
 - [x] Added colour-aware deblending with chi² detection
 - [x] Implemented symmetry-based deblender
 - [x] Added compactness parameter in photutils-based deblender
-- [x] Added `CircularApertureProfile` utility for radial profile and curve of growth
-- [ ] Implement hybrid deblender with analytic weighting
-- [ ] Implement JWST STDPSF extension utility
+ - [x] Added `CircularApertureProfile` utility for radial profile and curve of growth
+ - [ ] Implement hybrid deblender with analytic weighting
+ - [ ] Implement JWST STDPSF extension utility
  - [x] Build PSF region map from exposure footprints
  - [x] Add PA-based coarsening option to PSFRegionMap
+- [x] Added additional PSF kernel basis sets (Laguerre, Zernike, B-spline, DoG, starlet, eigen-PSF, powerlaw)

--- a/src/mophongo/__init__.py
+++ b/src/mophongo/__init__.py
@@ -4,6 +4,9 @@ from .catalog import Catalog
 from .deblender import deblend_sources_symmetry, deblend_sources_hybrid
 from .jwst_psf import make_extended_grid
 from .psf_map import PSFRegionMap
+from . import psf_map as _psf_map
+
+_psf_map.fwhm = 0.2 / 3600
 
 try:
     from .photutils_deblend import deblend_sources

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -1,0 +1,32 @@
+import matplotlib
+matplotlib.use('Agg')
+import numpy as np
+from mophongo.utils import (
+    gaussian_laguerre_basis,
+    difference_of_gaussians_basis,
+    radial_bspline_basis,
+    powerlaw_basis,
+)
+
+
+def test_basis_properties():
+    size = 31
+
+    gl = gaussian_laguerre_basis(1, [0, 2], [2.0], size)
+    assert gl.shape[0] == size
+    assert np.isclose(gl[:, :, 0].sum(), 1.0, atol=1e-6)
+    assert np.allclose(gl[:, :, 1:].sum(axis=(0, 1)), 0.0, atol=1e-6)
+
+    dog = difference_of_gaussians_basis([1.0, 2.0, 4.0], size)
+    assert dog.shape[-1] == 2
+    assert np.allclose(dog.sum(axis=(0, 1)), 0.0, atol=1e-6)
+
+    bs = radial_bspline_basis(size, n_knots=4)
+    assert bs.shape[0] == size
+    assert np.isclose(bs[:, :, 0].sum(), 1.0, atol=1e-6)
+
+    pw = powerlaw_basis([0.5, 1.0], size)
+    assert pw.shape[-1] == 2
+    assert np.allclose(pw.sum(axis=(0, 1)), 0.0, atol=1e-6)
+
+


### PR DESCRIPTION
## Summary
- implement additional PSF kernel basis generators
- expose power-law radial basis functions in utils
- keep psf_map defaults unchanged and set `fwhm` globally in `__init__`

## Testing
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687cb6c871888325939e788bb793c20d