### PR TITLE
Rename component solver to scene solver and centralize whitening

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -67,6 +67,7 @@ This checklist tracks tasks for building the photometry pipeline using Poetry an
   - [x] Added component-wise CG solver using STRtree groups
   - [x] Added component-wise solver with shift blocks
   - [x] Whitened component solver with sparse Cholesky preconditioner
+  - [x] Renamed component terminology to scene and centralized whitening in scene solver
 - [x] **Pipeline orchestrator** (`src/mophongo/pipeline.py`)
   - [x] `run` to tie all pieces together
   - [x] don't implement source detection just yet: assume detection + segmentation image + catalog are available.

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -25,7 +25,7 @@ def test_flux_recovery(tmp_path):
     fitter.build_normal_matrix()
     x, err, info = fitter.solve()
 
-    assert info == 0
+    assert info["cg_info"] == 0
 #    assert np.allclose(x, np.array(catalog['flux_true']), rtol=1e-1)
     model = fitter.model_image()
     fname = tmp_path / "fit.png"
@@ -157,7 +157,7 @@ def test_build_normal_tree_matches_loop():
     np.testing.assert_allclose(fitter_loop.atb, fitter_tree._atb)
 
 
-def test_solve_components_matches_global():
+def test_solve_scene_matches_global():
     img = np.zeros((6, 6))
     weights = np.ones_like(img)
 
@@ -196,7 +196,7 @@ def test_solve_components_matches_global():
     fitter_comp.templates[0].data[:] = t1.data
     fitter_comp.templates[1].data[:] = t2.data
     fitter_comp.templates[2].data[:] = t3.data
-    flux_comp, _, _ = fitter_comp.solve_components()
+    flux_comp, _, _ = fitter_comp.solve_scene()
 
     np.testing.assert_allclose(flux_comp, flux_all, rtol=1e-6, atol=1e-6)
 
@@ -246,7 +246,7 @@ def test_bright_source_detection():
     assert np.array_equal(fitter.bright_mask, expected)
 
 
-def test_solve_components_shifts_matches_global():
+def test_solve_scene_shifts_matches_global():
     img = np.zeros((6, 6))
     weights = np.ones_like(img)
 
@@ -283,7 +283,8 @@ def test_solve_components_shifts_matches_global():
     fitter_shift.templates[0].data[:] = t1.data
     fitter_shift.templates[1].data[:] = t2.data
     fitter_shift.templates[2].data[:] = t3.data
-    flux_shift, betas, _ = fitter_shift.solve_components_shifts(order=1)
+    flux_shift, _, info = fitter_shift.solve_scene_shifts(order=1)
+    betas = info["betas"]
 
     np.testing.assert_allclose(flux_shift, flux_all, rtol=1e-4, atol=1e-4)
     for _, beta in betas:


### PR DESCRIPTION
## Summary
- rename component terminology to scene across the fitter
- whiten normal matrix once per scene solve and unwhiten solution/errors after
- update scene shift solver and associated tests

## Testing
- `poetry run pytest tests/test_fit.py` *(fails: SparseFitter has no attribute solve_lo)*

------
https://chatgpt.com/codex/tasks/task_e_689aee971f408325ac8556eeae93de0e