### PR TITLE
Fix overlap cosine similarity in SparseFitter

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -51,6 +51,7 @@ This checklist tracks tasks for building the photometry pipeline using Poetry an
   - [x] Added safeguards against singular normal matrices
   - [x] Added Gaussian-process-based local astrometric correction
   - [x] Added ILU preconditioner and SuperLU-based flux error estimation with Hutchinson fallback
+  - [x] Deduplicate templates using weighted overlap cosine similarity
 - [x] **Pipeline orchestrator** (`src/mophongo/pipeline.py`)
   - [x] `run` to tie all pieces together
   - [x] don't implement source detection just yet: assume detection + segmentation image + catalog are available.

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -66,6 +66,36 @@ def test_zero_weight_template_dropped():
     assert len(fitter.templates) == 1
 
 
+def test_nonoverlapping_templates_not_deduplicated():
+    img = np.zeros((10, 10))
+    weights = np.ones_like(img)
+
+    t1 = Template(img, (2, 2), (3, 3))
+    t1.data[:] = 1.0
+    t2 = Template(img, (7, 7), (3, 3))
+    t2.data[:] = 1.0
+
+    fitter = SparseFitter([t1, t2], img, weights, FitConfig())
+    fitter.build_normal_matrix()
+
+    assert len(fitter.templates) == 2
+
+
+def test_overlapping_duplicate_templates_dropped():
+    img = np.zeros((10, 10))
+    weights = np.ones_like(img)
+
+    t1 = Template(img, (2, 2), (3, 3))
+    t1.data[:] = 1.0
+    t2 = Template(img, (2, 2), (3, 3))
+    t2.data[:] = 1.0
+
+    fitter = SparseFitter([t1, t2], img, weights, FitConfig())
+    fitter.build_normal_matrix()
+
+    assert len(fitter.templates) == 1
+
+
 def test_flux_errors_regularized():
     img = np.zeros((3, 3))
     weights = np.ones_like(img)


### PR DESCRIPTION
## Summary
- factor out weighted norm helper and integrate duplicate screening into normal matrix construction
- compute template similarity using weighted overlap directly during matrix assembly
- tests to ensure overlapping duplicates are dropped while non-overlapping templates remain

## Testing
- `PYTHONPATH=src poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e203f424c8325a448bde76013c774