### PR TITLE
Add AstroCorrect utilities for template shifts

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -51,6 +51,7 @@ This checklist tracks tasks for building the photometry pipeline using Poetry an
   - [x] Added safeguards against singular normal matrices
 - [x] Added Gaussian-process-based local astrometric correction
 - [x] Introduced `AstroCorrect` for pluggable local astrometry models
+- [x] Added static utilities in `AstroCorrect` for applying stored template shifts and building polynomial predictors
 - [x] Merged astrometry modules and added `AstroMap` for image-to-image shift mapping
 - [x] Removed deprecated `fit_astrometry` flag in `FitConfig`; use `fit_astrometry_niter` only
 - [x] Added ILU preconditioner and SuperLU-based flux error estimation with Hutchinson fallback

--- a/src/mophongo/astrometry.py
+++ b/src/mophongo/astrometry.py
@@ -266,6 +266,80 @@ class AstroCorrect:
         init=False, repr=False, default=lambda p: (np.zeros(len(p)), np.zeros(len(p)))
     )
 
+    # ------------------------------------------------------------
+    # static helpers
+    # ------------------------------------------------------------
+    @staticmethod
+    def apply_template_shifts(templates: Sequence[Template]) -> None:
+        """Apply stored ``shift`` values to templates in-place.
+
+        Parameters
+        ----------
+        templates:
+            Sequence of :class:`~mophongo.templates.Template` objects whose
+            ``shift`` attribute encodes the ``(dx, dy)`` offset to apply.
+        """
+
+        for tmpl in templates:
+            dx, dy = map(float, tmpl.shift)
+            if abs(dx) < 1e-2 and abs(dy) < 1e-2:
+                continue
+
+            x0, y0 = tmpl.input_position_original
+            tmpl.data = nd_shift(
+                tmpl.data,
+                (dy, dx),
+                order=3,
+                mode="constant",
+                cval=0.0,
+                prefilter=True,
+            )
+            tmpl.input_position_original = (x0 - dx, y0 - dy)
+            tmpl.shift[:] = 0.0
+
+    @staticmethod
+    def build_poly_predictor(
+        coeffs: np.ndarray,
+        x_cen: float,
+        y_cen: float,
+        order: int,
+    ) -> Callable[[float | np.ndarray, float | None], tuple[np.ndarray, np.ndarray]]:
+        """Return a callable predicting shifts from polynomial coefficients.
+
+        Parameters
+        ----------
+        coeffs:
+            Concatenated polynomial coefficients ``[β_x, β_y]``.  The first
+            ``n_terms(order)`` entries correspond to the ``x`` shift and the
+            remaining entries (if present) to the ``y`` shift.
+        x_cen, y_cen:
+            Central coordinates used when the polynomial field was fitted.
+        order:
+            Chebyshev polynomial order of the solution.
+        """
+
+        p = n_terms(order)
+        bx = np.array(coeffs[:p], dtype=float)
+        by = np.array(coeffs[p:], dtype=float) if coeffs.size >= 2 * p else np.zeros(p)
+
+        def predict(
+            x: float | np.ndarray, y: float | None = None
+        ) -> tuple[np.ndarray, np.ndarray]:
+            if y is None:
+                pts = np.asarray(x, float).reshape(-1, 2)
+                shape = pts.shape[:-1]
+            else:
+                pts = np.c_[np.asarray(x, float).ravel(), np.asarray(y, float).ravel()]
+                shape = np.broadcast(x, y).shape
+            phi = np.array(
+                [cheb_basis(px - x_cen, py - y_cen, order) for px, py in pts]
+            )
+            dx = phi @ bx
+            dy = phi @ by
+            return dx.reshape(shape), dy.reshape(shape)
+
+        return predict
+
     def __call__(
         self, x: float | np.ndarray, y: float | None = None
     ) -> tuple[np.ndarray, np.ndarray]:


### PR DESCRIPTION
## Summary
- add static helper `apply_template_shifts` to warp templates based on stored `shift` values
- add static helper `build_poly_predictor` to create shift prediction functions from polynomial coefficients
- test template shifting and polynomial predictor generation

## Testing
- `poetry run pytest tests/test_astrometry.py::test_apply_template_shifts_uses_shift_field`
- `poetry run pytest tests/test_astrometry.py::test_build_poly_predictor_returns_expected_shift`


------
https://chatgpt.com/codex/tasks/task_e_689c8356a0e48325b7387e77fbd33553