### PR TITLE
Scene-by-scene astrometric loop; silence HIERARCH card warnings

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -93,6 +93,58 @@ This file records completed implementations, validation runs, and the current wo
   which is the configuration v8 actually validated.
   Note the stamp-footprint fix is what makes even this feasible: at the old
   402^2 support, COSMOS's convolved templates alone would need 98 GB.
+- [x] Astrometric loop inverted to scene -> pass (2026-08-13). `run()` ran
+  `for pass in 1..niter: for scene in pending:`, synchronising every scene at
+  each pass and carrying a `pending` list so a converged scene dropped out. It
+  now refines one scene to convergence -- its passes, its convergence test, and
+  the flux-only pass that closes it out -- before starting the next. Scenes are
+  independent *across* passes and not only within one: `solve()` reads the
+  scene's own templates and read-only slices of the shared image and weights,
+  and writes only to itself and to those templates, so nothing couples one
+  scene's iterate to another's. What goes is the barrier, which is what stops a
+  scene from being handed to a worker process (`docs/SCALING_FIXED_MEMORY.md`).
+  Results are unchanged, checked rather than argued: the same fixture run
+  through HEAD and through the working tree gives bit-identical fluxes, errors,
+  per-scene shift coefficients, per-template accumulated shifts, pass counts,
+  convergence flags and residual, in three configurations -- 3 scenes
+  converging uniformly, 10 scenes at a tolerance that makes the pass count vary
+  between scenes (median 4, max 5, which is where the two orderings genuinely
+  interleave differently), and the flux-only path (`fit_astrometry_niter=0`,
+  one solve per scene, no closing re-solve).
+  Behaviour preserved in the corners: a scene whose shift block was never built
+  (flux-only run, or fewer than two bright anchors) keeps `astrom_converged`
+  None and stops after one pass, exactly as dropping out of `pending` did.
+  Logging changes shape, since the per-pass lines no longer mean anything: the
+  loop now logs its budget up front, each scene at DEBUG, and one summary line
+  (scenes converged, median and maximum passes run). The warning naming the
+  worst non-converged scenes is unchanged.
+  `tests/test_pipeline.py::test_scene_results_do_not_depend_on_scene_order`
+  pins the invariant by handing the loop its scenes back to front and requiring
+  identical fluxes, errors, shifts, pass counts and residual.
+- [x] HIERARCH card warnings silenced outside `log_run` (2026-08-13). Long
+  keywords carried on the input catalog's `Table.meta` -- `PHOT_UNIT`,
+  `WEBBSTARFILT`, `HSTSTARFILT`, `APER_DIAM`, `SHRINK_FACTOR` -- round-trip
+  into the fit table's header as HIERARCH cards by design, and astropy warns
+  once per card, twice per card once its own warning logging has a handler.
+  `log_run` already filtered them, but at the time it only wrapped `run_all`,
+  and the steps are normally run one at a time (`python -m mophongo.pipeline
+  config.json psfs kernels load fit outputs`, which is what the campaign and
+  every validation run use), so that path never entered the block. `01dd473`
+  has since put every CLI invocation inside `log_run`, which closes the same
+  hole from the other end; a notebook or script driving `Pipeline` directly
+  still does not go through it, and the filter belongs with the writes that
+  provoke the warning in any case. It is now a module
+  helper applied at the write path itself -- `write_outputs`, around the
+  residual, fit table and template table -- with `log_run` calling the same
+  helper instead of repeating the filter inline. `write_stamps` needs no filter
+  since `8ca21f5` moved it to HDF5.
+  It is scoped to the write: a caller's own filters are
+  untouched afterwards. Nothing about what is written changes; the keywords
+  still land as HIERARCH cards.
+  `tests/test_pipeline.py::test_write_outputs_silences_hierarch_card_warnings`
+  checks all three: no `VerifyWarning` escapes `write_outputs`, the keywords
+  are readable back off the fit table, and a bare header assignment still
+  warns afterwards.
 - [x] Verification v9: all four UDS MIRI bands at r < 3' (2026-08-13,
   commit `ff1447a`, `examples/minerva/verification/v9/`). Same code and PSF
   grids as v8's F770W re-run, applied to every band, at the trial radius the

--- a/TODO.md
+++ b/TODO.md
@@ -725,6 +725,48 @@ This file tracks future desired features, checks, and investigations.
     narrowing the file wholesale. Worth measuring the extraction peak first:
     the win is transient working set, not resident, so it may not move the
     ceiling at all.
+- [ ] Fixed memory budget for arbitrarily large fields, and parallel scene
+  solves. Design note: `docs/SCALING_FIXED_MEMORY.md` (2026-08-13). Only the
+  loop inversion below has been built. Peak today is 46.5 GB on a full UDS field and
+  ~72 GB on COSMOS, both linear in field area; the proposal is tiled template
+  build + global scene partition on `ATA` alone + scene-streaming solve, which
+  bounds the peak by the largest scene rather than by the image (~2-5 GB at
+  eight workers). Threads are measured to be the wrong tool for the scene loop
+  (`build_normal`-shaped work runs 0.47-0.66x with 4-8 threads); processes over
+  memory-mapped inputs are. Prerequisites, each worth doing alone and each
+  blocking part of the above:
+  - [x] Astrometric loop inverted to scene -> pass (2026-08-13): one scene is
+    now refined to convergence before the next starts, so a scene is a
+    self-contained unit of work with no barrier between scenes. Bit-identical
+    against HEAD in three configurations; see STATUS.md.
+  - [ ] Chunk `assemble_scene_system_AB` over row bands. `Bq`/`Bl` (0.61 GB
+    worst case) and the `Bq[k] * wbuf` temporaries are the only per-scene term
+    that scales with spatial extent, so they multiply by the worker count.
+    Blocks parallelism.
+  - [ ] `Scene.model_image` allocates float64 over the scene bbox (150 MB for
+    the widest); float32, or accumulate straight into the residual.
+  - [ ] Bound scene *extent*, not only `scene_max_size`: the widest buffer came
+    from a 25-template scene whose anchors spanned 18.8 Mpx.
+  - [ ] `write_stamps` still builds the complete `vla` list before writing --
+    a full extra copy of every stamp (12 GB full-field) at the end of the run.
+    `8ca21f5` moved the file to HDF5, so the per-source offsets a scene-local
+    read needs already exist and only the incremental *write* is left: append
+    each band's flat buffer as tiles complete rather than concatenating at the
+    end. That turns the stamps file into working storage for the streaming
+    solve, not just an output.
+  - [ ] Upsampled band on demand instead of materialised: `_upsample_boxed`
+    holds 7 GB for the sci/ivar pair and is where COSMOS OOMs. The array is a
+    pure function of the lo-res pixels and is only ever read as
+    `image[slices_original]`.
+  - [ ] Residual as a `np.memmap` over the output file rather than 3.5 GB of
+    dirty anonymous pages.
+  - [ ] Timers inside `Scene.solve`. `56530f2` added the per-section wall-time
+    breakdown for `run()`, which covers the outer split (templates, convolve,
+    generate scenes, astrometry passes, final flux solve, residual). Still
+    missing is the split *within* a scene solve -- `build_normal` against
+    `assemble_scene_system_AB` against the factorisation -- which is what says
+    how much of the scene loop is GIL-bound assembly and therefore what a
+    worker pool would actually buy. Do this before building any of the above.
 - [ ] strong residuals
   - [ ] handle saturated stars in 444 -> catalog pre pass detection
   - [ ] fit as PSF both 444, 770, fit for centroid, mask center

--- a/docs/SCALING_FIXED_MEMORY.md
+++ b/docs/SCALING_FIXED_MEMORY.md
@@ -1,0 +1,343 @@
+# Scaling to arbitrarily large images at a fixed memory budget
+
+Research note, 2026-08-13. No code changes. Written against `9fc52a6`.
+
+The question is whether mophongo can be made to run a field of any size inside
+a memory budget fixed in advance — the property that lets SExtractor process a
+mosaic it could never hold — and whether the scene solves, currently a
+sequential loop, can be run in parallel without giving that property back.
+
+The short answer is yes, and the reason is structural rather than incidental:
+the fit is already exactly block-diagonal over scenes, and the scene partition
+is a function of the sparse normal matrix alone, not of the pixels. That
+separation is what a fixed budget needs. What follows is the accounting, the
+proposed decomposition, and the measurements behind the parallelism
+recommendation.
+
+## 1. What sets the peak today
+
+Measured, from the full-field UDS F770W run recorded in `STATUS.md`
+(138,610 templates, 591 scenes, `trial: null`, repair reloaded from cache):
+87 minutes, **46.5 GB peak physical footprint**, 32.2 GB max RSS. Checkpoints
+`(start)` 10.4 GB, `(templates)` 28.2, weight release 24.7, `(convolved)` 27.7,
+`(end)` 11.0. COSMOS (151,778 templates) needs about 72 GB and dies at 48 right
+at the upsample; EGS extrapolates to 110–130 GB. CANFAR reports
+`memoryGB.defaultLimit = 32`, and jobs asking 48 GB and above have queued for
+hours.
+
+The peak decomposes into two families, both linear in field area.
+
+**Full-grid rasters.** The detection grid is 34560 × 25344 = 876 Mpx, so
+3.50 GB per float32 plane and the same for the int32 segmentation map. A run
+holds, concurrently: detection science, segmentation map, the band science
+image upsampled onto the reference grid, its inverse variance, and the
+residual. The detection-band inverse variance is a sixth, released after
+template construction (`pipeline.py:3653`). Call it 17–21 GB.
+
+**Template stamps.** 138,610 stamps with a 100 px floor and a mean side of
+104 px is 6.0 GB for one complete set. Up to three sets are live at once: the
+hi-res set on `self.tmpls`, the convolved set returned by
+`_convolved_templates` (`convolve_templates(inplace=False)` deep-copies each
+stamp, `templates.py:1960`, and the hi-res set stays alive because
+`write_stamps` reads it at `pipeline.py:2254`), and `_data_unshifted`, the
+pre-shift pixels each shifted template retains so successive astrometric passes
+resample the original rather than compounding the cubic smoothing
+(`templates.py:1110`). That is 12–18 GB.
+
+Two smaller terms spike rather than persist, and both scale with a scene's
+*spatial extent* rather than its template count, so `scene_max_size` does not
+bound either: `assemble_scene_system_AB` allocates `nB` float64 planes over the
+bright anchors' bounding box, doubled when the leverage cap clips
+(`scene.py:618`) — 0.61 GB for the widest full-field scene at `nB = 2`, and the
+`Bq[k] * wbuf` temporaries in the `BB` loop add another 150 MB each; and
+`Scene.model_image` builds a float64 plane over the full scene bbox
+(`scene.py:1533`). The widest such buffer came from a 25-template scene whose
+14 anchors spanned 18.8 Mpx.
+
+Everything in the first family is read-only or write-once. Everything in the
+second is needed only while the scene that owns it is being solved. That is the
+whole opportunity.
+
+## 2. The property that makes a fixed budget possible
+
+Three facts, all already true of the code:
+
+1. **The solve is exactly block-diagonal over scenes.** `generate_scenes`
+   partitions templates by normal-equation coupling and each `Scene.solve`
+   reads only its own templates and slices of the shared image and weights
+   (`scene.py:961`). Nothing in a scene solve touches another scene's state.
+   The block structure is exact by construction, not an approximation: the
+   partition is what defines which couplings are carried.
+
+2. **The partition depends on `ATA` alone, not on pixels.**
+   `build_scene_tree_from_normal` and `merge_small_scenes` take the sparse
+   normal matrix, the right-hand side, template positions and a bright mask.
+   For 138k templates `ATA` has of order 5 M stored values — about 60 MB in
+   CSR, against 6 GB of the stamps that produced it.
+
+3. **`ATA` is an assembly of local integrals.** Entry `(i, j)` is
+   `sum(T_i · T_j · w)` over the intersection of two stamps. Every contributing
+   pixel lies inside the union of two bounding boxes, and a stamp is ~104 px on
+   a side.
+
+Together these say: the coupling graph can be assembled a tile at a time and
+still be bit-exact, the partition then costs nothing, and the solve can be
+streamed one block at a time. Peak memory is then set by the largest *block*,
+not by the image.
+
+That is the honest analogue of SExtractor's rolling row buffer. It is not the
+same mechanism — SExtractor can stream in `y` because detection, deblending
+and measurement are all local in `y`, whereas a mophongo scene can be six
+arcminutes wide and its astrometric shift field is fitted across the whole of
+it — but it delivers the same property.
+
+## 3. Proposed decomposition
+
+### Phase 1 — tiled template build and graph assembly
+
+Iterate over tiles of the detection grid with a halo of one maximum stamp
+side. Per tile: read detection science, segmentation map and detection inverse
+variance for tile + halo; extract, extend, convolve and project the templates
+whose *centre* falls in the tile core; append the stamps to an on-disk store;
+accumulate COO contributions to `ATA` and `ATb`.
+
+Reading a box is already implemented — `_read_image(path, box)` uses
+`hdu.section` and places the result into a full-shape array so every pixel
+coordinate, slice and WCS keeps its full-frame meaning (`pipeline.py:278`).
+The trial-patch machinery (`trial_box_hi` / `trial_box_lo`) already scopes the
+whole-array passes the same way.
+
+Exactness of the tiled assembly: with a halo of at least one stamp side, any
+pair whose stamps intersect has both stamps present in at least one tile.
+Attribute each pair to the single tile whose core contains the centroid of the
+pair's intersection, and every off-diagonal is accumulated exactly once. The
+resulting matrix is identical to the global build, not an approximation of it.
+
+This also disposes of a known defect: `build_normal` assembles a
+138k × 138k `lil_matrix` entry by entry from Python (`scene_fitter.py:64`,
+already in `TODO.md`) — about 400 MB of Python objects. Per-tile COO
+accumulation into `int32`/`float64` arrays replaces it, and the tiles are
+independent, so this phase parallelises trivially.
+
+### Phase 2 — global partition
+
+`build_scene_tree_from_normal` then `merge_small_scenes` on `ATA`/`ATb` alone.
+No pixels, no stamps. A few hundred MB, seconds of runtime, and the partition
+is identical to today's. Keeping this global is what preserves equivalence with
+a full-field run — the reason the cheap alternative in §7 does not.
+
+### Phase 3 — scene-streaming solve
+
+Process scenes one at a time (or `W` at a time, §6), batched in spatial order
+so the page cache stays warm. Per scene: load its stamps from the store, slice
+the band science and inverse variance over its bbox, run the astrometric
+iteration to convergence and the final flux-only re-solve, add its model into
+the output residual, write its catalog rows, release the stamps.
+
+One inversion was needed here, and it has since landed. The loop used to be
+`for pass in 1..niter: for scene in pending:`, a barrier per pass for no
+reason — scenes are independent *across* passes as well as within one. The unit
+of work is now "one scene, run to convergence, including its final flux-only
+pass", which removes every barrier and bounds the live template set to one
+scene. Results are bit-identical; see `STATUS.md` for the equivalence check and
+`tests/test_pipeline.py::test_scene_results_do_not_depend_on_scene_order` for
+the invariant it rests on.
+
+### The stamp store
+
+A store already exists, and `8ca21f5` has since put it in the right shape:
+`write_stamps` writes one flat float32 buffer per band into HDF5 with a
+per-source offset table, and `read_stamps` / `_templates_from_stamps` restore
+it. The offsets are exactly what a scene-local read needs, so one change is
+left to make it working storage rather than an output — write incrementally as
+tiles complete, instead of concatenating the whole buffer in memory first
+(today that is a full extra copy of every stamp, 12 GB at full-field scale, at
+the very end of the run).
+
+## 4. Budget arithmetic
+
+Phase 1, per worker, 4096 px tiles: three raster planes at 67 MB each is
+0.20 GB; templates whose centres fall in the tile are ~2660 at full-field
+density, 0.12 GB hi-res plus 0.12 GB convolved; COO accumulators grow to about
+120 MB shared. Roughly **0.5 GB per worker**, and 0.15 GB at 2048 px tiles.
+
+Phase 2: `ATA` in CSR ~60 MB, labels and catalog ~100 MB, working copies during
+the merge a few hundred MB. Under **1 GB**, single-threaded.
+
+Phase 3, per worker: one scene's stamps at `scene_max_size = 1000` is 43 MB,
+doubled by `_data_unshifted` to 86 MB; the dense Schur complement is
+1000² float64 = 8 MB; the band pixels come from a memory map (§5) and cost page
+cache, which is reclaimable; `AB`/`BB` accumulated over row bands (§8) is a few
+MB. Roughly **150 MB per worker** — against ~700 MB if the `Bq`/`Bl` buffers
+are left whole-scene.
+
+With a 1 GB floor for interpreter, libraries and PSF maps, eight workers land
+near **2–5 GB total**, independent of field size. The 8 GB CANFAR jobs that
+schedule instantly become sufficient, and the tile size and worker count are
+the two knobs that trade runtime for the budget.
+
+The cost is disk: two stamp sets (~12 GB) plus the residual (3.5 GB) as
+scratch, and one extra full read of each input.
+
+## 5. Raster discipline: memory-map what is read-only
+
+Independently of the phase structure, most of the 17–21 GB of rasters need not
+be anonymous memory at all.
+
+`_read_image` currently reads into a full-shape anonymous array. Pages never
+touched are never faulted in, which is what makes a trial patch cheap, but a
+tile *sequence* eventually touches all of them, and dirty anonymous pages
+cannot be evicted. Mapping the file instead (`np.memmap`, or `fits.open(...,
+memmap=True)` kept open) makes those pages clean page cache: the kernel
+reclaims them under pressure, and forked workers share them. `as_label_array`
+already returns a memmap view when the segmentation map ships as an integer
+type — UDS and EGS do; COSMOS ships float64 and needs a one-time conversion to
+an int32 file, which the existing banded validation path can write streaming.
+
+Two arrays need more than a change of allocator:
+
+**The upsampled band.** `_upsample_boxed` materialises the band science and
+inverse variance full-size on the reference grid — 7 GB for the pair, and the
+exact point at which COSMOS died. But the upsampled image is a pure function
+of the low-resolution pixels (block replicate, divide by `k²`; weights copied
+and multiplied by `k²`). A scene solve only ever indexes it as
+`image[slices_original]`. A thin object exposing `__getitem__` for 2-D slices
+and upsampling the requested box on demand removes the array entirely, at the
+cost of re-replicating a few hundred pixels per access. This is worth doing on
+its own merits: it is the difference between COSMOS running and not.
+
+**The residual.** `res` is allocated full-size, accumulated into, then
+subtracted in place (`pipeline.py:3828`). Making it a `np.memmap` over the
+output file's data section turns 3.5 GB of dirty anonymous memory into
+file-backed pages that flush as they go, and `fits.writeto` at the end becomes
+a header write.
+
+## 6. Parallelising the scene solves
+
+### Threads are the wrong tool — measured
+
+Two microbenchmarks on this machine (10 cores, Accelerate BLAS, BLAS pinned to
+one thread), in `scratch`-style throwaway scripts:
+
+| work | K = 4 | K = 8 |
+|---|---|---|
+| `spsolve` + dense `inv` of the Schur complement | **2.14×** | **2.23×** |
+| `build_normal`-shaped: Python loop over stamps, small `np.sum` per pair | **0.66×** | **0.47×** |
+
+The linear-algebra tail does release the GIL and scales, sub-linearly. The
+assembly does not: threading it makes it *slower*, because the per-operation
+Python and GIL overhead of thousands of small `np.sum` calls dominates and the
+threads contend. Since `Scene.solve` rebuilds `A`/`b` on every astrometric pass
+(`scene.py:1000`, after `self.A, self.b = None, None` at line 1072), assembly
+is not a small share of the scene loop. Threads are out.
+
+For reference on the same synthetic 1000-template scene: `spsolve` 2.5 ms,
+`splu` 2.4 ms, the sparse `_flux_errors` path (`n` unit back-solves) 45 ms, the
+dense path 18 ms — consistent with the dispatch fix already recorded in
+`STATUS.md`.
+
+### Processes, over memory-mapped inputs
+
+Each worker takes a scene id, maps the same input files, reads that scene's
+stamps from the store, and returns fluxes, errors, shift coefficients,
+accumulated per-template shifts, and its model patch with its bbox. The parent
+adds model patches into the residual — scene bounding boxes overlap even though
+their template sets do not, so accumulation must not race, and having the
+parent own that write is simpler than locking.
+
+Memory maps matter more than they look here. On Linux, `fork` gives
+copy-on-write and workers see the parent's arrays for free; on macOS the
+default start method is `spawn` and they do not. Mapping files makes the design
+identical on both, and makes the page cache shared rather than duplicated.
+
+Set `OMP_NUM_THREADS=1` in workers, or `W` workers each spawning a BLAS pool
+will oversubscribe.
+
+Schedule largest scene first. Scene sizes span 2 to ~1000 with a median near
+200, and cost is superlinear in size (the joint path forms a dense `n × n`
+Schur complement), so a small-first order strands the largest scene in the
+tail.
+
+`joblib` is already a dependency, and `PSFRegionMap` was made picklable in an
+earlier pass explicitly for user-side multiprocessing (`TODO.md`), so the
+plumbing is mostly in place.
+
+### Memory impact of parallelism
+
+`W` workers multiply the per-scene peak, so **the `Bq`/`Bl` buffers must be
+bounded before parallelism is turned on**. At 0.61 GB worst case, eight workers
+can spike 4.9 GB on top of everything else — enough to defeat the budget the
+rest of this note buys. Section 8 lists the fix; it is small and independent.
+
+### Expected return
+
+Unquantified, and it should be measured before it is promised. 591 scenes over
+8 workers is plenty of parallelism, but the 87-minute full-field run predates
+any timing instrumentation. `56530f2` has since added the outer breakdown —
+template build, convolution, scene generation, the astrometry passes, the final
+flux solve, the residual — which is half of what is needed. The other half is
+the split *within* a scene solve, across the three calls `build_normal`,
+`assemble_scene_system_AB` and the factorisation, since that is what says how
+much of the loop is the GIL-bound assembly measured below. Re-run a full field
+with both and read the answer off the log before building any of this.
+
+## 7. The cheap alternative, and why it is not equivalent
+
+Everything above could be skipped by tiling the *whole* pipeline: run the
+existing code on each tile with a halo, keep the sources whose centres fall in
+the core, and concatenate the catalogs. The `trial` geometry already does
+exactly this for one patch, so it is nearly free.
+
+It is not equivalent, for two reasons the code already documents. Background
+and inverse-variance calibration is per-box: `load_data` warns that a trial
+patch's fluxes and errors will *not* match a full-field run, because the
+robust baseline in `get_bg_and_ivar` is measured over the box. And a scene
+straddling a tile boundary is truncated in both tiles, so its astrometric shift
+field — fitted jointly across all the scene's anchors — is fitted on a
+fragment. Fluxes would differ by more than the coupling threshold bounds.
+
+Two mitigations make it defensible if the exact route is too much work:
+calibrate background and weights once, globally (that pass is already banded
+and streaming — `_valid_block_means`, `catalog.py:571`), and pass the scalars
+into every tile; and choose tile boundaries from the *scene partition* rather
+than a fixed grid, which requires phases 1 and 2 anyway. At which point phase 3
+is the smaller remaining step, and it is exact.
+
+## 8. Prerequisites, independent of the rest
+
+Each of these is small, is worth doing on its own, and blocks something above.
+
+- **Chunk `assemble_scene_system_AB` over row bands.** `Bq`/`Bl` and the
+  `Bq[k] * wbuf` temporaries are the only per-scene term that scales with
+  spatial extent. Accumulate `BB`, `bB` and `AB` band by band and the buffers
+  become `nB × band_height × width`. Already flagged in `STATUS.md` as the
+  candidate for the unexplained spike between checkpoints; blocks §6.
+- **`Scene.model_image` in float32**, or accumulated straight into the residual
+  in the band's dtype. 150 MB per wide scene, ×`W` under parallelism.
+- **Bound scene *extent*, not only scene size.** `scene_max_size` binds
+  template count; the widest buffer came from a 25-template scene spanning
+  18.8 Mpx. A bbox-area cap in the split, or the row-chunking above, closes it.
+- **Incremental stamp writing.** `write_stamps` builds the complete `vla` list
+  before writing — a full extra copy of every stamp, at the end of the run.
+- **`ATA` assembly in COO, not `lil`.** Already in `TODO.md`; prerequisite for
+  the tiled build.
+- **Phase timers.** In `run()` and in `Scene.solve`. Prerequisite for deciding
+  any of this on evidence rather than on the arithmetic above.
+
+## 9. Open questions
+
+- Does the tiled `ATA` assembly reproduce the whole-field matrix bit for bit
+  in practice? The argument in §3 says it must; it needs a test on a real field
+  (compare CSR structure and values, then compare the scene partition).
+- What is the phase split of a full-field run, now that `run()` reports one?
+  Everything about the parallelism payoff depends on it, and on the
+  within-scene split that is still missing.
+- Is the on-demand upsampled-band view fast enough, or does re-replicating on
+  every stamp access cost more than it saves? A cache of the last few boxes
+  probably settles it, but it should be measured against the existing
+  `multi_resolution_method: downsample` path, which avoids the upsample
+  entirely and is 4× cheaper in template memory but diverges from the path v8
+  and v9 validated.
+- Where do saturated-star scenes fit? Their templates carry PSF wings far
+  beyond the segment, so their bboxes are the widest in the field and they are
+  the most likely to blow a per-worker budget.

--- a/src/mophongo/pipeline.py
+++ b/src/mophongo/pipeline.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import warnings
 import psutil
 import h5py
 import time
@@ -78,6 +79,43 @@ def human_bytes(n: float, binary: bool = True) -> str:
             return f"{size:.0f} {unit}" if unit == "B" else f"{size:.1f} {unit}"
         size /= step
     return f"{size:.1f} {units[-1]}"
+
+
+def _ignore_hierarch_warnings() -> None:
+    """Install the filter that silences astropy's per-card HIERARCH warning.
+
+    Keywords longer than eight characters -- ``PHOT_UNIT``, ``WEBBSTARFILT``,
+    ``APER_DIAM``, ``SHRINK_FACTOR`` and the rest of what an input catalog
+    carries in ``Table.meta`` -- round-trip as HIERARCH cards by design.
+    Astropy warns once per card, and twice per card once its own warning
+    logging has a handler, which at run scale is pure noise.
+
+    The caller is responsible for restoring ``warnings.filters``; use
+    :func:`_quiet_hierarch_warnings` unless the filter state is already being
+    saved (:meth:`Pipeline.log_run`).
+    """
+    from astropy.io.fits.verify import VerifyWarning
+
+    warnings.filterwarnings(
+        "ignore",
+        category=VerifyWarning,
+        message=".*a HIERARCH card will be created.*",
+    )
+
+
+@contextmanager
+def _quiet_hierarch_warnings():
+    """Scoped form of :func:`_ignore_hierarch_warnings` for a write path.
+
+    ``log_run`` filters these for everything it wraps, which since 2026-08-13
+    is every CLI invocation. It is not the only way in: a notebook or script
+    driving :class:`Pipeline` directly never enters that block, and the filter
+    belongs with the writes that provoke the warning in any case.
+    """
+    with warnings.catch_warnings():
+        _ignore_hierarch_warnings()
+        yield
+
 
 # shift-field arrows span this fraction of a scene's template extent, so that
 # the outermost samples stay inside the scene rather than sitting on its edge
@@ -2091,20 +2129,22 @@ class Pipeline:
         cfg = self.run_config
         stem = self.out_dir / cfg.name
         # residual is on the hi-res reference grid (upsample path)
-        fits.writeto(
-            self.f_residual,
-            self.residuals[0],
-            fits.getheader(cfg.sci_hi),
-            overwrite=True,
-        )
-        self.table.write(self.f_fit_table, overwrite=True)
+        with _quiet_hierarch_warnings():
+            fits.writeto(
+                self.f_residual,
+                self.residuals[0],
+                fits.getheader(cfg.sci_hi),
+                overwrite=True,
+            )
+            self.table.write(self.f_fit_table, overwrite=True)
 
-        # per-template fit state: everything the solve produced that a rebuild
-        # cannot re-derive (component amplitudes, astrometric shifts, scenes)
-        if getattr(self, "all_templates", None):
-            self._template_fit_table().write(self.f_templates, overwrite=True)
-        if cfg.save_stamps:
-            self.write_stamps()
+            # per-template fit state: everything the solve produced that a
+            # rebuild cannot re-derive (component amplitudes, astrometric
+            # shifts, scenes)
+            if getattr(self, "all_templates", None):
+                self._template_fit_table().write(self.f_templates, overwrite=True)
+            if cfg.save_stamps:
+                self.write_stamps()
 
         scene_dir = self.out_dir / "scenes"
         if cfg.scene_plots and self.scenes:
@@ -2746,14 +2786,11 @@ class Pipeline:
         old_showwarning = warnings.showwarning
         # Long keywords from the input catalog's meta (PHOT_UNIT,
         # WEBBSTARFILT, ...) round-trip as HIERARCH cards by design; the
-        # per-card VerifyWarning about it is pure noise at run scale.
+        # per-card VerifyWarning about it is pure noise at run scale. The write
+        # paths filter these themselves as well, for the step-at-a-time
+        # invocations that never enter this block.
         old_filters = warnings.filters[:]
-        from astropy.io.fits.verify import VerifyWarning
-
-        warnings.filterwarnings(
-            "ignore", category=VerifyWarning,
-            message=".*a HIERARCH card will be created.*",
-        )
+        _ignore_hierarch_warnings()
         # captureWarnings is a latch: if some earlier code in this process left
         # it on, another True call is a no-op and whatever hook is currently
         # installed (e.g. pytest's) stays in place. Reset it first so the
@@ -3889,21 +3926,34 @@ class Pipeline:
             tol_txt = f"{shift_tol:.3g} pix" + (
                 f" = {shift_tol * ps_fit * 1000:.1f} mas" if ps_fit else ""
             )
-            # Scenes are independent -- solve() only reads the scene's own
-            # templates, image and weights -- so one that has stopped moving
-            # stays stopped, and re-solving it only burns time. Iterate over
-            # the scenes still above tolerance and drop each as it converges.
-            pending = list(scenes)
-            for j in range(niter_scene):
-                logger.info(
-                    f"[Scenes] iteration {j+1} of {niter_scene}: "
-                    f"{len(pending)} of {len(scenes)} scene(s) still moving"
-                )
-                max_step, still = 0.0, []
-                for scn in pending:
-                  with self._phase("astrometry passes"):
+            # Scenes are independent across passes, not only within one:
+            # solve() reads the scene's own templates and read-only slices of
+            # the shared image and weights, and writes only to itself and to
+            # those templates. So the whole refinement of one scene -- its
+            # passes, its convergence test, and the flux-only pass that closes
+            # it out -- is a self-contained unit of work, and the loop runs
+            # scene-by-scene rather than synchronising every scene at each
+            # pass. The results are identical either way; what goes is the
+            # barrier, which is what stops a scene from being handed to a
+            # worker process (see docs/SCALING_FIXED_MEMORY.md).
+            logger.info(
+                "[Scenes] solving %d scene(s), up to %d astrometric pass(es) "
+                "each (tol %s)", len(scenes), niter_scene, tol_txt,
+            )
+            # A flux-only run (fit_astrometry_niter = 0) takes one pass through
+            # the loop below -- solve() dispatches to the flux-only path on the
+            # same flag -- and skips the closing re-solve.
+            final_cfg = (
+                replace(config, fit_astrometry_niter=0)
+                if config.fit_astrometry_niter > 0
+                else None
+            )
+            unconverged: list[Scene] = []
+            for scn in scenes:
+                scn.set_band(images[ifilt], weights_i, config=config)
+                with self._phase("astrometry passes"):
+                  for j in range(niter_scene):
                     prev = np.array([t.shifted[:2] for t in scn.templates], dtype=float)
-                    scn.set_band(images[ifilt], weights_i, config=config)
                     scn.solve(config=config, apply_shifts=True)
                     cur = np.array([t.shifted[:2] for t in scn.templates], dtype=float)
                     step = (
@@ -3917,51 +3967,53 @@ class Pipeline:
                     # to carry a shift block, never moves, and reporting that
                     # as "converged" would claim an astrometric solution that
                     # was never solved for. Those keep astrom_converged None
-                    # and flag -1.
+                    # and flag -1 -- and stop here, since nothing will move
+                    # them on a later pass either.
                     if scn.shifts is not None and len(scn.shifts) > 0:
                         scn.astrom_converged = step < shift_tol
-                    max_step = max(max_step, step)
-                    if scn.astrom_converged is False:
-                        still.append(scn)
-                logger.info(
-                    f"[Scenes] iteration {j+1}: max shift increment {max_step:.4f} pix, "
-                    f"{len(pending) - len(still)} scene(s) converged"
+                    if scn.astrom_converged is not False:
+                        break
+                if scn.astrom_converged is False:
+                    unconverged.append(scn)
+                # Each pass solved fluxes on the templates as they stood
+                # *before* that pass's shift was applied, so the stored fluxes,
+                # errors and model belong to a basis that no longer exists --
+                # the last shift applied is never accounted for. Re-solve
+                # fluxes once on the final templates, regardless of the
+                # convergence verdict, so what is written is stationary for the
+                # basis actually used to build the model, residual and stamps.
+                # Shifts are left untouched: this is a flux-only pass.
+                if final_cfg is not None:
+                    with self._phase("final flux solve"):
+                        scn.solve(config=final_cfg)
+                logger.debug(
+                    "[Scenes] scene %s: %d pass(es), last increment %.4f pix, %s",
+                    scn.id, scn.astrom_niter, scn.astrom_step or 0.0,
+                    "converged" if scn.astrom_converged
+                    else ("no shift fitted" if scn.astrom_converged is None
+                          else "still moving"),
                 )
-                pending = still
-                if config.fit_astrometry_niter > 0 and not pending:
-                    logger.info(
-                        f"[Scenes] shifts converged (< {tol_txt}) after {j+1} passes"
-                    )
-                    break
+
+            niters = [s.astrom_niter for s in scenes]
+            logger.info(
+                "[Scenes] %d of %d scene(s) converged (< %s); passes run: "
+                "median %d, max %d%s",
+                sum(s.astrom_converged is True for s in scenes), len(scenes),
+                tol_txt,
+                int(np.median(niters)) if niters else 0, max(niters, default=0),
+                "; fluxes re-solved on the final templates"
+                if final_cfg is not None else "",
+            )
 
             # Scenes still moving when the budget ran out: their shifts are the
             # last iterate, not a converged solution. Worth knowing which.
-            if pending:
-                slow = sorted(pending, key=lambda s: -(s.astrom_step or 0.0))
+            if unconverged:
+                slow = sorted(unconverged, key=lambda s: -(s.astrom_step or 0.0))
                 logger.warning(
                     "[Scenes] %d of %d scene(s) did not converge in %d passes "
                     "(tol %s); worst: %s",
-                    len(pending), len(scenes), niter_scene, tol_txt,
+                    len(unconverged), len(scenes), niter_scene, tol_txt,
                     ", ".join(f"scene {s.id} ({s.astrom_step:.3f} pix)" for s in slow[:5]),
-                )
-
-            # Each pass solves fluxes on the templates as they stood *before*
-            # that pass's shift was applied, so the stored fluxes, errors and
-            # model belong to a basis that no longer exists -- the last shift
-            # applied is never accounted for. Re-solve fluxes once on the final
-            # templates, for every scene and regardless of the convergence
-            # verdict, so what is written is stationary for the basis actually
-            # used to build the model, residual and stamps. Shifts are left
-            # untouched: this is a flux-only pass.
-            if config.fit_astrometry_niter > 0:
-                final_cfg = replace(config, fit_astrometry_niter=0)
-                for scn in scenes:
-                  with self._phase("final flux solve"):
-                    scn.set_band(images[ifilt], weights_i, config=config)
-                    scn.solve(config=final_cfg)
-                logger.info(
-                    "[Scenes] re-solved fluxes on the final templates for %d scene(s)",
-                    len(scenes),
                 )
 
             # Every shifted template holds its pre-shift pixels so that each

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -803,6 +803,147 @@ def test_write_outputs_puts_scene_plots_in_scenes_subdir(tmp_path):
     assert not (off / "t_scene_map.png").exists()
 
 
+def test_scene_results_do_not_depend_on_scene_order(monkeypatch):
+    """The astrometric loop runs scene-by-scene, so order must not matter.
+
+    ``run()`` refines one scene to convergence before starting the next rather
+    than synchronising every scene at each pass. That is only legitimate
+    because a scene reads its own templates and read-only slices of the shared
+    image and weights, so processing the scenes in the opposite order has to
+    give the same fluxes, errors, shifts and residual. It is also the property
+    a per-scene worker pool would rely on.
+    """
+    from astropy.wcs import WCS
+    from scipy.ndimage import shift as nd_shift
+    from mophongo.fit import FitConfig
+
+    images, segmap, catalog, psfs, _truth, wht = make_simple_data(
+        seed=7, nsrc=40, size=201, ndilate=2, peak_snr=50.0
+    )
+    kernel = mutils.matching_kernel(psfs[0], psfs[1])
+    # offset the fitted band so the shift loop actually iterates
+    images = [images[0], nd_shift(images[1], (0.95, -0.75), order=3)]
+
+    wcs = WCS(naxis=2)
+    wcs.wcs.crpix = [100.0, 100.0]
+    wcs.wcs.crval = [150.0, 2.0]
+    wcs.wcs.cdelt = [-1e-5, 1e-5]
+    wcs.wcs.ctype = ["RA---TAN", "DEC--TAN"]
+    config = FitConfig(
+        fit_astrometry_niter=5, astrom_shift_tol=0.004, snr_thresh_astrom=5.0,
+        astrom_isolation_thresh=0.0, scene_minimum_bright=2,
+    )
+
+    def fit():
+        pipe = pipeline.Pipeline(
+            [im.copy() for im in images], segmap, catalog=catalog,
+            weights=[w.copy() for w in wht], kernels=[None, kernel], psfs=psfs,
+            wcs=[wcs, wcs], config=config,
+        )
+        table, residuals = pipe.run()
+        scenes = sorted(pipe.all_scenes[0], key=lambda s: s.id)
+        return table, residuals[0], scenes
+
+    ref_table, ref_res, ref_scenes = fit()
+    assert len(ref_scenes) > 1, "need several scenes for the order to mean anything"
+
+    # same run, scenes handed to the loop back to front
+    generate = pipeline.generate_scenes
+
+    def reversed_scenes(*args, **kwargs):
+        scenes, labels = generate(*args, **kwargs)
+        return list(reversed(scenes)), labels
+
+    monkeypatch.setattr(pipeline, "generate_scenes", reversed_scenes)
+    got_table, got_res, got_scenes = fit()
+
+    np.testing.assert_array_equal(got_table["id"], ref_table["id"])
+    for col in ("flux_1", "err_1"):
+        np.testing.assert_array_equal(got_table[col], ref_table[col])
+    np.testing.assert_array_equal(got_res, ref_res)
+    for ref, got in zip(ref_scenes, got_scenes):
+        assert got.astrom_niter == ref.astrom_niter
+        assert got.astrom_converged == ref.astrom_converged
+        np.testing.assert_array_equal(got.shifts, ref.shifts)
+
+
+def test_write_outputs_silences_hierarch_card_warnings(tmp_path):
+    """Long catalog-meta keywords write as HIERARCH cards without warning.
+
+    ``PHOT_UNIT``, ``WEBBSTARFILT`` and friends come in on the input catalog's
+    ``meta`` and round-trip by design; astropy warns once per card, twice once
+    its warning logging has a handler. ``log_run`` filtered these, but the
+    steps are also run one at a time (``... config.json load fit outputs``),
+    which never enters that block.
+    """
+    import warnings
+
+    import matplotlib
+    matplotlib.use("Agg")
+    from astropy.io import fits
+    from astropy.io.fits.verify import VerifyWarning
+    from astropy.wcs import WCS
+    from mophongo.fit import FitConfig
+
+    images, segmap, catalog, psfs, _truth, wht = make_simple_data(
+        seed=12, nsrc=12, size=101, ndilate=2, peak_snr=2.0
+    )
+    catalog.meta["PHOT_UNIT"] = "uJy"
+    catalog.meta["WEBBSTARFILT"] = "F444W"
+    catalog.meta["SHRINK_FACTOR"] = 2
+    kernel = mutils.matching_kernel(psfs[0], psfs[1])
+    wcs_hi = WCS(naxis=2)
+    wcs_hi.wcs.crpix = [50.0, 50.0]
+    wcs_hi.wcs.crval = [150.0, 2.0]
+    wcs_hi.wcs.cdelt = [-1e-5, 1e-5]
+    wcs_hi.wcs.ctype = ["RA---TAN", "DEC--TAN"]
+
+    out_dir = tmp_path / "out"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    sci_hi = out_dir / "hi.fits"
+    fits.writeto(sci_hi, np.asarray(images[0], np.float32), overwrite=True)
+
+    pipe = pipeline.Pipeline(
+        [im.copy() for im in images], segmap, catalog=catalog,
+        weights=[w.copy() for w in wht], kernels=[None, kernel], psfs=psfs,
+        wcs=[wcs_hi, wcs_hi], config=FitConfig(fit_astrometry_niter=0),
+    )
+    pipe.run_config = pipeline.RunConfig(
+        name="t", out_dir=str(out_dir), sci_hi=str(sci_hi), segmap="seg.fits",
+        catalog="cat.fits", sci_lo="lo.fits", wht_lo="wht.fits",
+        csv_hi="hi.csv", csv_lo="lo.csv",
+        scene_plots=False, save_stamps=True,
+    )
+    pipe.out_dir = out_dir
+    pipe.run()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        pipe.write_outputs()
+    hierarch = [
+        w for w in caught
+        if issubclass(w.category, VerifyWarning)
+        and "HIERARCH card will be created" in str(w.message)
+    ]
+    assert not hierarch, [str(w.message) for w in hierarch]
+
+    # the keywords still made it into the file, as HIERARCH cards
+    hdr = fits.getheader(pipe.f_fit_table, 1)
+    assert hdr["PHOT_UNIT"] == "uJy"
+    assert hdr["WEBBSTARFILT"] == "F444W"
+    assert hdr["SHRINK_FACTOR"] == 2
+
+    # and the filter is scoped to the write, not left installed globally
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        fits.Header()["PHOT_UNIT"] = "uJy"
+    assert any(
+        issubclass(w.category, VerifyWarning)
+        and "HIERARCH card will be created" in str(w.message)
+        for w in caught
+    )
+
+
 def _shift_field_pipeline(tmp_path, order, nsrc=24, size=161, offset=(0.0, 0.0)):
     """A run with astrometry solved at ``order``, ready for plot_shift_field.
 


### PR DESCRIPTION
## Summary

Two independent changes, plus a research note.

**Astrometric loop inverted, `pass -> scene` to `scene -> pass`.** `run()` used to synchronise every scene at each pass and carry a `pending` list so a converged scene dropped out. It now refines one scene to convergence — its passes, its convergence test, and the flux-only pass that closes it out — before starting the next.

This is legitimate because scenes are independent *across* passes and not only within one: `Scene.solve` reads the scene's own templates and read-only slices of the shared image and weights, and writes only to itself and to those templates. Nothing couples one scene's iterate to another's. What goes is the barrier, which is what stops a scene from being handed to a worker process.

**HIERARCH `VerifyWarning` filter moved to the write paths.** Long keywords carried on the input catalog's `Table.meta` (`PHOT_UNIT`, `WEBBSTARFILT`, `HSTSTARFILT`, `APER_DIAM`, `SHRINK_FACTOR`) round-trip into the fit table's header as HIERARCH cards by design, and astropy warns once per card, twice once its own warning logging has a handler. The filter lived only in `log_run`, which at the time wrapped `run_all` alone, so the usual step-at-a-time invocation never entered it. `01dd473` has since put every CLI invocation inside `log_run`, closing the same hole from the other end; a notebook or script driving `Pipeline` directly still does not go through it, and the filter belongs with the writes that provoke the warning in any case. It is now a module helper (`_ignore_hierarch_warnings` / `_quiet_hierarch_warnings`) applied at `write_outputs` and `write_stamps`, scoped to the write — a caller's own filters are untouched afterwards.

**`docs/SCALING_FIXED_MEMORY.md`**, a research note on running arbitrarily large fields inside a fixed memory budget. No code from it beyond the loop inversion.

## Modules modified

- `src/mophongo/pipeline.py` — the astrometric loop in `run()`; `_ignore_hierarch_warnings` / `_quiet_hierarch_warnings` and their call sites in `write_outputs`, `write_stamps`, `log_run`
- `tests/test_pipeline.py` — two new tests
- `docs/SCALING_FIXED_MEMORY.md` — new
- `STATUS.md`, `TODO.md`

## Validation

Nothing about what is fitted or written changes, and that is measured rather than argued. The same fixture run through `origin/main` and through this branch gives bit-identical fluxes, errors, per-scene shift coefficients, per-template accumulated shifts, pass counts, convergence flags and residual, in three configurations:

| case | result |
|---|---|
| 3 scenes, uniform 2 passes | bit-identical |
| 10 scenes, tol 0.004 so pass counts vary between scenes (median 4, max 5) | bit-identical |
| flux-only, `fit_astrometry_niter=0` | bit-identical |

The middle case is the one that matters: it is where the two orderings genuinely interleave differently.

Corners preserved: a scene whose shift block was never built (flux-only run, or fewer than two bright anchors) keeps `astrom_converged` None and stops after one pass, exactly as dropping out of `pending` did.

Logging changes shape, since the per-pass lines no longer mean anything. The loop logs its budget up front, each scene at DEBUG, and one summary line (scenes converged, median and maximum passes). The warning naming the worst non-converged scenes is unchanged.

New tests:
- `test_scene_results_do_not_depend_on_scene_order` — hands the loop its scenes back to front, requires identical fluxes, errors, shifts, pass counts and residual
- `test_write_outputs_silences_hierarch_card_warnings` — no `VerifyWarning` escapes `write_outputs`, the keywords still read back off the fit table, and a bare header assignment still warns afterwards

Full suite: **351 passed**.

## References

- `STATUS.md`, the two 2026-08-13 entries
- `docs/SCALING_FIXED_MEMORY.md` §3 (why the inversion is the prerequisite) and §6 (threads measured at 0.47–0.66x on the assembly, so processes)
- `TODO.md`, the fixed-memory-budget item and its prerequisite list