### PR TITLE
Config generator: scene_max_size 1000, matching the raised default

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -103,13 +103,12 @@ This file tracks future desired features, checks, and investigations.
   (2026-08-12), which already makes bands 2..N of a campaign reload band
   1's repair; the footprint cut makes band 1 itself cheap on small
   patches.
-- [ ] `make_minerva_configs.py` must write `wht_hi`: the scheme-based
-  template builds require the detection weight map, and the automatic
-  `_sci`->`_wht` substitution cannot see through the `_bkgsub` suffix of the
-  MINERVA `sci_hi` names. The v2/v3 verification driver injects the derived
-  `..._drc_wht.fits` path per config as a stopgap
-  (`examples/minerva/run_verification_v2.py::prep_configs`); fold that into
-  the generator and regenerate the 17 configs.
+- [x] `make_minerva_configs.py` writes `wht_hi` (verified 2026-08-13): the
+  scheme-based template builds require the detection weight map, and the
+  automatic `_sci`->`_wht` substitution cannot see through the `_bkgsub`
+  suffix of the MINERVA `sci_hi` names. The generator emits it directly and
+  all 53 CANFAR configs on disk carry it, so the verification driver's
+  per-config stopgap is no longer load-bearing.
 - [ ] F1280W scene 1: convolved templates lose their aperture flux. In the
   v7 run 612 of the 618 sources in scene 1 (a compact block at x 10982-12254,
   y 3712-5157) have `tot_stamp_1` ~ 7.96, i.e. only 12.6% of the convolved

--- a/examples/make_minerva_configs.py
+++ b/examples/make_minerva_configs.py
@@ -311,8 +311,12 @@ def band_configs(rel: Release) -> list[dict]:
                     "scene_minimum_bright": 5,
                     # larger scenes before the local threshold bisection kicks
                     # in, and no long-range gluing of underfilled scenes
-                    # (radius in 40 mas reference pixels; 1000 px = 40")
-                    "scene_max_size": 800,
+                    # (radius in 40 mas reference pixels; 1000 px = 40").
+                    # The cap now also binds through merge_small_scenes, and a
+                    # scene costs quadratically in its size (the joint solve's
+                    # Schur complement is dense), so it is a real ceiling
+                    # rather than advice; matches FitConfig's default.
+                    "scene_max_size": 1000,
                     "scene_max_merge_radius": 1000,
                     "aperture_diam": APERTURE_DIAM_ARCSEC[band],
                 },


### PR DESCRIPTION
Every generated config pinned `scene_max_size: 800`, so raising `FitConfig`'s default to 1000 had no effect on any MINERVA or CANFAR run.

Four of the five keys in the generated `fit` block restate `FitConfig` defaults exactly (`fit_astrometry_joint`, `scene_minimum_bright`, `scene_max_merge_radius`, and now `scene_max_size`); only `aperture_diam` is genuinely per-run.

The cap matters more than it used to: it binds through `merge_small_scenes` now rather than being undone by it (#102), and a scene costs quadratically in its size because the joint flux+shift solve forms a dense Schur complement.

**Verification.** All 53 CANFAR and 17 MINERVA configs on disk validate against the current `RunConfig`/`FitConfig` — 0 failures before and after. They were patched in place by textual substitution so the `#` comment headers and formatting survive; the diff on each is the single cap line. 17 of the CANFAR configs are full-field (`trial: null`) — the runs that were hitting the memory ceiling. Those files are gitignored, so only the generator is tracked here.

Also closes the `wht_hi` TODO: the generator emits it directly and all 53 CANFAR configs carry it.

https://claude.ai/code/session_01Ut5iQHWqMr8TVACX28yvJj