### PR TITLE
Add component-wise solver using STRtree grouping

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -57,6 +57,7 @@ This checklist tracks tasks for building the photometry pipeline using Poetry an
   - [ ] Deduplicate templates using weighted overlap cosine similarity
   - [x] Consolidated flux and RMS estimation into parent `SparseFitter`
   - [x] Added STRtree-based normal matrix builder (`build_normal_tree`)
+  - [x] Added component-wise CG solver using STRtree groups
 - [x] **Pipeline orchestrator** (`src/mophongo/pipeline.py`)
   - [x] `run` to tie all pieces together
   - [x] don't implement source detection just yet: assume detection + segmentation image + catalog are available.


### PR DESCRIPTION
## Summary
- group overlapping templates into connected components with an STRtree
- add CG solver that tackles each component independently
- test component solver against global solution

## Testing
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'mophongo.fft'; ImportError: cannot import name 'bin2d_mean' from 'mophongo.utils')*
- `poetry run pytest tests/test_fit.py::test_solve_components_matches_global -q`


------
https://chatgpt.com/codex/tasks/task_e_68997588f6f48325b26851af11a41a67