### PR TITLE
feat: add sparse Cholesky preconditioner for component solver

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -66,6 +66,7 @@ This checklist tracks tasks for building the photometry pipeline using Poetry an
   - [x] Added STRtree-based normal matrix builder (`build_normal_tree`)
   - [x] Added component-wise CG solver using STRtree groups
   - [x] Added component-wise solver with shift blocks
+  - [x] Whitened component solver with sparse Cholesky preconditioner
 - [x] **Pipeline orchestrator** (`src/mophongo/pipeline.py`)
   - [x] `run` to tie all pieces together
   - [x] don't implement source detection just yet: assume detection + segmentation image + catalog are available.
@@ -122,7 +123,7 @@ This checklist tracks tasks for building the photometry pipeline using Poetry an
 - [ ] Profiling speed + memory usage
 - [ ] optimizations
   - [x] adaptive kernel size depending on SNR
-  - [ ] preconditioning matrix   
+  - [x] preconditioning matrix
 - [ ] strong residuals
   - [ ] handle saturated stars in 444 -> catalog pre pass detection
   - [ ] fit as PSF both 444, 770, fit for centroid, mask center

--- a/tests/test_sparse_cholesky.py
+++ b/tests/test_sparse_cholesky.py
@@ -1,0 +1,16 @@
+import numpy as np
+from scipy.sparse import diags
+from scipy.sparse.linalg import cg
+
+from mophongo.fit import make_sparse_chol_prec
+
+
+def test_sparse_cholesky_preconditioner_solve():
+    n = 5
+    A = diags([2 * np.ones(n), -1 * np.ones(n - 1), -1 * np.ones(n - 1)], [0, -1, 1], format="csc")
+    b = np.ones(n)
+    M = make_sparse_chol_prec(A)
+    x, info = cg(A, b, M=M, atol=0.0, rtol=1e-12)
+    x_true = np.linalg.solve(A.toarray(), b)
+    assert info == 0
+    np.testing.assert_allclose(x, x_true, rtol=1e-8, atol=1e-8)


### PR DESCRIPTION
## Summary
- add pure-Python sparse Cholesky factorization and preconditioner
- whiten component blocks and solve with Cholesky-preconditioned CG
- cover preconditioner with a dedicated unit test

## Testing
- `poetry run pytest`
- `poetry run pytest tests/test_sparse_cholesky.py`


------
https://chatgpt.com/codex/tasks/task_e_689aa42eafe483259e7e160e06e44eb2