### PR TITLE
Prune templates without weight overlap

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -59,6 +59,7 @@ This checklist tracks tasks for building the photometry pipeline using Poetry an
   - [x] Load or receive arrays for the images, catalog, and PSFs.
   - [x] Call template builder, construct sparse system, solve for fluxes, and return a table of measurements plus residuals.
   - [x] Propagate RMS images as weights to compute flux uncertainties
+  - [x] Prune templates lacking weight overlap before convolution
 - [x] Enabled template deduplication after extraction
 - [x] Added multi-template second pass for poor-fit sources
 - [x] Added integer-factor multi-resolution support with template and kernel downsampling

--- a/tests/test_pipeline_prune_templates.py
+++ b/tests/test_pipeline_prune_templates.py
@@ -1,0 +1,26 @@
+import numpy as np
+from astropy.table import Table
+import mophongo.pipeline as pipeline
+
+
+def test_pipeline_prunes_templates_with_zero_weight():
+    hires = np.zeros((4, 4))
+    lowres = np.zeros((4, 4))
+    segmap = np.zeros((4, 4), dtype=int)
+    segmap[0:2, 0:2] = 1
+    segmap[2:4, 2:4] = 2
+    hires[segmap > 0] = 1.0
+
+    images = [hires, lowres]
+    catalog = Table({"id": [1, 2], "x": [0, 3], "y": [0, 3]})
+    w0 = np.ones_like(hires)
+    w1 = np.ones_like(lowres)
+    w1[2:4, 2:4] = 0
+    weights = [w0, w1]
+    kernels = [None, None]
+
+    table, residuals, fitter = pipeline.run(images, segmap, catalog=catalog, weights=weights, kernels=kernels)
+
+    assert len(fitter.templates) == 1
+    assert np.isfinite(table["flux_1"][0])
+    assert np.isnan(table["flux_1"][1])


### PR DESCRIPTION
## Summary
- remove templates whose segmentation footprint has no overlap with the weight map
- drop zero-weight templates in the pipeline before convolution
- test template pruning via pipeline

## Testing
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f57eea06c8325a9fc04f05535bdca