### PR TITLE
feat: add template components and chi2 helper

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -96,3 +96,4 @@ This checklist tracks tasks for building the photometry pipeline using Poetry an
   - [ ] split off real data as submodule?
   - [ ] other code review, misc refactoring, consolidation
   - [ ] remove unused modules, orphan code
+- [ ] support multi-component templates based on per-source \(\chi^2\)

--- a/src/mophongo/astro_fit.py
+++ b/src/mophongo/astro_fit.py
@@ -34,11 +34,17 @@ class GlobalAstroFitter(SparseFitter):
         templates: list[Template],
         image: np.ndarray,
         weights: np.ndarray | None,
-        config: FitConfig 
+        segmap_or_config: np.ndarray | FitConfig | None = None,
+        config: FitConfig | None = None
     ):
-
+        if isinstance(segmap_or_config, FitConfig) and config is None:
+            cfg = segmap_or_config
+            segmap = None
+        else:
+            segmap = segmap_or_config
+            cfg = config or FitConfig()
         # ---------- flux part ----------
-        super().__init__(list(templates), image, weights, config)
+        super().__init__(list(templates), image, weights, cfg)
 
         print('GlobalAstroFitter: templates in', len(templates))
         if not self.config.fit_astrometry:
@@ -46,7 +52,7 @@ class GlobalAstroFitter(SparseFitter):
             return      # nothing more to do
 
         # ---------- astrometry part ----------
-        order = config.astrom_basis_order
+        order = cfg.astrom_basis_order
         self.basis_order = order
         self.n_alpha = astrometry.n_terms(order)   # α_k  (β_k shares the same K)
 
@@ -116,9 +122,10 @@ class GlobalAstroFitter(SparseFitter):
     # ------------------------------------------------------------
     # 3.  solve   # keep track of valid fluxes through ID, not n_flux
     # ------------------------------------------------------------
-    def solve(self, 
-              config: FitConfig | None = None
-    ) -> Tuple[np.ndarray, np.ndarray, int]:
+    def solve(
+        self,
+        config: FitConfig | None = None,
+    ) -> Tuple[np.ndarray, int]:
         cfg   = config or self.config
 
         # build big normal matrix once, this as a shift entry for every template
@@ -189,7 +196,7 @@ class GlobalAstroFitter(SparseFitter):
             tmpl.flux = flux 
             tmpl.err = err
 
-        return self.solution, self.solution_err, info
+        return self.solution, info
 
     # ------------------------------------------------------------
     # helper – evaluate polynomial at any point

--- a/src/mophongo/fit.py
+++ b/src/mophongo/fit.py
@@ -43,6 +43,9 @@ class FitConfig:
     reg_astrom: float = 1e-4
     snr_thresh_astrom: float = 10.0   # 0 → keep all sources (current behaviour)
     astrom_model: str = "polynomial"  # 'polynomial' or 'gp'
+    multi_tmpl_chi2_thresh: float = 5.0
+    multi_tmpl_psf_core: bool = True
+    multi_tmpl_colour: bool = True
 
 
 class SparseFitter:
@@ -244,10 +247,16 @@ class SparseFitter:
             tmpl.flux = flux 
             tmpl.err = err
 
-        return self.solution, self.solution_err, info
+        return self.solution, info
 
     def residual(self) -> np.ndarray:
         return self.image - self.model_image()
+
+    def flux_errors(self) -> np.ndarray:
+        """Return 1σ uncertainties on the fitted fluxes."""
+        if self.solution_err is None:
+            raise ValueError("Call solve() before requesting flux errors")
+        return self.solution_err
 
     def quick_flux(self, templates: Optional[List[Template]] = None) -> np.ndarray:
         """Return quick flux estimates based on template data and image."""

--- a/src/mophongo/pipeline.py
+++ b/src/mophongo/pipeline.py
@@ -137,7 +137,8 @@ def run(
             print( f"Running iteration {j+1} of {config.fit_astrometry_niter}")
 
             fitter = fitter_cls(templates, images[idx], weights_i, config)
-            fluxes, errs, info = fitter.solve()
+            fluxes, info = fitter.solve()
+            errs = fitter.flux_errors()
             print(f'Pipeline (solve) memory: {psutil.Process(os.getpid()).memory_info().rss/1e9:.1f} GB')
             res = fitter.residual()
             print(f'Pipeline (residual) memory: {psutil.Process(os.getpid()).memory_info().rss/1e9:.1f} GB')
@@ -165,7 +166,8 @@ def run(
                 # check if this call is ok, only makes sense if we rebuild the normal matrix
                 # TODO: track this from the templates is_dirty flag
                 fitter._ata = None  # @@@ do this properly
-                fluxes, errs, info = fitter.solve()   
+                fluxes, info = fitter.solve()
+                errs = fitter.flux_errors()
 
         err_pred = fitter.predicted_errors()
  

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,7 +1,7 @@
 #%%
 import numpy as np
 from mophongo.psf import PSF
-from mophongo.templates import Templates, Template
+from mophongo.templates import Templates, Template, per_source_chi2
 from utils import make_simple_data, save_template_diagnostic
 import pytest
 from astropy.wcs import WCS
@@ -62,3 +62,25 @@ def test_template_extension_methods(tmp_path):
 
 def test_kernel_padding():
     return
+
+
+def test_add_component_clones_parent():
+    tmpl = Template(np.ones((3, 3)), (1, 1), (3, 3), label=7)
+    tlist = Templates()
+    tlist._templates.append(tmpl)
+    new_data = np.full((3, 3), 2.0)
+    comp = tlist.add_component(tmpl, new_data, "psf_core")
+
+    assert comp is tlist[-1]
+    assert comp.component == "psf_core"
+    assert comp.parent_id == tmpl.id
+    np.testing.assert_array_equal(comp.data, new_data)
+
+
+def test_per_source_chi2_simple():
+    residual = np.ones((5, 5))
+    sigma = np.ones((5, 5))
+    t1 = Template(np.ones((3, 3)), (2, 2), (3, 3), label=1)
+    t2 = Template(np.ones((3, 3)), (2, 2), (3, 3), label=2)
+    chis = per_source_chi2(residual, sigma, [t1, t2])
+    assert np.allclose(chis, 1.0)


### PR DESCRIPTION
## Summary
- track parent and component tags for templates and add chi²-based helper
- expose flux uncertainty retrieval and expand config for multi-template control
- harmonize fitter, astrometry, and pipeline interfaces with new template features

## Testing
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e34fbf4b0832588ffb6bff122adf2