### PR TITLE
Add stateless SceneFitter and Scene utilities

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -66,9 +66,10 @@ This checklist tracks tasks for building the photometry pipeline using Poetry an
   - [x] Consolidated flux and RMS estimation into parent `SparseFitter`
   - [x] Added STRtree-based normal matrix builder (`build_normal_tree`)
   - [x] Added component-wise CG solver using STRtree groups
-  - [x] Added component-wise solver with shift blocks
-  - [x] Whitened component solver with sparse Cholesky preconditioner
-  - [x] Renamed component terminology to scene and centralized whitening in scene solver
+- [x] Added component-wise solver with shift blocks
+- [x] Whitened component solver with sparse Cholesky preconditioner
+- [x] Renamed component terminology to scene and centralized whitening in scene solver
+- [x] Introduced stateless `SceneFitter` and `Scene` utilities
 - [x] **Pipeline orchestrator** (`src/mophongo/pipeline.py`)
   - [x] `run` to tie all pieces together
   - [x] don't implement source detection just yet: assume detection + segmentation image + catalog are available.

--- a/src/mophongo/__init__.py
+++ b/src/mophongo/__init__.py
@@ -1,5 +1,7 @@
 from .templates import Templates, Template
 from .fit import SparseFitter
+from .scene_fitter import SceneFitter
+from .scene import Scene
 from .astrometry import AstroCorrect, AstroMap
 from .catalog import Catalog
 #from .deblender import deblend_sources_symmetry, deblend_sources_hybrid
@@ -19,6 +21,8 @@ __all__ = [
 #    "Template",
 #    "FitConfig",
     "SparseFitter",
+    "SceneFitter",
+    "Scene",
     "AstroCorrect",
     "AstroMap",
     "Catalog",

--- a/src/mophongo/scene.py
+++ b/src/mophongo/scene.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import List, Tuple
+
+import numpy as np
+import scipy.sparse as sp
+
+from .templates import Template
+from .scene_fitter import SceneFitter
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Scene:
+    """Container for templates belonging to a single scene."""
+
+    templates: List[Template]
+    fitter: SceneFitter
+    shift_basis: np.ndarray | None = None
+    bbox: Tuple[int, int, int, int] | None = None
+
+    def solve(
+        self,
+        A: sp.spmatrix,
+        b: np.ndarray,
+        *,
+        AB: sp.spmatrix | None = None,
+        BB: sp.spmatrix | None = None,
+        bB: np.ndarray | None = None,
+        **kwargs,
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray | None, int]:
+        """Solve this scene's normal equations."""
+        return self.fitter.solve(A, b, AB=AB, BB=BB, bB=bB, **kwargs)
+
+    def add_residuals(self, image: np.ndarray, coeffs: np.ndarray) -> np.ndarray:
+        """Subtract model contributions from ``image`` in-place."""
+        for c, tmpl in zip(coeffs, self.templates):
+            sl = tmpl.slices_original
+            cut = tmpl.data[tmpl.slices_cutout]
+            image[sl] -= c * cut
+        return image
+
+    @staticmethod
+    def create_scene_graph(templates: List[Template]) -> np.ndarray:
+        """Return connected-component labels for ``templates``."""
+        n = len(templates)
+        adj = sp.lil_matrix((n, n), dtype=int)
+        for i in range(n):
+            for j in range(i + 1, n):
+                if Scene._overlaps(templates[i].bbox, templates[j].bbox):
+                    adj[i, j] = 1
+                    adj[j, i] = 1
+        labels = sp.csgraph.connected_components(adj.tocsr(), directed=False)[1]
+        return labels
+
+    @staticmethod
+    def overlay_scene_graph(
+        templates: List[Template], shape: Tuple[int, int]
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """Overlay scene labels onto an empty image of ``shape``."""
+        labels = Scene.create_scene_graph(templates)
+        seg = np.zeros(shape, dtype=int)
+        for lbl, tmpl in zip(labels, templates):
+            y0, y1, x0, x1 = tmpl.bbox
+            seg[y0:y1, x0:x1] = int(lbl) + 1
+        return seg, labels
+
+    @staticmethod
+    def _overlaps(a: Tuple[int, int, int, int], b: Tuple[int, int, int, int]) -> bool:
+        """Return True if bounding boxes ``a`` and ``b`` overlap."""
+        y0a, y1a, x0a, x1a = a
+        y0b, y1b, x0b, x1b = b
+        return not (y1a <= y0b or y1b <= y0a or x1a <= x0b or x1b <= x0a)
+
+    def plot(self, image: np.ndarray, ax=None, **imshow_kwargs):
+        """Plot the scene on top of ``image``."""
+        import matplotlib.pyplot as plt
+
+        if ax is None:
+            ax = plt.gca()
+        ax.imshow(image, origin="lower", **imshow_kwargs)
+        for tmpl in self.templates:
+            y0, y1, x0, x1 = tmpl.bbox
+            rect = plt.Rectangle((x0, y0), x1 - x0, y1 - y0, fill=False, color="r")
+            ax.add_patch(rect)
+        return ax

--- a/src/mophongo/scene_fitter.py
+++ b/src/mophongo/scene_fitter.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import numpy as np
+import scipy.sparse as sp
+from scipy.sparse.linalg import cg
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SceneFitter:
+    """Stateless solver for scene normal equations.
+
+    The fitter whitens the flux block of the normal matrix, solves the
+    system using conjugate gradients and returns unwhitened fluxes and
+    their 1σ uncertainties. Optionally, an additional shift block can be
+    supplied which is solved jointly with the fluxes.
+    """
+
+    @staticmethod
+    def solve(
+        A: sp.spmatrix,
+        b: np.ndarray,
+        *,
+        reg: float = 0.0,
+        AB: sp.spmatrix | None = None,
+        BB: sp.spmatrix | None = None,
+        bB: np.ndarray | None = None,
+        cg_kwargs: Optional[dict] = None,
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray | None, int]:
+        """Solve ``A x = b`` with optional shift block.
+
+        Parameters
+        ----------
+        A
+            Flux normal matrix (unwhitened).
+        b
+            Right hand side.
+        reg
+            Diagonal regularisation strength.
+        AB, BB, bB
+            Optional blocks coupling the fluxes to shift parameters.
+        cg_kwargs
+            Extra keyword arguments passed to :func:`scipy.sparse.linalg.cg`.
+
+        Returns
+        -------
+        alpha, err, beta, info
+            Unwhitened fluxes, their 1σ errors, optional shift coefficients
+            and the CG exit flag.
+        """
+
+        cg_kwargs = cg_kwargs or {}
+
+        Areg = A + reg * sp.eye(A.shape[0], format="csr")
+        d = np.sqrt(Areg.diagonal())
+        Dinv = sp.diags(1.0 / d, 0, format="csr")
+        A_w = Dinv @ Areg @ Dinv
+        b_w = Dinv @ b
+
+        if AB is not None:
+            if BB is None or bB is None:
+                raise ValueError("AB provided but BB or bB missing")
+            AB_w = Dinv @ AB
+            top = sp.hstack([A_w, AB_w], format="csr")
+            bottom = sp.hstack([AB_w.T, BB], format="csr")
+            sys = sp.vstack([top, bottom], format="csr")
+            rhs = np.concatenate([b_w, bB])
+        else:
+            sys = A_w
+            rhs = b_w
+
+        xw, info = cg(sys, rhs, **cg_kwargs)
+        if info != 0:
+            logger.warning("CG did not converge: info=%d", info)
+
+        if AB is not None:
+            alpha_w = xw[: A.shape[0]]
+            beta = xw[A.shape[0] :]
+        else:
+            alpha_w = xw
+            beta = None
+
+        alpha = alpha_w / d
+
+        try:
+            cov = np.linalg.inv(sys.toarray())
+            err_w = np.sqrt(np.diag(cov)[: A.shape[0]])
+        except Exception:
+            logger.exception("Failed to compute covariance")
+            err_w = np.full(A.shape[0], np.nan)
+        err = err_w / d
+
+        return alpha, err, beta, info

--- a/tests/test_scene_fitter.py
+++ b/tests/test_scene_fitter.py
@@ -1,0 +1,57 @@
+import numpy as np
+import scipy.sparse as sp
+
+from mophongo.scene_fitter import SceneFitter
+from mophongo.scene import Scene
+from mophongo.templates import Template
+
+
+def test_scene_fitter_flux_only():
+    A = sp.csr_matrix([[4.0, 1.0], [1.0, 3.0]])
+    b = np.array([1.0, 2.0])
+    alpha, err, beta, info = SceneFitter.solve(A, b)
+    expected = np.linalg.solve(A.toarray(), b)
+    cov = np.linalg.inv(A.toarray())
+    expected_err = np.sqrt(np.diag(cov))
+    assert info == 0
+    assert beta is None
+    np.testing.assert_allclose(alpha, expected)
+    np.testing.assert_allclose(err, expected_err)
+
+
+def test_scene_fitter_with_shift_block():
+    A = sp.csr_matrix([[2.0, 0.0], [0.0, 1.0]])
+    b = np.array([1.0, 1.0])
+    AB = sp.csr_matrix([[1.0], [2.0]])
+    BB = sp.csr_matrix([[3.0]])
+    bB = np.array([0.5])
+    alpha, err, beta, info = SceneFitter.solve(A, b, AB=AB, BB=BB, bB=bB)
+    M = np.block([[A.toarray(), AB.toarray()], [AB.T.toarray(), BB.toarray()]])
+    rhs = np.concatenate([b, bB])
+    dense = np.linalg.solve(M, rhs)
+    np.testing.assert_allclose(alpha, dense[:2])
+    np.testing.assert_allclose(beta, dense[2:])
+
+
+def test_scene_graph_and_residuals():
+    img = np.zeros((10, 10))
+    size = (3, 3)
+    t1 = Template(img, (2, 2), size, label=1)
+    t2 = Template(img, (2, 3), size, label=2)
+    t3 = Template(img, (7, 7), size, label=3)
+    scene_labels = Scene.create_scene_graph([t1, t2, t3])
+    assert scene_labels[t1.id - 1] == scene_labels[t2.id - 1]
+    assert scene_labels[t1.id - 1] != scene_labels[t3.id - 1]
+    seg, labels = Scene.overlay_scene_graph([t1, t2, t3], img.shape)
+    assert seg[t1.bbox[0], t1.bbox[2]] == seg[t2.bbox[0], t2.bbox[2]]
+    assert seg[t3.bbox[0], t3.bbox[2]] != seg[t1.bbox[0], t1.bbox[2]]
+    # Residuals
+    for tmpl in (t1, t2, t3):
+        tmpl.data[...] = 1.0
+    sc = Scene([t1, t2], SceneFitter())
+    coeffs = np.array([2.0, 3.0])
+    res = sc.add_residuals(np.zeros_like(img), coeffs)
+    expected = np.zeros_like(img)
+    expected[t1.slices_original] -= 2.0
+    expected[t2.slices_original] -= 3.0
+    np.testing.assert_array_almost_equal(res, expected)


### PR DESCRIPTION
## Summary
- implement stateless `SceneFitter` to whiten/solve normal matrices with optional shift block
- add `Scene` dataclass with graph utilities, residual handling and plotting
- expose new classes via package init and document in checklist
- cover solver and scene graph behaviour with new tests

## Testing
- `poetry run pytest tests/test_scene_fitter.py -q`
- `poetry run pytest -q` *(fails: FitConfig.__init__() unexpected keyword argument 'astrom_basis_order')*

------
https://chatgpt.com/codex/tasks/task_e_68ad30b8902883259c317a9b88b9a84b