### PR TITLE
Add spatially varying kernel support and example

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -76,4 +76,5 @@ This checklist tracks tasks for building the Standalone Photometry Pipeline usin
  - [x] Build PSF region map from exposure footprints
  - [x] Add PA-based coarsening option to PSFRegionMap
  - [x] Added KernelLookup utility and kernel generation notebook
+ - [x] Added spatially varying kernel support in `run_photometry` and template convolution
  - [ ] End-to-end test with realistic mosaic data using `make_mosaic_dataset`

--- a/examples/full_pipeline.ipynb
+++ b/examples/full_pipeline.ipynb
@@ -1,0 +1,138 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Full Photometry Pipeline\n",
+    "\n",
+    "This tutorial demonstrates how to run the end--to--end photometry pipeline on\n",
+    "real JWST data included with *Mophongo*. We build templates from the F444W\n",
+    "mosaic and fit fluxes in the F770W image using spatially varying PSF\n",
+    "matching kernels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import numpy as np\n",
+    "from astropy.io import fits\n",
+    "\n",
+    "from mophongo.catalog import Catalog\n",
+    "from mophongo.psf import DrizzlePSF, PSF\n",
+    "from mophongo.psf_map import PSFRegionMap\n",
+    "from mophongo.kernels import KernelLookup\n",
+    "from mophongo.pipeline import run_photometry\n",
+    "from mophongo.templates import Templates\n",
+    "\n",
+    "data_dir = Path('data')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Detect sources in F444W"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sci_444 = data_dir / 'uds-test-f444w_sci.fits'\n",
+    "wht_444 = data_dir / 'uds-test-f444w_wht.fits'\n",
+    "cat = Catalog.from_fits(sci_444, wht_444)\n",
+    "segmap = fits.getdata(data_dir / 'uds-test-LW_seg.fits')\n",
+    "catalog = cat.catalog\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Build PSF region map"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "csv_444 = data_dir / 'uds-test-f444w_wcs.csv'\n",
+    "csv_770 = data_dir / 'uds-test-f770w_wcs.csv'\n",
+    "dpsf_444 = DrizzlePSF(driz_image=str(sci_444), csv_file=str(csv_444))\n",
+    "dpsf_770 = DrizzlePSF(driz_image=str(data_dir / 'uds-test-f770w_sci.fits'), csv_file=str(csv_770))\n",
+    "\n",
+    "# Keep only footprints overlapping the F444W mosaic\n",
+    "fp = {k: v for k, v in dpsf_770.footprint.items() if v.intersects(dpsf_444.driz_wcs.calc_footprint().astype(float))}\n",
+    "prm = PSFRegionMap.from_footprints(fp)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create PSF kernels"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "kernels = []\n",
+    "for key, row in prm.regions.iterrows():\n",
+    "    ra, dec = row.geometry.centroid.x, row.geometry.centroid.y\n",
+    "    psf_444 = dpsf_444.get_psf(ra=ra, dec=dec)[1].data\n",
+    "    psf_770 = dpsf_770.get_psf(ra=ra, dec=dec)[1].data\n",
+    "    k = PSF.from_array(psf_444).matching_kernel(psf_770)\n",
+    "    kernels.append(k)\n",
+    "kernels = np.stack(kernels)\n",
+    "klu = KernelLookup(prm, kernels)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run photometry"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "img_770 = fits.getdata(data_dir / 'uds-test-f770w_sci.fits')\n",
+    "wht_770 = fits.getdata(data_dir / 'uds-test-f770w_wht.fits')\n",
+    "images = [fits.getdata(sci_444), img_770]\n",
+    "psfs = [psf_444, psf_770] = [dpsf_444.get_psf(ra=prm.regions.geometry.centroid.x.iloc[0], dec=prm.regions.geometry.centroid.y.iloc[0])[1].data,\n    dpsf_770.get_psf(ra=prm.regions.geometry.centroid.x.iloc[0], dec=prm.regions.geometry.centroid.y.iloc[0])[1].data]\n",
+    "wht = [fits.getdata(wht_444), wht_770]\n",
+    "tbl, resid, _ = run_photometry(images, segmap, catalog, psfs, wht_images=wht, kernels=[None, klu])\n",
+    "tbl.write('photometry.cat', format='ascii.commented_header', overwrite=True)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/mophongo/kernels.py
+++ b/src/mophongo/kernels.py
@@ -16,10 +16,13 @@ class KernelLookup:
     kernels: np.ndarray
     _cache: Dict[int, np.ndarray] = field(default_factory=dict, init=False, repr=False)
 
-    def get_kernel(self, ra: float, dec: float) -> np.ndarray | None:
-        key = self.region_map.lookup_key(ra, dec)
-        if key is None:
-            return None
+    def get_kernel(self, ra: float | None, dec: float | None) -> np.ndarray | None:
+        if ra is None or dec is None or np.isnan(ra) or np.isnan(dec):
+            key = 0
+        else:
+            key = self.region_map.lookup_key(ra, dec)
+            if key is None:
+                return None
         if key not in self._cache:
             self._cache[key] = self.kernels[key]
         return self._cache[key]

--- a/tests/test_pipeline_kernel_lookup.py
+++ b/tests/test_pipeline_kernel_lookup.py
@@ -1,0 +1,25 @@
+import numpy as np
+import shapely.geometry as sgeom
+
+from mophongo.pipeline import run_photometry
+from mophongo.psf_map import PSFRegionMap
+from mophongo.kernels import KernelLookup
+from mophongo.psf import PSF
+from utils import make_simple_data
+
+
+def test_run_photometry_with_lookup(tmp_path):
+    images, segmap, catalog, psfs, truth, wht = make_simple_data(seed=42, nsrc=20, size=101)
+
+    footprints = {"A": sgeom.box(0, 0, 1, 1)}
+    prm = PSFRegionMap.from_footprints(footprints, crs=None)
+
+    kernel = PSF.from_array(psfs[0]).matching_kernel(psfs[1])
+    lookup = KernelLookup(prm, np.stack([kernel]))
+
+    table, resid, _ = run_photometry(
+        images, segmap, catalog, psfs, wht_images=wht, kernels=[None, lookup]
+    )
+
+    assert "flux_1" in table.colnames
+    assert resid[0].shape == images[1].shape


### PR DESCRIPTION
## Summary
- support KernelLookup in template convolution
- allow `run_photometry` to take precomputed kernels
- handle missing coordinates in `KernelLookup.get_kernel`
- add example notebook demonstrating full pipeline on UDS data
- add regression test for KernelLookup with `run_photometry`
- update project checklist

## Testing
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687cd0236ccc832584f7ef73a12bd327