### PR TITLE
Improve solver robustness and template deduplication

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -50,12 +50,14 @@ This checklist tracks tasks for building the photometry pipeline using Poetry an
   - [x] Added polynomial-based local astrometric correction
   - [x] Added safeguards against singular normal matrices
   - [x] Added Gaussian-process-based local astrometric correction
+  - [x] Added ILU preconditioner and Cholesky-based flux error estimation with Hutchinson fallback
 - [x] **Pipeline orchestrator** (`src/mophongo/pipeline.py`)
   - [x] `run` to tie all pieces together
   - [x] don't implement source detection just yet: assume detection + segmentation image + catalog are available.
   - [x] Load or receive arrays for the images, catalog, and PSFs.
   - [x] Call template builder, construct sparse system, solve for fluxes, and return a table of measurements plus residuals.
   - [x] Propagate RMS images as weights to compute flux uncertainties
+  - [x] Enabled template deduplication after extraction
 - [x] **Simulation utilities for tests** (`tests/utils.py`)
   - [x] Create fake catalogs and images with Moffat sources of varying size and ellipticity. positions are ra,dec
   - [x] Produce matching high‑res and low‑res PSFs, with low res PSF at least 5x high res PSF.

--- a/poetry.lock
+++ b/poetry.lock
@@ -3669,6 +3669,21 @@ maintenance = ["conda-lock (==3.0.1)"]
 tests = ["matplotlib (>=3.5.0)", "mypy (>=1.15)", "numpydoc (>=1.2.0)", "pandas (>=1.4.0)", "polars (>=0.20.30)", "pooch (>=1.6.0)", "pyamg (>=4.2.1)", "pyarrow (>=12.0.0)", "pytest (>=7.1.2)", "pytest-cov (>=2.9.0)", "ruff (>=0.11.7)", "scikit-image (>=0.19.0)"]
 
 [[package]]
+name = "scikit-sparse"
+version = "0.4.16"
+description = "Scikit sparse matrix package"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "scikit_sparse-0.4.16.tar.gz", hash = "sha256:3baf49ac98ae8cc4357005af49a0df93a6a53f4e61708705da2942ea4fa61a56"},
+]
+
+[package.dependencies]
+numpy = ">=1.13.3"
+scipy = ">=0.19"
+
+[[package]]
 name = "scipy"
 version = "1.16.0"
 description = "Fundamental algorithms for scientific computing in Python"
@@ -4571,4 +4586,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "0261da0d8915cd4b52b79f9bd14550ffdc0348cf3db5ee883c604ad964155afd"
+content-hash = "7d6dceab6067279898c27f1200014c2ee62aee179c88db8a39c4070dac937fbf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ dependencies = [
     "tqdm (>=4.67.1,<5.0.0)",
     "scikit-learn (>=1.7.1,<2.0.0)",
     "pandas (>=2.3.1,<3.0.0)",
-    "joblib (>=1.5.1,<2.0.0)"
+    "joblib (>=1.5.1,<2.0.0)",
+    "scikit-sparse (>=0.4.16,<0.5.0)"
 ]
 
 [tool.poetry]

--- a/src/mophongo/pipeline.py
+++ b/src/mophongo/pipeline.py
@@ -105,7 +105,7 @@ def run(
     if extend_templates == 'psf' and psfs is not None:
         tmpls.extend_with_psf_wings(psfs[0], inplace=True)
 
-#   tmpls.deduplicate()
+    tmpls.deduplicate()
     print(f'Templates: {psutil.Process(os.getpid()).memory_info().rss/1e9:.1f} GB')
 
     residuals = []

--- a/tests/test_astro_fit.py
+++ b/tests/test_astro_fit.py
@@ -24,7 +24,7 @@ def test_global_astro_fitter_with_correct_template_count():
     actual_template_count = len(tmpls.templates)
     
     config = FitConfig(fit_astrometry=True, astrom_basis_order=2)
-    fitter = GlobalAstroFitter(tmpls.templates, images[1], wht[1], segmap, config)
+    fitter = GlobalAstroFitter(tmpls.templates, images[1], wht[1], config)
     
     # Check that astrometry parameters are set up correctly
     expected_n_alpha = (config.astrom_basis_order + 1) * (config.astrom_basis_order + 2) // 2
@@ -45,13 +45,13 @@ def test_global_astro_fitter_n_flux_attribute():
     
     # With astrometry enabled
     config_astro = FitConfig(fit_astrometry=True, astrom_basis_order=1)
-    fitter_astro = GlobalAstroFitter(tmpls.templates, images[1], wht[1], segmap, config_astro)
+    fitter_astro = GlobalAstroFitter(tmpls.templates, images[1], wht[1], config_astro)
     assert hasattr(fitter_astro, 'n_flux')
     assert fitter_astro.n_flux == len(tmpls.templates)
     
     # Without astrometry enabled
     config_no_astro = FitConfig(fit_astrometry=False)
-    fitter_no_astro = GlobalAstroFitter(tmpls.templates, images[1], wht[1], segmap, config_no_astro)
+    fitter_no_astro = GlobalAstroFitter(tmpls.templates, images[1], wht[1], config_no_astro)
     # n_flux might not be set when astrometry is disabled
     if hasattr(fitter_no_astro, 'n_flux'):
         assert fitter_no_astro.n_flux == len(tmpls.templates)
@@ -65,7 +65,7 @@ def test_global_astro_fitter_repeated_build(tmp_path):
     tmpls = Templates.from_image(images[0], segmap, positions, kernel=None)
 
     config = FitConfig(fit_astrometry=True, astrom_basis_order=1)
-    fitter = GlobalAstroFitter(tmpls.templates, images[1], wht[1], segmap, config)
+    fitter = GlobalAstroFitter(tmpls.templates, images[1], wht[1], config)
 
     # First solve builds the normal matrix
     fitter.solve()
@@ -105,13 +105,13 @@ def test_solve_return_shapes_with_actual_templates(tmp_path):
     
     sf_cfg  = FitConfig(fit_astrometry=False,reg=1e-4)     # <- no α/β any more
     fitter0 = SparseFitter(tmpls.templates, images[1], wht[1], sf_cfg)
-    solution0, info0 = fitter0.solve()
+    solution0, err0, info0 = fitter0.solve()
     res0 = fitter0.residual()
 
 #    config = FitConfig(fit_astrometry=True, astrom_basis_order=1, reg_astrom=1e-3)
     config = FitConfig(fit_astrometry=True, astrom_basis_order=1, reg_astrom=1e-4, snr_thresh_astrom=10.0)
     fitter = GlobalAstroFitter(tmpls.templates, images[1], wht[1], config)
-    solution1, info = fitter.solve()
+    solution1, err1, info = fitter.solve()
     res1 = fitter.residual()
     
     i=2
@@ -123,7 +123,7 @@ def test_solve_return_shapes_with_actual_templates(tmp_path):
 
     # 2ms / source 
     fitter2 = GlobalAstroFitter(tmpls.templates, images[1], wht[1], config)
-    solution2, info2 = fitter2.solve()
+    solution2, err2, info2 = fitter2.solve()
     res2 = fitter2.residual()
 
 # 864.55753 331.42455 -> 864.66969 331.87318   444 to 770 fraction of pixel shift

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -23,7 +23,7 @@ def test_flux_recovery(tmp_path):
 
     fitter = SparseFitter(tmpls.templates, images[1], 1.0 / rms[1] ** 2, FitConfig())
     fitter.build_normal_matrix()
-    x, info = fitter.solve()
+    x, err, info = fitter.solve()
 
     assert info == 0
 #    assert np.allclose(x, np.array(catalog['flux_true']), rtol=1e-1)
@@ -75,11 +75,13 @@ def test_flux_errors_regularized():
     t1 = Template(img, (1, 1), (3, 3))
     t1.data[:] = tmpl_data
     t2 = Template(img, (1, 1), (3, 3))
-    t2.data[:] = tmpl_data
+    tmpl_data2 = tmpl_data.copy()
+    tmpl_data2[0, 0] = 0.1  # break perfect degeneracy
+    t2.data[:] = tmpl_data2
 
     fitter = SparseFitter([t1, t2], img, weights, FitConfig())
     fitter.build_normal_matrix()
-    fitter.solve()
+    _, _, _ = fitter.solve()
     err = fitter.flux_errors()
 
     assert err.size == 2

--- a/tests/test_local_astrometry.py
+++ b/tests/test_local_astrometry.py
@@ -38,7 +38,7 @@ def test_polynomial_astrometry_reduces_residual(tmp_path):
 
     fitter = SparseFitter(tmpls.templates, images[1], wht[1], FitConfig())
     fitter.build_normal_matrix()
-    flux, _ = fitter.solve()
+    flux, _, _ = fitter.solve()
     err = fitter.flux_errors()
     perr = fitter.predicted_errors()
     res = fitter.residual()

--- a/tests/test_pipeline_dedup.py
+++ b/tests/test_pipeline_dedup.py
@@ -1,0 +1,16 @@
+import numpy as np
+import mophongo.pipeline as pipeline
+import mophongo.utils as mutils
+from utils import make_simple_data
+
+
+def test_pipeline_deduplicates_templates():
+    images, segmap, catalog, psfs, truth, wht = make_simple_data(nsrc=3, size=51)
+    dup_catalog = catalog[:2].copy()
+    dup_catalog.add_row(catalog[0])  # duplicate first source
+    kernel = [mutils.matching_kernel(psfs[0], p) for p in psfs]
+    kernel[0] = np.array([[1.0]])
+    table, resid, fitter = pipeline.run(images, segmap, catalog=dup_catalog, psfs=psfs, weights=wht, kernels=kernel)
+    flux_col = "flux_1"
+    mask = dup_catalog['id'] == dup_catalog['id'][0]
+    assert np.count_nonzero(np.isfinite(table[flux_col][mask])) == 1


### PR DESCRIPTION
## Summary
- prune low-power templates and drop highly correlated ones in `SparseFitter`
- add automatic ILU preconditioning and Cholesky-based flux error estimation
- deduplicate templates in the pipeline and add regression test

## Testing
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d42757d888325830cf83c90db3009