### PR TITLE
Fix astro fitter template counting

### DIFF
--- a/src/mophongo/astro_fit.py
+++ b/src/mophongo/astro_fit.py
@@ -6,7 +6,7 @@ from typing import List
 
 import numpy as np
 from scipy.ndimage import shift as nd_shift
-from scipy.sparse import eye
+from scipy.sparse import eye, diags
 from scipy.sparse.linalg import cg
 
 from .fit import SparseFitter, FitConfig
@@ -25,24 +25,44 @@ class GlobalAstroFitter(SparseFitter):
         segmap: np.ndarray,
         config: FitConfig,
     ) -> None:
-        super().__init__(templates, image, weights, config)
+        _orig_templates = list(templates)
+        _n_flux = len(_orig_templates)
+
+        super().__init__(_orig_templates, image, weights, config)
         if not config.fit_astrometry:
+            self.n_flux = _n_flux
             return
 
         order = config.astrom_basis_order
         k = astrometry.n_terms(order)
         self.basis_order = order
         self.n_alpha = k
-        self.n_flux = len(templates)
+        self.n_flux = _n_flux
 
-        gx, gy = astrometry.make_gradients(templates, image.shape)
-        phi = astrometry.basis_matrix(templates, segmap, order)
+        gx, gy = astrometry.make_gradients(_orig_templates, image.shape)
+        phi = astrometry.basis_matrix(_orig_templates, segmap, order)
         GX, GY = astrometry.collapse_gradients(gx, gy, phi, k, image.shape)
+        GX = np.atleast_3d(GX)
+        GY = np.atleast_3d(GY)
+        cy, cx = image.shape[0] / 2, image.shape[1] / 2
+        for i in range(k):
+            t = Template(GX[i], (cx, cy), image.shape)
+            t.position_original = (cx, cy)
+            self.templates.append(t)
+        for i in range(k):
+            t = Template(GY[i], (cx, cy), image.shape)
+            t.position_original = (cx, cy)
+            self.templates.append(t)
 
-        self.templates.extend(
-            [Template(GX[i], (image.shape[1] / 2, image.shape[0] / 2), image.shape) for i in range(k)]
-            + [Template(GY[i], (image.shape[1] / 2, image.shape[0] / 2), image.shape) for i in range(k)]
-        )
+    # ------------------------------------------------------------------ #
+    # override to return only the flux-component uncertainties
+    def predicted_errors(self):
+        errs = super().predicted_errors()
+        return errs[: self.n_flux]
+
+    def flux_errors(self):
+        errs = super().flux_errors()
+        return errs[: self.n_flux]
 
     def _apply_shifts(self, alpha: np.ndarray, beta: np.ndarray) -> None:
         order = self.basis_order
@@ -73,16 +93,9 @@ class GlobalAstroFitter(SparseFitter):
             ata = ata + eye(ata.shape[0]) * cfg.reg
         if cfg.fit_astrometry and cfg.reg_astrom is not None:
             start = self.n_flux
-            diag_idx = np.arange(start, start + 2 * self.n_alpha)
-            # Fix: Create regularization matrix properly
-            from scipy.sparse import csr_matrix
-
-            reg_data = np.zeros(ata.shape[0])
-            reg_data[diag_idx] = cfg.reg_astrom
-            reg_matrix = csr_matrix(
-                (reg_data, (np.arange(ata.shape[0]), np.arange(ata.shape[0]))), shape=ata.shape
-            )
-            ata = ata + reg_matrix
+            reg_diag = np.zeros(ata.shape[0], dtype=float)
+            reg_diag[start : start + 2 * self.n_alpha] = cfg.reg_astrom
+            ata = ata + diags(reg_diag, 0, format="csr")
         x, info = cg(ata, atb, **cfg.cg_kwargs)
         if cfg.positivity:
             x = np.where(x < 0, 0, x)

--- a/src/mophongo/catalog.py
+++ b/src/mophongo/catalog.py
@@ -276,7 +276,7 @@ class Catalog:
         )
         from astropy.convolution import convolve
 
-        print(f"Convolving with kernel size {self.params["kernel_size"]} pixels")
+        print(f"Convolving with kernel size {self.params['kernel_size']} pixels")
         smooth = convolve(self.det_img, kernel, normalize_kernel=True)
         print("Detecting sources...")
         segmap = detect_sources(

--- a/src/mophongo/pipeline.py
+++ b/src/mophongo/pipeline.py
@@ -143,6 +143,7 @@ def run(
 
         if weights_i is not None:
             pred = fitter.predicted_errors()
+            pred = pred[: len(cat)]      # guard against length drift
 
         if len(tmpls.templates) == len(cat):
             if weights_i is not None:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -791,16 +791,17 @@ def make_testdata():
 # %%
 
 
-data_dir = '/Users/ivo/Astro/PROJECTS/MINERVA/data/v1.0/'
+if __name__ == "__main__":
+    data_dir = '/Users/ivo/Astro/PROJECTS/MINERVA/data/v1.0/'
 
-from astropy.wcs import WCS
-from astropy.io import fits
+    from astropy.wcs import WCS
+    from astropy.io import fits
 
-hdr = fits.getheader(data_dir+'uds-grizli-v8.0-minerva-v1.0-40mas-f444w-clear_drc_sci.fits')
-wcs_40mas = WCS(hdr)
-wcs_80mas = wcs_40mas.slice((slice(None, None, 2), slice(None, None, 2)))
+    hdr = fits.getheader(data_dir+'uds-grizli-v8.0-minerva-v1.0-40mas-f444w-clear_drc_sci.fits')
+    wcs_40mas = WCS(hdr)
+    wcs_80mas = wcs_40mas.slice((slice(None, None, 2), slice(None, None, 2)))
 
-# create a new WCS that corresponds to slicing every 2nd pixel in both Y and X
-#wcs2 = wcs.slice((slice(None, None, 2), slice(None, None, 2)))
+    # create a new WCS that corresponds to slicing every 2nd pixel in both Y and X
+    #wcs2 = wcs.slice((slice(None, None, 2), slice(None, None, 2)))
 
 # %%


### PR DESCRIPTION
## Summary
- ensure `GlobalAstroFitter` keeps the original number of flux templates
- create gradient templates robustly and set their positions
- trim error arrays for flux components only
- build regularisation diagonal with sparse `diags`
- guard predicted error column length in pipeline
- fix formatting bug in catalog diagnostic message
- disable stray dataset code in test utilities

## Testing
- `poetry run pytest tests/test_astro_fit.py::test_solve_return_shapes_with_actual_templates tests/test_astro_fit.py::test_regularization_with_consistent_shapes tests/test_astro_fit.py::test_global_astro_fitter_gradient_templates -q`

------
https://chatgpt.com/codex/tasks/task_e_6886b6b2ceb48325a8438008aaa3d65f