### PR TITLE
long-wavelength residual bux fix + astrometry source selection improvements

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -132,6 +132,21 @@ This checklist tracks tasks for building the photometry pipeline using Poetry an
 - [ ] optimizations
   - [x] adaptive kernel size depending on SNR
   - [x] preconditioning matrix
+- [ ] scene size guard and template radius limiting
+  - [ ] **Test needed first**: run F1800W without `max_template_radius` to confirm whether `scene_coupling_thresh` alone is sufficient to prevent ginormous scenes, or if radius capping is also required.
+  - [ ] **Scene size inspection**: after `generate_scenes` in pipeline, compute per-scene template count and pixel footprint. If any scene exceeds a configurable threshold (e.g. `max_scene_templates: int = None` in FitConfig), halt and print a summary table of scene sizes so the user can decide whether to tighten `scene_coupling_thresh` or enable radius capping.
+  - [ ] **`max_template_radius` feature** (implemented but not yet validated — discard from codebase until tested):
+    - `FitConfig.max_template_radius: float | None = None` — max footprint radius in arcsec (None = unlimited).
+    - In `pipeline.py` before `convolve_templates`: `max_radius_pix = config.max_template_radius / pscale_arcsec` (uses `proj_plane_pixel_scales(wcs[0])[0] * 3600`).
+    - In `Templates.convolve_templates(kernel, max_radius_pix=None)`: after each `convolve_cutout`, zero pixels beyond radius — `dist = sqrt((y-yc)^2 + (x-xc)^2); new_tmpl.data[dist > max_radius_pix] = 0.0` where `xc, yc = new_tmpl.input_position_cutout`.
+    - Also add `FitConfig.scene_max_merge_radius: float = np.inf` which is already wired in pipeline via `getattr`.
+- [ ] astrometric shift quality improvements
+  - [ ] `astrom_isolation_thresh` in FitConfig: per-source isolation cut for bright-source astrometry mask.
+        Compute max off-diagonal coupling score from scene.A (same metric as scene_coupling_thresh) per
+        source; only use sources where max neighbour contamination < threshold for shift estimation.
+        Addresses inflated alpha0 from blending biasing shift estimates (shift ∝ 1/alpha0).
+        Threshold must be > scene_coupling_thresh (else all blended-scene sources are excluded).
+        Suggested default ~0.2 (20%); needs empirical tuning on F1800W fields.
 - [ ] strong residuals
   - [ ] handle saturated stars in 444 -> catalog pre pass detection
   - [ ] fit as PSF both 444, 770, fit for centroid, mask center

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -140,19 +140,24 @@ This checklist tracks tasks for building the photometry pipeline using Poetry an
     - In `pipeline.py` before `convolve_templates`: `max_radius_pix = config.max_template_radius / pscale_arcsec` (uses `proj_plane_pixel_scales(wcs[0])[0] * 3600`).
     - In `Templates.convolve_templates(kernel, max_radius_pix=None)`: after each `convolve_cutout`, zero pixels beyond radius — `dist = sqrt((y-yc)^2 + (x-xc)^2); new_tmpl.data[dist > max_radius_pix] = 0.0` where `xc, yc = new_tmpl.input_position_cutout`.
     - Also add `FitConfig.scene_max_merge_radius: float = np.inf` which is already wired in pipeline via `getattr`.
-- [ ] astrometric shift quality improvements
-  - [ ] `astrom_isolation_thresh` in FitConfig: per-source isolation cut for bright-source astrometry mask.
-        Compute max off-diagonal coupling score from scene.A (same metric as scene_coupling_thresh) per
-        source; only use sources where max neighbour contamination < threshold for shift estimation.
-        Addresses inflated alpha0 from blending biasing shift estimates (shift ∝ 1/alpha0).
-        Threshold must be > scene_coupling_thresh (else all blended-scene sources are excluded).
-        Suggested default ~0.2 (20%); needs empirical tuning on F1800W fields.
+- [x] astrometric shift quality improvements
+  - [x] `astrom_isolation_thresh` in FitConfig: sources used for astrometry must contribute >= thresh
+        fraction of the flux at their own location (coupling-weighted template overlap). Stars excluded
+        via `flag_star` catalog column. `merge_small_scenes` now uses bright non-star count so
+        star-dominated scenes are merged into neighbors before solve.
+  - [ ] Scene with no bright non-star isolated sources skips astrometry with a warning.
+        TODO: consider merging such scenes with a neighbor rather than skipping — isolation filtering
+        can't be applied at merge time, so all-blended scenes currently fall through to the guard.
 - [ ] strong residuals
   - [ ] handle saturated stars in 444 -> catalog pre pass detection
   - [ ] fit as PSF both 444, 770, fit for centroid, mask center
 - [ ]  wavelength dependent morphology: only where residuals are significant.
   - [ ] Add point source, if PSF not given start with marginally sampled Gaussian?  
   - [ ] add second bluer band
+- [ ] stale tests in `tests/test_fit.py` — 8 tests reference old `SparseFitter` method names
+        (`build_normal_matrix`, `solve_lo`, `bright_mask`, `solve_scene_shifts`) that have been
+        renamed or removed. Also `test_pipeline.py::test_download_rate` hangs on MAST network call.
+        Either update tests to match current API or delete if no longer relevant.
 - [ ] refactoring for readibility and modularity
   - [ ] split off PSF map / drizzle PSF / PSFs module, make submodule
   - [ ] split off real data as submodule?

--- a/src/mophongo/fit.py
+++ b/src/mophongo/fit.py
@@ -65,6 +65,7 @@ class FitConfig:
     # --- astrometry options -------------------------------------------------
     reg_astrom: float = 1e-4
     snr_thresh_astrom: float = 15.0  # 0 → keep all sources
+    astrom_isolation_thresh: float = 0.5  # min flux dominance to include in astrometry (0–1); 0.0 = no cut
     astrom_model: str = "gp"  # 'polynomial' or 'gp'
     astrom_centroid: str = "centroid"  # "centroid" (=old) | "correlation"
     astrom_kwargs: dict[str, dict] = field(

--- a/src/mophongo/fit.py
+++ b/src/mophongo/fit.py
@@ -97,6 +97,7 @@ class FitConfig:
     # scene processing
     run_scene_solver: bool = True  # Whether to run the scene solver at all
     scene_coupling_thresh: float = 1e-3  # 1% leakage threshold for scene splitting
+    scene_max_merge_radius: float = np.inf  # Max distance (px) to merge underfilled scenes (default: inf = no limit)
     generate_scene_catalog: bool = False  # If True, generate scene catalog and exit
 
     def __post_init__(self):

--- a/src/mophongo/pipeline.py
+++ b/src/mophongo/pipeline.py
@@ -577,6 +577,13 @@ class Pipeline:
         for t in templates:
             assert np.all(np.isfinite(t.data)), "Templates contain NaN values"
 
+        if catalog is not None and "flag_star" in catalog.colnames:
+            star_ids = set(int(r["id"]) for r in catalog if r["flag_star"] == 1)
+            for t in templates:
+                if int(t.id) in star_ids:
+                    t.is_star = True
+            logger.info("Marked %d templates as stars (excluded from astrometry)", sum(t.is_star for t in templates))
+
         ndropped = len(cat) - len(templates)
         # @@@ this is because of reliance of x,y in catalog -> use segmap + weight?
         print(f"Pipepline: {len(templates)} extracted templates, dropped {ndropped}.")

--- a/src/mophongo/pipeline.py
+++ b/src/mophongo/pipeline.py
@@ -467,11 +467,6 @@ class Pipeline:
         r_img_pix = self._resolve_image_ap_radius_pix(
             idx, cfg
         )  # same for all in this band (by design)
-        r_cat_pix_by_id = self._resolve_catalog_ap_radius_pix(cat, cfg, r_default=r_img_pix)
-
-        # map parent id -> original (pre-convolution) template on the ref image
-        ref_tmpls = {int(t.id): t for t in self.tmpls.templates}
-
         # residual+model patch measurement (raw)
         for tmpl, fl in zip(templates, fluxes):
             pid = tmpl.id_parent if getattr(tmpl, "parent_id", None) is not None else tmpl.id
@@ -490,15 +485,16 @@ class Pipeline:
             phot = aperture_photometry(patch, aper_img, method="exact")
             ap_raw = float(phot["aperture_sum"][0])
 
-            # --- PSF correction from templates (pre vs post conv) -----------------
-            # numerator: ref pre-convolution template with *catalog* aperture (per source)
-            tmpl_ref = ref_tmpls.get(int(pid))
-            r_cat_pix = r_cat_pix_by_id.get(int(pid), np.nan)
-            num = (
-                self._aperture_sum_on_template(tmpl_ref, r_cat_pix)
-                if (tmpl_ref and np.isfinite(r_cat_pix))
-                else np.nan
-            )
+            # --- correction from aperture flux to total flux via template EE -----------
+            # numerator: total flux of the convolved template (= post-conv sum).
+            # Using the post-conv total (rather than 1.0) accounts for any flux lost
+            # at the template boundary during convolution.
+            # denominator: flux of the convolved template within the photometric aperture.
+            # corr = num/den = post_conv_total / post_conv_aperture = 1/EE_source_MIRI(r),
+            # which converts ap_raw (partial aperture flux) to total flux.
+            # Previously num used aperture_sum(pre_conv_template, r), which gave
+            # EE_source_F444W(r) ~ 0.3 in the numerator and caused a ~1.2 mag offset.
+            num = float(tmpl.data.sum())
 
             # denominator: current *convolved* template with *image* aperture
             den = self._aperture_sum_on_template(tmpl, r_img_pix)

--- a/src/mophongo/scene.py
+++ b/src/mophongo/scene.py
@@ -45,6 +45,30 @@ def _bbox_overlap(a: Tuple[int, int, int, int], b: Tuple[int, int, int, int]) ->
     return not (a[1] <= b[0] or b[1] <= a[0] or a[3] <= b[2] or b[3] <= a[2])
 
 
+def _astrom_isolation_mask(A: sp.spmatrix, b: np.ndarray, thresh: float) -> np.ndarray:
+    """Return bool mask: True where source contributes >= thresh of its own local flux.
+
+    dominance[i] = (alpha0[i] * ATA[i,i]) /
+                   (alpha0[i] * ATA[i,i] + sum_j alpha0[j] * |ATA[i,j]|)
+
+    ATA[i,j] is the integral of T_i * T_j over the image, so alpha0[j] * ATA[i,j]
+    is exactly the neighbor flux falling within source i's template footprint.
+    """
+    n = A.shape[0]
+    diag = np.maximum(A.diagonal(), 1e-12)
+    alpha0 = np.abs(b) / diag
+    Au = sp.triu(A, k=1).tocoo()
+    if Au.nnz == 0:
+        return np.ones(n, dtype=bool)
+    i, j, aij = Au.row, Au.col, np.abs(Au.data)
+    neighbor_flux = np.zeros(n)
+    np.add.at(neighbor_flux, i, alpha0[j] * aij)
+    np.add.at(neighbor_flux, j, alpha0[i] * aij)
+    self_flux = alpha0 * diag
+    dominance = self_flux / np.maximum(self_flux + neighbor_flux, 1e-12)
+    return dominance >= thresh
+
+
 def build_scene_tree_from_normal(
     ATA: sp.spmatrix,
     ATb: np.ndarray,
@@ -521,7 +545,8 @@ def generate_scenes(
     snr_proxy = np.divide(
         ATb, np.sqrt(np.maximum(d, 1e-12)), out=np.zeros_like(ATb, dtype=float), where=d > 0
     )
-    bright_mask = np.asarray(snr_proxy > float(snr_thresh_astrom), dtype=bool)
+    not_star = ~np.array([t.is_star for t in templates], dtype=bool)
+    bright_mask = np.asarray(snr_proxy > float(snr_thresh_astrom), dtype=bool) & not_star
 
     labels, nscene = merge_small_scenes(
         labels0,
@@ -631,12 +656,14 @@ class Scene:
 
         A, b = self.A, self.b
 
-        # bright mask via SNR proxy against cfg.snr_thresh_astrom
+        # bright mask: SNR cut + exclude stars + isolation cut
         d = np.asarray(A.diagonal(), dtype=float)
         snr_proxy = np.divide(
             b, np.sqrt(np.maximum(d, 1e-12)), out=np.zeros_like(b, dtype=float), where=d > 0
         )
-        self.is_bright = snr_proxy > float(cfg.snr_thresh_astrom)
+        not_star = ~np.array([t.is_star for t in self.templates], dtype=bool)
+        isolated = _astrom_isolation_mask(A, b, float(cfg.astrom_isolation_thresh))
+        self.is_bright = (snr_proxy > float(cfg.snr_thresh_astrom)) & not_star & isolated
 
         # flux-only path
         if not cfg.fit_astrometry_joint:
@@ -668,39 +695,50 @@ class Scene:
             sol = SceneFitter.solve(A, b, AB=AB, BB=BB, bB=bB, config=cfg, **kwargs)
             self.shifts = sol.shifts
 
-            # record per object shift in templates
-            predict = AstroCorrect.build_poly_predictor(self.shifts, x0, y0, order, Sx, Sy)
-            pts = np.array([t.position_original for t in self.templates], dtype=float)
-            dx, dy = predict(pts[:, 0], pts[:, 1])
-            for k, tmpl in enumerate(self.templates):
-                tmpl.to_shift = np.array([float(dx[k]), float(dy[k])], dtype=float)
+            if self.shifts is not None and len(self.shifts) > 0:
+                # record per object shift in templates
+                predict = AstroCorrect.build_poly_predictor(self.shifts, x0, y0, order, Sx, Sy)
+                pts = np.array([t.position_original for t in self.templates], dtype=float)
+                dx, dy = predict(pts[:, 0], pts[:, 1])
+                for k, tmpl in enumerate(self.templates):
+                    tmpl.to_shift = np.array([float(dx[k]), float(dy[k])], dtype=float)
 
-            # optionally apply shifts to templates now and clear A/b
-            if apply_shifts:
-                Templates.apply_template_shifts(self.templates)
-                self.A, self.b = None, None
+                # optionally apply shifts to templates now and clear A/b
+                if apply_shifts:
+                    Templates.apply_template_shifts(self.templates)
+                    self.A, self.b = None, None
 
-            sid = getattr(self, "id", -1)
-            beta_scene = self.shifts
-            p = len(cheb_basis(0.0, 0.0, order))
-            bx = beta_scene[:p]
-            by = beta_scene[p : 2 * p]
-            phi0 = cheb_basis(0.0, 0.0, order)
-            mean_dx = float(phi0 @ bx)
-            mean_dy = float(phi0 @ by)
-            logger.info(
-                "[Scenes] Scene %s shift at x0,y0 ≈ (%.3f, %.3f) px", sid, mean_dx, mean_dy
-            )
+                sid = getattr(self, "id", -1)
+                beta_scene = self.shifts
+                p = len(cheb_basis(0.0, 0.0, order))
+                bx = beta_scene[:p]
+                by = beta_scene[p : 2 * p]
+                phi0 = cheb_basis(0.0, 0.0, order)
+                mean_dx = float(phi0 @ bx)
+                mean_dy = float(phi0 @ by)
+                logger.info(
+                    "[Scenes] Scene %s shift at x0,y0 ≈ (%.3f, %.3f) px", sid, mean_dx, mean_dy
+                )
 
-            logger.debug(
-                "[Scenes] center=(%.3f, %.3f) scale=(%.3f, %.3f) order=%d",
-                x0,
-                y0,
-                Sx,
-                Sy,
-                int(order),
-            )
-            logger.debug(f"[scenes] betas {self.id}:{self.shifts}")
+                logger.debug(
+                    "[Scenes] center=(%.3f, %.3f) scale=(%.3f, %.3f) order=%d",
+                    x0,
+                    y0,
+                    Sx,
+                    Sy,
+                    int(order),
+                )
+                logger.debug(f"[scenes] betas {self.id}:{self.shifts}")
+            else:
+                # TODO: consider merging this scene with a neighbor rather than skipping,
+                # since isolation filtering (unlike star filtering) can't be applied at
+                # merge time. Currently the star mask is applied during merge so this
+                # should only be reached in pathological all-blended scenes.
+                logger.warning(
+                    "[Scenes] Scene %s: no bright non-star isolated sources after isolation filter; "
+                    "astrometry skipped for this scene.",
+                    getattr(self, "id", -1),
+                )
 
         # store solution
         self.solution = sol

--- a/src/mophongo/scene_fitter.py
+++ b/src/mophongo/scene_fitter.py
@@ -153,11 +153,10 @@ class SceneFitter:
             Unwhitened fluxes, their 1σ errors, optional shift coefficients
             and the CG exit flag.
         """
-        # do regularization here
-        reg = getattr(config, "reg_astrom", 0)
-        if reg <= 0:
-            reg = 1e-6 * np.median(A.diagonal())
-        Areg = A + sp.eye(A.shape[0], format="csr") * reg
+        # Flux block: adaptive regularization relative to ATA scale (avoids biasing fluxes).
+        # reg_astrom is reserved for the shift block only.
+        flux_reg = 1e-6 * np.median(A.diagonal())
+        Areg = A + sp.eye(A.shape[0], format="csr") * flux_reg
 
         if AB is not None and BB is not None and bB is not None:
             diag_BB = BB.diagonal()
@@ -176,14 +175,14 @@ class SceneFitter:
 
     @staticmethod
     def solve_flux(
-        self, A: sp.spmatrix, b: np.ndarray, config: Optional[FitConfig] = None
+        A: sp.spmatrix, b: np.ndarray, config: Optional[FitConfig] = None
     ) -> tuple[np.ndarray, np.ndarray, dict]:
         """Solve ``A x = b`` for flux parameters using conjugate gradient."""
         cfg = config or FitConfig()
         A = A.tocsr()
 
         d = np.sqrt(np.maximum(A.diagonal(), 1e-12))
-        Dinv = diags(1.0 / d, 0, format="csr")
+        Dinv = sp.diags(1.0 / d, 0, format="csr")
         A_w = Dinv @ A @ Dinv
         b_w = Dinv @ b
 

--- a/src/mophongo/scene_fitter.py
+++ b/src/mophongo/scene_fitter.py
@@ -6,7 +6,7 @@ from typing import Optional, Tuple
 
 import numpy as np
 import scipy.sparse as sp
-from scipy.sparse.linalg import cg
+from scipy.sparse.linalg import cg, spsolve
 from types import SimpleNamespace
 
 logger = logging.getLogger(__name__)
@@ -186,7 +186,8 @@ class SceneFitter:
         A_w = Dinv @ A @ Dinv
         b_w = Dinv @ b
 
-        x_w, info = cg(A_w, b_w, **cfg.cg_kwargs)
+        x_w = spsolve(A_w, b_w)
+        info = 0
         x = x_w / d
         err = SceneFitter._flux_errors(A_w) / d
 
@@ -228,13 +229,8 @@ class SceneFitter:
         # --- joint solve in whitened variables
         K = sp.bmat([[A_w, AB_w], [AB_w.T, BB_wI]], format="csr")
         rhs = np.concatenate([b_w, bB_w])
-        sol, info = cg(
-            K,
-            rhs,
-            atol=0.0,
-            rtol=cfg.cg_kwargs.get("rtol", 1e-6),
-            maxiter=cfg.cg_kwargs.get("maxiter", 2000),
-        )
+        sol = spsolve(K, rhs)
+        info = 0
 
         na = A.shape[0]
         xw = sol[:na]

--- a/src/mophongo/templates.py
+++ b/src/mophongo/templates.py
@@ -418,6 +418,7 @@ class Template(Cutout2D):
 
         self.flag = 0  # bitwise flag for diagnostics
         self.flag |= Template.FLAG_VALID
+        self.is_star: bool = False  # set by pipeline from catalog flag_star
 
         # flux
         self.flux = 0.0

--- a/tests/test_astrometry.py
+++ b/tests/test_astrometry.py
@@ -7,6 +7,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "."))
 import numpy as np
 from numpy.polynomial.chebyshev import chebval
 from scipy.ndimage import shift as nd_shift
+from scipy.signal import fftconvolve
 
 from pathlib import Path
 from utils import make_simple_data
@@ -14,7 +15,49 @@ from mophongo.psf import PSF
 from mophongo.templates import Templates, Template
 from mophongo.fit import SparseFitter, FitConfig
 from mophongo.astrometry import AstroCorrect, AstroMap, cheb_basis
+from mophongo.scene import generate_scenes, make_scene_basis, assemble_scene_system_AB
+from mophongo.scene_fitter import SceneFitter, build_normal
 from utils import save_diagnostic_image
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers for the scene-solver astrometry tests
+# ---------------------------------------------------------------------------
+
+def _make_gaussian_psf_array(fwhm: float, size: int = 51) -> np.ndarray:
+    """Return a normalised 2-D Gaussian PSF of given FWHM (in pixels)."""
+    sig = fwhm / 2.355
+    y, x = np.mgrid[:size, :size] - size // 2
+    p = np.exp(-0.5 * (y ** 2 + x ** 2) / sig ** 2)
+    return p / p.sum()
+
+
+def _collect_to_shifts(scenes) -> tuple[np.ndarray, np.ndarray]:
+    """Return arrays of (dx, dy) stored in tmpl.to_shift across all scenes."""
+    dx_list, dy_list = [], []
+    for scene in scenes:
+        for tmpl in scene.templates:
+            ts = getattr(tmpl, "to_shift", None)
+            if ts is not None and (abs(ts[0]) > 1e-6 or abs(ts[1]) > 1e-6):
+                dx_list.append(float(ts[0]))
+                dy_list.append(float(ts[1]))
+    return np.array(dx_list), np.array(dy_list)
+
+
+def _run_scenes(templates, science, weight, cfg):
+    """Generate and solve all scenes; return the scene list."""
+    scenes, _ = generate_scenes(
+        templates,
+        science,
+        weight,
+        coupling_thresh=cfg.scene_coupling_thresh,
+        snr_thresh_astrom=cfg.snr_thresh_astrom,
+        minimum_bright=cfg.scene_minimum_bright,
+    )
+    for scene in scenes:
+        scene.set_band(science, weight, config=cfg)
+        scene.solve(config=cfg, apply_shifts=False)
+    return scenes
 
 
 def test_polynomial_astrometry_reduces_residual(tmp_path):
@@ -155,3 +198,273 @@ def test_cheb_basis_handles_domain_edges():
         for j in range(order + 1 - i):
             expected.append(tx[i] * ty[j])
     assert np.allclose(phi, expected)
+
+
+# ---------------------------------------------------------------------------
+# Test 1: end-to-end scene-solver shift recovery
+# ---------------------------------------------------------------------------
+
+def test_scene_solver_recovers_known_shift():
+    """Scene.solve() recovers a known global pixel shift applied to the science image.
+
+    A global (dx, dy) shift is applied to the low-resolution science image.  After
+    running generate_scenes + Scene.solve(apply_shifts=False) the per-template
+    to_shift values should have a mean close to the injected shift.
+    """
+    images, segmap, catalog, psfs, truth, wht = make_simple_data(
+        nsrc=15, size=151, peak_snr=20, seed=42
+    )
+
+    psf_hi = PSF.from_array(psfs[0])
+    psf_lo = PSF.from_array(psfs[1])
+    kernel = psf_hi.matching_kernel(psf_lo)
+
+    true_dx, true_dy = 0.6, -0.5
+    science = nd_shift(images[1], (true_dy, true_dx))
+    weight = wht[1]
+
+    positions = list(zip(catalog["x"], catalog["y"]))
+    tmpls = Templates.from_image(images[0], segmap, positions, kernel)
+
+    cfg = FitConfig(
+        fit_astrometry_joint=True,
+        snr_thresh_astrom=3.0,
+        scene_minimum_bright=2,
+        scene_coupling_thresh=0.01,
+        astrom_kwargs={"poly": {"order": 0}, "gp": {"length_scale": 400}},
+    )
+
+    scenes = _run_scenes(tmpls.templates, science, weight, cfg)
+    dx_arr, dy_arr = _collect_to_shifts(scenes)
+
+    print(f"\n[test1] True shift: dx={true_dx:.3f}, dy={true_dy:.3f} px")
+    print(f"[test1] Recovered (n={len(dx_arr)}): "
+          f"dx={dx_arr.mean():.3f}±{dx_arr.std():.3f}, "
+          f"dy={dy_arr.mean():.3f}±{dy_arr.std():.3f}")
+
+    assert len(dx_arr) > 0, "No shifts were recovered — check bright-source threshold"
+    assert abs(dx_arr.mean() - true_dx) < 0.3, (
+        f"dx recovered {dx_arr.mean():.3f}, expected {true_dx:.3f}"
+    )
+    assert abs(dy_arr.mean() - true_dy) < 0.3, (
+        f"dy recovered {dy_arr.mean():.3f}, expected {true_dy:.3f}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: shift recovery degrades with PSF width
+# ---------------------------------------------------------------------------
+
+def test_scene_shift_uncertainty_scales_with_psf_width():
+    """Shift recovery is more accurate with a narrower PSF (stronger gradient signal).
+
+    The same true shift is injected into two science images: one convolved with a
+    narrow PSF (F770W-like, FWHM≈6 px) and one with a wide PSF (F1800W-like,
+    FWHM≈15 px).  The narrow-PSF case should have a smaller shift-recovery error.
+    """
+    images, segmap, catalog, psfs, truth, wht = make_simple_data(
+        nsrc=20, size=151, peak_snr=50, seed=7
+    )
+    psf_hi = PSF.from_array(psfs[0])
+
+    narrow_arr = _make_gaussian_psf_array(fwhm=6.0, size=51)
+    wide_arr = _make_gaussian_psf_array(fwhm=15.0, size=51)
+
+    science_narrow = fftconvolve(truth, narrow_arr, mode="same")
+    science_wide = fftconvolve(truth, wide_arr, mode="same")
+
+    rng = np.random.default_rng(7)
+    noise_std = float(truth.max()) / 50.0
+    science_narrow += rng.normal(0, noise_std, science_narrow.shape)
+    science_wide += rng.normal(0, noise_std, science_wide.shape)
+    weight = np.ones_like(truth) / noise_std ** 2
+
+    true_dx, true_dy = 0.4, -0.35
+    science_narrow = nd_shift(science_narrow, (true_dy, true_dx))
+    science_wide = nd_shift(science_wide, (true_dy, true_dx))
+
+    cfg = FitConfig(
+        fit_astrometry_joint=True,
+        snr_thresh_astrom=3.0,
+        scene_minimum_bright=2,
+        scene_coupling_thresh=0.01,
+        astrom_kwargs={"poly": {"order": 0}, "gp": {"length_scale": 400}},
+    )
+
+    positions = list(zip(catalog["x"], catalog["y"]))
+
+    kernel_narrow = psf_hi.matching_kernel(PSF.from_array(narrow_arr))
+    tmpls_narrow = Templates.from_image(images[0], segmap, positions, kernel_narrow)
+    scenes_narrow = _run_scenes(tmpls_narrow.templates, science_narrow, weight, cfg)
+    dx_n, dy_n = _collect_to_shifts(scenes_narrow)
+
+    kernel_wide = psf_hi.matching_kernel(PSF.from_array(wide_arr))
+    tmpls_wide = Templates.from_image(images[0], segmap, positions, kernel_wide)
+    scenes_wide = _run_scenes(tmpls_wide.templates, science_wide, weight, cfg)
+    dx_w, dy_w = _collect_to_shifts(scenes_wide)
+
+    err_narrow = float(np.sqrt((dx_n.mean() - true_dx) ** 2 + (dy_n.mean() - true_dy) ** 2))
+    err_wide = float(np.sqrt((dx_w.mean() - true_dx) ** 2 + (dy_w.mean() - true_dy) ** 2))
+
+    print(f"\n[test2] True shift: dx={true_dx:.3f}, dy={true_dy:.3f} px")
+    print(f"[test2] Narrow PSF (FWHM=6): dx={dx_n.mean():.3f}, dy={dy_n.mean():.3f} — error={err_narrow:.4f} px")
+    print(f"[test2] Wide PSF  (FWHM=15): dx={dx_w.mean():.3f}, dy={dy_w.mean():.3f} — error={err_wide:.4f} px")
+
+    assert len(dx_n) > 0 and len(dx_w) > 0, "No shifts recovered in one of the PSF cases"
+    assert err_narrow < err_wide, (
+        f"Expected narrow PSF error ({err_narrow:.4f}) < wide PSF error ({err_wide:.4f})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: shift estimate scales as 1/alpha0 — biased flux biases shifts
+# ---------------------------------------------------------------------------
+
+def test_scene_shift_depends_on_alpha0_scale():
+    """Shift estimate ∝ 1/alpha0_scale: underestimated fluxes inflate shifts.
+
+    The shift signal is bB ∝ alpha0 × image_gradient and the gradient information
+    matrix BB ∝ alpha0².  Their ratio shift ≈ bB/BB ∝ 1/alpha0.  When alpha0 is
+    scaled by factor k, the recovered shift should scale by 1/k.  This confirms
+    that the old reg_astrom flux bias (alpha0 ≈ 0.57×) was inflating shifts by ~1.75×.
+    """
+    images, segmap, catalog, psfs, truth, wht = make_simple_data(
+        nsrc=10, size=101, peak_snr=30, seed=55
+    )
+
+    psf_hi = PSF.from_array(psfs[0])
+    psf_lo = PSF.from_array(psfs[1])
+    kernel = psf_hi.matching_kernel(psf_lo)
+
+    true_dx, true_dy = 0.5, 0.4
+    science = nd_shift(images[1], (true_dy, true_dx))
+    weight = wht[1]
+
+    positions = list(zip(catalog["x"], catalog["y"]))
+    tmpls = Templates.from_image(images[0], segmap, positions, kernel)
+
+    cfg = FitConfig(
+        fit_astrometry_joint=True,
+        snr_thresh_astrom=0.0,
+        scene_minimum_bright=1,
+        scene_coupling_thresh=0.005,
+        astrom_kwargs={"poly": {"order": 0}, "gp": {"length_scale": 400}},
+    )
+
+    # Build a single scene from all templates so the has_shift >= 2 requirement is met.
+    # This keeps the test focused on the alpha0 → shift dependency, not scene partitioning.
+    from mophongo.scene import Scene
+    all_templates = list(tmpls.templates)
+    A, b, _ = build_normal(all_templates, science, weight)
+    scene = Scene(
+        id=1,
+        templates=all_templates,
+        fitter=SceneFitter(),
+        image=science,
+        weights=weight,
+        config=cfg,
+    )
+    scene.A = A
+    scene.b = b
+    d = A.diagonal()
+    alpha0_true = np.divide(b, d, out=np.zeros_like(b), where=d > 0)
+    bright_mask = np.ones(len(scene.templates), dtype=bool)
+    basis, (x0, y0), (Sx, Sy) = make_scene_basis(scene.templates, bright_mask, order=0)
+
+    recovered = {}
+    for scale in (0.5, 1.0, 2.0):
+        alpha0 = alpha0_true * scale
+        AB, BB, bB = assemble_scene_system_AB(
+            scene.templates, science, weight, basis,
+            alpha0=alpha0, order=0, include_y=True, ab_from_bright_only=False,
+        )
+        sol = SceneFitter.solve(A, b, AB=AB, BB=BB, bB=bB, config=cfg)
+        if sol.shifts is not None and len(sol.shifts) >= 2:
+            # order=0: shifts = [beta_x, beta_y], each length p=1
+            recovered[scale] = (float(sol.shifts[0]), float(sol.shifts[1]))
+
+    print(f"\n[test3] True shift: dx={true_dx:.3f}, dy={true_dy:.3f} px")
+    for scale, (rdx, rdy) in recovered.items():
+        print(f"[test3] alpha0 scale={scale:.1f}: dx={rdx:.4f}, dy={rdy:.4f}")
+
+    assert set(recovered) >= {0.5, 1.0, 2.0}, "Not all alpha0 scales produced shift estimates"
+
+    dx_half, _ = recovered[0.5]
+    dx_one, _ = recovered[1.0]
+    dx_two, _ = recovered[2.0]
+
+    # shift ∝ 1/scale: half alpha0 → double shift, double alpha0 → half shift
+    ratio_half = dx_half / dx_one if abs(dx_one) > 1e-6 else float("nan")
+    ratio_two = dx_two / dx_one if abs(dx_one) > 1e-6 else float("nan")
+    print(f"[test3] dx(0.5×)/dx(1×) = {ratio_half:.3f}  (expected ~2.0)")
+    print(f"[test3] dx(2×) /dx(1×) = {ratio_two:.3f}  (expected ~0.5)")
+    assert abs(ratio_half - 2.0) < 0.5, f"Expected ratio ≈ 2, got {ratio_half:.3f}"
+    assert abs(ratio_two - 0.5) < 0.25, f"Expected ratio ≈ 0.5, got {ratio_two:.3f}"
+
+    # The unbiased (scale=1.0) estimate should match the true shift
+    assert abs(dx_one - true_dx) < 0.3, f"Unbiased dx={dx_one:.4f}, true={true_dx}"
+    assert abs(recovered[1.0][1] - true_dy) < 0.3, (
+        f"Unbiased dy={recovered[1.0][1]:.4f}, true={true_dy}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: iterative shift application converges (residual shift shrinks)
+# ---------------------------------------------------------------------------
+
+def test_scene_shift_iteration_converges():
+    """Residual shifts in the second iteration are smaller than in the first.
+
+    After applying the first-pass shifts to the templates, the second pass should
+    see only small residual offsets.  If the solver is diverging, second-pass
+    |to_shift| would be larger than or equal to the first pass — a red flag for
+    the iterative scheme used by fit_astrometry_niter=2.
+    """
+    images, segmap, catalog, psfs, truth, wht = make_simple_data(
+        nsrc=15, size=151, peak_snr=20, seed=77
+    )
+
+    psf_hi = PSF.from_array(psfs[0])
+    psf_lo = PSF.from_array(psfs[1])
+    kernel = psf_hi.matching_kernel(psf_lo)
+
+    true_dx, true_dy = 0.5, -0.4
+    science = nd_shift(images[1], (true_dy, true_dx))
+    weight = wht[1]
+
+    positions = list(zip(catalog["x"], catalog["y"]))
+    tmpls = Templates.from_image(images[0], segmap, positions, kernel)
+
+    cfg = FitConfig(
+        fit_astrometry_joint=True,
+        snr_thresh_astrom=3.0,
+        scene_minimum_bright=2,
+        scene_coupling_thresh=0.01,
+        astrom_kwargs={"poly": {"order": 0}, "gp": {"length_scale": 400}},
+    )
+
+    # --- Pass 1: solve, record to_shift, then apply ---
+    scenes1 = _run_scenes(tmpls.templates, science, weight, cfg)
+    dx1, dy1 = _collect_to_shifts(scenes1)
+    mag1 = float(np.sqrt(dx1 ** 2 + dy1 ** 2).mean()) if len(dx1) > 0 else 0.0
+
+    # Apply the first-pass shifts to the templates in-place
+    all_templates = [t for s in scenes1 for t in s.templates]
+    Templates.apply_template_shifts(all_templates)
+
+    # --- Pass 2: rebuild normal equations from shifted templates, solve again ---
+    scenes2 = _run_scenes(tmpls.templates, science, weight, cfg)
+    dx2, dy2 = _collect_to_shifts(scenes2)
+    mag2 = float(np.sqrt(dx2 ** 2 + dy2 ** 2).mean()) if len(dx2) > 0 else 0.0
+
+    print(f"\n[test4] True shift: dx={true_dx:.3f}, dy={true_dy:.3f} px")
+    print(f"[test4] Pass 1: mean |shift| = {mag1:.4f} px  "
+          f"(dx={dx1.mean():.3f}, dy={dy1.mean():.3f})")
+    print(f"[test4] Pass 2: mean |shift| = {mag2:.4f} px  "
+          f"(dx={dx2.mean():.3f}, dy={dy2.mean():.3f})")
+
+    assert len(dx1) > 0, "Pass 1 produced no shifts"
+    assert mag1 > 0.05, f"Pass-1 shift too small ({mag1:.4f}), test may not be exercising the solver"
+    assert mag2 < mag1, (
+        f"Pass-2 residual shift ({mag2:.4f} px) should be smaller than pass-1 ({mag1:.4f} px)"
+    )


### PR DESCRIPTION
- **fix flux bias at long wavelengths**: reg_astrom, a fixed constant, was being added directly to the flux block diagonal. As wavelength increases, typical fluxes decrease, and that constant started to meaningfully contribute & significantly suppress flux estimates. Moved reg_astrom to the astrometric shift block only; flux block now uses adaptive regularization 1e-6 * median(ATA) so it scales with source flux and doesn't dominate. Also fixed two latent bugs in solve_flux: stray self argument and bare diags() call (should be sp.diags).
- **improved astrometric source selection**: exclude stars and highly-blended sources from shift estimation, as they were poorly centroided especially at long wavelength and pulling the astrometry around. Stars id'd from NIRCam catalog. Highly-blended sources id'd by checking the percentage of the source's flux that is contributed by itself vs blended neighbors. "astrom_isolation_thresh" now a settable parameter in the pipeline; value of 0.7 (source must have <30% of its flux contributed by neighbors) seems to work well from initial runs
- **updated CG to spsolve**: scenes at longer wavelength are more ill-conditioned and CG was not converging even when upping iterations. Since scenes are small, switched to exact spsolve which does not seem to significantly increase runtime but does make cleaner F1800W residuals.
- **scene_max_merge_radius documentation**: this existed but wasn't ever declared in FitConfig so wasn't easily editable; can now change in different pipeline runs. I was fiddling with this for scene size, but ended up tuning decent values for scene_coupling_thresh instead to get ~150-200 scenes per band for full UDS which seems to generally produce nice residuals.
