### PR TITLE
feat: add multi-template fitting pass

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -58,7 +58,8 @@ This checklist tracks tasks for building the photometry pipeline using Poetry an
   - [x] Load or receive arrays for the images, catalog, and PSFs.
   - [x] Call template builder, construct sparse system, solve for fluxes, and return a table of measurements plus residuals.
   - [x] Propagate RMS images as weights to compute flux uncertainties
-  - [x] Enabled template deduplication after extraction
+- [x] Enabled template deduplication after extraction
+- [x] Added multi-template second pass for poor-fit sources
 - [x] **Simulation utilities for tests** (`tests/utils.py`)
   - [x] Create fake catalogs and images with Moffat sources of varying size and ellipticity. positions are ra,dec
   - [x] Produce matching high‑res and low‑res PSFs, with low res PSF at least 5x high res PSF.
@@ -79,6 +80,7 @@ This checklist tracks tasks for building the photometry pipeline using Poetry an
 
 ## TODO
 - [ ] scan for bug fixes / robustness improvements
+  - [x] align PSF components to fractional template centers
   - [ ] automated way of determining optimal convolution kernels for PSF  
 - [ ] validate output catalogs on MIRI data
   - [ ] color color, color mag

--- a/src/mophongo/fit.py
+++ b/src/mophongo/fit.py
@@ -48,6 +48,9 @@ class FitConfig:
     reg_astrom: float = 1e-4
     snr_thresh_astrom: float = 10.0   # 0 → keep all sources (current behaviour)
     astrom_model: str = "polynomial"  # 'polynomial' or 'gp'
+    multi_tmpl_chi2_thresh: float = 5.0
+    multi_tmpl_psf_core: bool = True
+    multi_tmpl_colour: bool = True
 
 
 class SparseFitter:

--- a/tests/test_pipeline_multitemplate.py
+++ b/tests/test_pipeline_multitemplate.py
@@ -1,0 +1,42 @@
+import numpy as np
+import mophongo.pipeline as pipeline
+import mophongo.utils as mutils
+from mophongo.fit import FitConfig
+from utils import make_simple_data
+from dataclasses import dataclass
+
+
+def test_pipeline_multitemplate_pass():
+    images, segmap, catalog, psfs, truth, wht = make_simple_data(nsrc=3, size=51)
+    kernel = [mutils.matching_kernel(psfs[0], p) for p in psfs]
+    kernel[0] = np.array([[1.0]])
+    config = FitConfig(multi_tmpl_chi2_thresh=0.0)
+    table, resid, fitter = pipeline.run(
+        images,
+        segmap,
+        catalog=catalog,
+        psfs=psfs,
+        weights=wht,
+        kernels=kernel,
+        config=config,
+    )
+    assert len(fitter.templates) > len(catalog)
+    assert np.all(np.isfinite(table['flux_1']))
+
+
+@dataclass
+class DummyTemplate:
+    data: np.ndarray
+    input_position_cutout: tuple[float, float]
+
+
+def test_extract_psf_fractional_center_alignment():
+    psf = np.zeros((21, 21))
+    psf[10, 10] = 1.0
+    tmpl = DummyTemplate(data=np.zeros((11, 11)), input_position_cutout=(5.3, 5.7))
+    stamp = pipeline._extract_psf_at(tmpl, psf)
+    y, x = np.indices(stamp.shape)
+    x_c = float((stamp * x).sum())
+    y_c = float((stamp * y).sum())
+    assert np.isclose(stamp.sum(), 1.0)
+    assert np.allclose([x_c, y_c], tmpl.input_position_cutout, atol=1e-3)


### PR DESCRIPTION
## Summary
- tag templates with `parent_id` and `component` and provide helper to append residual-driven components
- configure and run a multi-template second pass in the pipeline with per-source chi^2 checks
- aggregate fluxes from multiple components and test multi-template integration
- align PSF residual components to each template's fractional center

## Testing
- `PYTHONPATH=src poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e433dc18c8325b4f902c74f12a300