### PR TITLE
feat: add optional fft-fast kernel truncation

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -97,7 +97,7 @@ This checklist tracks tasks for building the photometry pipeline using Poetry an
 - [ ] End-to-end test with realistic mosaic data using `make_mosaic_dataset`
 - [ ] Profiling speed + memory usage
 - [ ] optimizations
-  - [ ] adaptive kernel size depending on SNR
+  - [x] adaptive kernel size depending on SNR
   - [ ] tracking is_dirty on templates
   - [ ] partial normal matrix rebuilding / deleting / refactoring
   - [ ] conditioning matrix   

--- a/src/mophongo/fit.py
+++ b/src/mophongo/fit.py
@@ -41,6 +41,7 @@ class FitConfig:
     solve_method: str = "ata"  # 'ata' or 'lo' (linear operator)
     cg_kwargs: Dict[str, Any] = field(default_factory=lambda: {"M": None, "maxiter": 500, "atol": 1e-6})
     fit_covariances: bool = False  # Use simple fitting errors from diagonal of normal matrix
+    fft_fast: float | bool = False  # False for full kernel, float (0.1-1.0) for truncated FFT kernels
     # condense fit astrometry flags into one: fit_astrometry_niter = 0, means not fitting astrometry
     fit_astrometry_niter: int = 2     # Number of astrometry refinement passes (0 → disabled)
     fit_astrometry_joint: bool = False  # Use joint astrometry fitting, or separate step


### PR DESCRIPTION
## Summary
- store truncated-kernel radius and encircled-energy directly on each `Template`
- factor out PSF profile prep and kernel cropping helpers and compute truncation purely in pixel units
- crop kernels via `Cutout2D` and correct fitted fluxes using `ee_fraction`

## Testing
- `poetry run pytest tests/test_templates.py::test_extract_templates_sizes_and_norm -q`
- `poetry run pytest tests/test_templates.py::test_convolve_templates_fft_fast -q`
- `poetry run pytest -q` *(fails: FitConfig.__init__ unexpected keyword argument 'astrom_basis_order'; SparseFitter solve_lo missing; UnboundLocalError in pipeline)*

------
https://chatgpt.com/codex/tasks/task_e_689302abb6708325b2ce0899682ca042