### PR TITLE
Default PSF grids to one per epoch, and add an OzStar campaign toolkit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,18 @@ examples/canfar/*
 !examples/canfar/jobs/
 examples/canfar/jobs/*
 !examples/canfar/jobs/*.sh
+# OzStar toolkit: the same rule - scripts and docs, not the generated configs
+# (they carry a hardcoded run root), the staging lists, or the fetched outputs
+!examples/ozstar/
+examples/ozstar/*
+!examples/ozstar/*.py
+!examples/ozstar/*.md
+!examples/ozstar/*.sh
+!examples/ozstar/jobs/
+examples/ozstar/jobs/*
+!examples/ozstar/jobs/*.sh
+!examples/ozstar/jobs/*.slurm
+!examples/ozstar/jobs/*.py
 legacy/autopilot/*png
 legacy/autopilot/*pdf
 !data/*test*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,6 +166,16 @@ into B.
 - Long-form reports (`.tex`/`.md` compiled to PDF): plain academic prose, no
   AI narrative tics; run a humanizer pass before finalizing/compiling.
 
+## Branches And Commits
+
+- Do not create a branch, commit, push, or open a PR unless the user asked for
+  it in this session. Work in the tree the user left you in.
+- Ask before switching branches or moving work onto a new one, even when the
+  current branch looks wrong for the change.
+- The working tree often carries unrelated work in progress. Commit only the
+  files belonging to the task you were given, and say which files you left
+  uncommitted.
+
 ## Pull Request Preparation
 
 Before preparing a PR:

--- a/STATUS.md
+++ b/STATUS.md
@@ -3,6 +3,149 @@
 This file records completed implementations, validation runs, and the current work state.
 
 ## Current Work
+- [x] Array-lifetime audit, `docs/MEMORY_LIFETIMES.md` (2026-08-13). No code
+  changes; companion to `docs/SCALING_FIXED_MEMORY.md`, which proposes the
+  decomposition. This one inventories every full-field array a run allocates,
+  records where each is born and last read, and separates what is still needed
+  from what is merely still referenced. Findings feeding `TODO.md`:
+  * `weights_i` (3.5 GB upsampled ivar) is dead after `run:4061` but is pinned
+    by `Scene.weights` through the stamp write, which is where the full-field
+    runs die.
+  * `get_bg_and_ivar` copies its inputs on byte order: FITS is big-endian, so a
+    memmap arrives as `>f4` and `np.asarray(x, dtype=np.float32)` copies. The
+    detection-band call transiently allocates ~12 GB on a full field.
+  * The `isfinite` sweep at `pipeline.py:3838` has an inverted image branch
+    (dead) and a weight branch that touches all 876 Mpx for a guard
+    `load_data` already applied.
+  * `wht_hi`/`ivar_hi`/`weights[0]` are not three arrays: the first is a
+    transient memmap and the last two are the same object. The only true
+    information duplicate in a run is `weights[1]` against `weights_i` -- the
+    same weights on two grids, both alive to the end.
+- [x] `PSFFactory.date_mode` now defaults to `"all"`, and configs can set it
+  (2026-08-13). The default was `"modal"` -- the centre of the densest 5-day
+  window, i.e. exactly *one* date per (detector, filter). Since the grids are
+  MJD-tagged and looked up by nearest date, autobuilding a band whose
+  exposures span years produced a single epoch's wavefront for all of them,
+  silently. Found on OzStar, where nothing had been pre-built: MINERVA
+  exposure lists span up to 1460 days over 4-18 epochs, and every autobuilt
+  band got one grid while the laptop-built UDS F770W/F1800W had 9 (those were
+  made in `cluster` mode). A release built that way would have mixed two PSF
+  conventions across its bands.
+  * `psf_factory.PSFFactory.date_mode` default `"modal"` -> `"all"`, with the
+    docstring saying why the collapsing modes are the wrong default.
+  * New `RunConfig.psf_date_mode` (default `"all"`), threaded into the
+    `PSFFactory` call in `Pipeline._load_epsf`. The mode was previously
+    unreachable from a config at all.
+  * `examples/make_minerva_configs.py` writes `psf_date_mode` explicitly, so
+    every generated MINERVA config states it rather than inheriting it; the
+    53 CANFAR and 35 OzStar configs derived from them carry it too.
+  * Grid counts this implies, from the real exposure lists: 416 across the
+    release in `all` mode against 333 in `cluster` (UDS F770W 17 vs 9,
+    COSMOS F444W 78 vs 44, EGS F444W 42 vs 2).
+  * `poetry run pytest`: 358 passed.
+- [ ] MINERVA v1.0b full-field campaign on OzStar (2026-08-13/14, running).
+  Measured, which is what the OzStar README was missing:
+  * UDS full field F770W: **57.4 GB MaxRSS**, 56m19s, 26 GB of outputs,
+    138,634 sources (8,827 at SNR>5). A 64 GB request would have peaked at
+    90%; 96 GB is the right ask for UDS/COSMOS and EGS gets 128 GB, since its
+    detection grid is ~1.4x UDS's.
+  * 1.5' trial patch: 20 GB, 9m51s, 4,607 sources. Full field is ~3x the patch
+    in memory.
+  * CPU is **6.1% of 16 cores, i.e. about one core**. The fit is serial; cores
+    buy threaded BLAS in a few phases and queue time everywhere else. Memory
+    is the only resource that kills a run. (CANFAR measured 0.2 of a core for
+    the same work, dominated by waiting on NFS `/arc`; Lustre removes that.)
+  * Staging: 66 files, 64 GB, 15-21 min per field on three datamover nodes.
+  * OzStar took a ~30 min unannounced maintenance outage mid-campaign. Queued
+    jobs survived it; `uds_f770w_v1.0b` had already completed.
+  Done autonomously while the user was away, and worth reviewing: the
+  COSMOS/EGS grids are being rebuilt with `date_mode="all"` passed explicitly
+  by `jobs/build_psfs.py`, which calls `PSFFactory` directly rather than going
+  through the pipeline's autobuild. That sidesteps needing the `psf_date_mode`
+  change deployed (the run tree pulls from GitHub `main`, and the change is
+  local and uncommitted) and sidesteps the autobuild's fire-only-when-nothing-
+  matches rule. COSMOS F444W resolves to 39 dates in `all` mode against 22 in
+  `cluster` and 1 in `modal`. UDS grids are deliberately untouched: its bands
+  are in flight and adding dates mid-release would leave `f770w` fitted
+  against 9 grids and later bands against 17.
+- [ ] OzStar campaign toolkit, `examples/ozstar/` (2026-08-13). The CANFAR
+  toolkit's counterpart for Swinburne's Ngarrgu Tindebeek. Two differences
+  drive the design: OzStar has no view of the MINERVA release, so every input a
+  config names is copied from CANFAR arc onto `/fred` before anything runs; and
+  compute is ssh + SLURM rather than a REST API, so a campaign is one
+  dependency graph submitted in a single command instead of a laptop-side
+  process blocking on each stage.
+  * `ozroot.py` (run tree and ssh target from `$OZSTAR_*`), `ozify.py` (local
+    RunConfig -> `<name>_ozstar.json` + `<name>_stage.tsv`), `submit.py`
+    (cert/setup/sync/push/stage/run/status/logs/fetch/cancel/seed),
+    `campaign.py`, `release_v1.0b.sh`, and `jobs/` (setup_env.sh, stage.sh,
+    run.slurm, sync_src.sh, seed_cache.sh).
+  * `ozify.py` imports `roots_for`/`arc_index`/`resolve` from
+    `examples/canfar/arcify.py` rather than copying them - finding a file on
+    arc is the same problem on both platforms. That needed one change there:
+    the module-level `RUN` is now a lazy `arc_run()`, so importing the helpers
+    no longer requires a CANFAR run root. Behaviour is unchanged.
+  * Staging is one datamover job per *field* (bands share the F444W mosaic,
+    weight and segmap), fits wait on it with `--dependency=afterok`, and a
+    field with no PSF grids sends one band ahead of the rest so concurrent
+    bands do not race on one `psf_dir`.
+  * Four platform traps, all found by running into them and all documented in
+    `README.md`/`MANUAL.md`: Lmod is hierarchical, so `python/3.12.3` needs
+    `gcccore/13.3.0` loaded first; the python module puts an EasyBuild shim
+    ahead of the venv on `sys.path`, which on some nodes resolved
+    `cryptography` to a build for another python and killed every `vcp` with a
+    missing `libssl.so.1.1` (job scripts now `unset PYTHONPATH`); a site plugin
+    reassigns the partition of a job that names `datamover` in a `#SBATCH`
+    directive alone, so it has to be on the sbatch command line or the transfer
+    lands on a node with no internet; and datamover nodes have no `/apps`, so
+    the module python is absent there and the CADC tools need their own
+    `venv-vos` built from `/usr/bin/python3`.
+  * Standard request 16 cores / 64 GB per fit, no partition (the scheduler
+    picks between skylake and milan).
+  * State: all three fields staging from arc (17 configs, 8 inputs each);
+    `uds_f770w_trial` (1.5' patch) queued behind UDS staging as the smoke test;
+    the v1.0b full-field release goes in after it passes.
+- [x] Controlled MINERVA SED co-add experiment (2026-08-13). Rebuilt the
+  underlying stack at `Delta z=0.035(1+z)` with 2x rendering interpolation and
+  restricted the continuum-residual panel to observed 0.35--5 micron, where
+  connected filter coverage makes that residual meaningful. Relative to 0.05,
+  the experiment adds 42% more measured redshift rows below z=8 while retaining
+  a median 5,292 galaxies/bin; 0.025 nearly doubles the rows but raises residual
+  noise 16% and adds horizontal striping. OIII coherence improves modestly,
+  H-alpha does not benefit from 0.025, and no coherent Pa-beta/Pa-alpha ridge is
+  detected. The original 0.05 equal-mean product remains primary.
+  Added `scratch/minerva_sed_estimator_experiment.py`: 64 exact complementary
+  split halves over 4,204 field/native-band/redshift cells independently
+  recompute every estimator. Raw IVW is 3.66x less repeatable than the equal
+  mean with median Neff/N=0.0215; Q95 IVW is 1.62x worse with 0.185. The
+  population-scatter weight improves repeatability 16% overall but moves MIRI
+  by a median 0.31 MAD. Winsorizing 0.5% per tail is the conservative companion
+  (1.7% precision gain, 0.008-MAD median shift); 1% is the empirical knee
+  (3.5%, 0.013 MAD). Matched-three-band, `use_phot_miri`, high-quality-z, and
+  spec-only EGS splits yield no stable feature-S/N gain; triple matching keeps
+  only 3,229/126,655 normalized galaxies. Corrected H-alpha and OIII guides to
+  their vacuum wavelengths. Focused SED tests: 30 passed.
+- [x] MINERVA all-field SED-stack MIRI visibility and quality-control pass
+  (2026-08-13). Regenerated every ignored FITS/PNG/PDF product for 357,044
+  normalized COSMOS+EGS+UDS galaxies. Replaced the 1.6-micron continuum-bump
+  guide with vacuum Pa-beta/Pa-alpha, and added a distinct magenta rest-5000-A
+  normalization guide. The new MIRI PNG uses a shared tight signed-asinh
+  stretch plus independently scaled signed profiles, empirical standard
+  errors, N, and effective N; the values are not renormalized per filter.
+  Sampling explains much of the visibility difference: F560W has 5,299
+  normalized measurements and is EGS-only, F770W has 169,862 across all three
+  fields, and F1000W has 94,566 across COSMOS+EGS.
+  Added machine-readable MIRI ECSV/FITS QC with equal means, medians, empirical
+  SEM, 0.5--99.5% field-local winsorized means, population-scatter-regularized
+  weights, effective counts, and raw/Q95 IVW failure columns. An actual
+  4,204-cell all-band audit rejects ordinary IVW: median Neff/N=0.0215 and
+  empirical error 3.2x the equal mean; Q95 capping still gives 0.185 and 1.47x.
+  The equal-galaxy signed mean therefore remains primary and measured S/N is
+  never a weight. Common-galaxy checks find no local 2.5--3-micron F277W
+  excess: F277W is 2--4% below the F250M--F300M interpolation in every field;
+  the visual block is the declining F-lambda continuum plus the real
+  2.226--2.412-micron gap, with the 5000-A anchor crossing it at z=4--5.
+  `tests/test_sed_stack.py`: 27 passed.
 - [ ] Scene solve cost and the size cap (2026-08-13). Two defects found while
   chasing the full-field memory peak; both are about the cost of a scene
   growing with the number of templates in it.
@@ -60,11 +203,38 @@ This file records completed implementations, validation runs, and the current wo
   Still to do: a full-field run on an idle machine for the peak against the
   recorded 46.5 GB, and the same partition/flux comparison at full-field scale,
   where scenes are larger and the cap bites harder.
-- [ ] CANFAR v1.0 campaign: submitted, queued on platform capacity
-  (2026-08-12 evening). 17 configs (uds/cosmos/egs x all staged MIRI bands),
-  `--r-trial 1.5 --suffix _v1.0`, outputs to
-  `/arc/home/ilabbe/run/out/<field>_<band>_v1.0`. Push, setup and all 17
-  stage jobs completed; the run step is queued.
+- [ ] CANFAR v1.0 campaign, **full field** (2026-08-13). v1.0 is now a
+  whole-field run per field-band, not the 1.5' patch the entry below
+  describes: the memory work merged in `9fc52a6` brought UDS full field to
+  46.5 GB, under the 48 GB request. 17 configs (uds/cosmos/egs x all staged
+  MIRI bands) re-arcified with `--r-trial 0 --suffix _v1.0`, so `trial` is
+  null and outputs still go to
+  `/arc/home/ilabbe/run/out/<field>_<band>_v1.0`. Jobs request 4 cores and
+  48 GB. EGS is 1221 Mpx against UDS's 876 and extrapolates over 48 GB, so
+  its bands are the ones expected to OOM; the agreed response is to resubmit
+  those at `--ram 64` rather than raise the request everywhere, since 48 GB
+  and up have queued for hours when the platform is busy.
+  The earlier patch submission was stopped first. That took two rounds: six
+  sessions were listed and destroyed, and ten more appeared minutes later,
+  because skaha does not list a session until the service registers it. They
+  carried the same run names as the new campaign and would have written into
+  the same `out/` directories. `submit.py kill` now sweeps for this.
+  **Result so far: the fits succeed, the stamps write does not.** Every band
+  that has failed wrote a complete fit table first -- egs_f1000w 142,323 rows
+  (142,299 finite `flux_1`), uds_f1800w 137,609, uds_f1280w 140,972, all 22
+  columns -- plus its residual, kernel, PSFs and templates, then died in the
+  stamps write with no `RUN_DONE` and no traceback. Not a memory ceiling:
+  egs_f1000w reached `Pipeline (end) memory: 49.4 GB` against a 48 GB request,
+  but uds_f1800w reached only 41.6 GB and died the same way, and the stamps
+  files it left are truncated at 31-32 MB where a full field should be
+  multi-GB. This is the area `3c29ddd`, `8ca21f5` and `b7bec1e` address on
+  main; the campaign predates them and stays pinned to `9fc52a6a6` through
+  `submit.py run --ref`, so v1.0 is one code version rather than two. Open
+  decision: accept v1.0 as the fit tables from that commit and rebuild stamps
+  separately, or rerun the campaign on current main, which also brings the
+  scene-by-scene astrometric loop (`1ab936e`) and the float32 narrowing into
+  the release. EGS's seven bands are at `--ram 64` since it is the hottest
+  field, though that alone will not produce `RUN_DONE`.
   Four toolkit defects fixed to get this far, all committed:
   * `campaign.py` globbed every JSON in `examples/minerva`, including
     `minerva_sed_fields.json`, which is not a RunConfig and died inside
@@ -82,15 +252,14 @@ This file records completed implementations, validation runs, and the current wo
   520,875 catalogue sources). The platform reports
   `memoryGB.defaultLimit = 32`; 8 GB jobs schedule instantly, 48 GB
   scheduled once while the platform was quiet, and 48/64/128/192 GB have
-  all queued for hours since. **Full field is therefore not runnable on
-  this platform as the pipeline currently allocates**, independent of the
-  campaign tooling.
-  Two ways forward, both needing a decision rather than a default:
-  `multi_resolution_method: downsample` (templates on the lo grid, 4x less
-  template memory -- COSMOS 24.8 -> 6.2 GB -- but it diverges from the
-  upsample path v8 verified), or tiling a field across jobs, which the
-  toolkit does not support. Until then v1.0 is a 1.5' patch per field-band,
-  which is the configuration v8 actually validated.
+  all queued for hours since. Those allocation figures are **pre-`9fc52a6`**
+  and no longer describe the pipeline: cutting the redundant template sets
+  and banding the whole-array passes brought UDS full field to 46.5 GB, so
+  the conclusion recorded here -- that full field was not runnable on this
+  platform, and that the only ways forward were
+  `multi_resolution_method: downsample` or tiling a field across jobs --
+  is superseded. Full field per field-band is what v1.0 now runs; neither
+  fallback was needed. EGS remains the field where 48 GB may not be enough.
   Note the stamp-footprint fix is what makes even this feasible: at the old
   402^2 support, COSMOS's convolved templates alone would need 98 GB.
 - [x] Astrometric loop inverted to scene -> pass (2026-08-13). `run()` ran
@@ -145,6 +314,78 @@ This file records completed implementations, validation runs, and the current wo
   checks all three: no `VerifyWarning` escapes `write_outputs`, the keywords
   are readable back off the fit table, and a bare header assignment still
   warns afterwards.
+- [x] CANFAR toolkit: lessons from starting the full-field campaign
+  (2026-08-13). Nine changes in `examples/canfar/`, each from something that
+  cost time in this run:
+  * **A dropped submission is no longer silent.** Submitting seven EGS bands,
+    the service returned HTTP 500 with
+    `JedisDataException: ERR max number of clients reached` for three of
+    them; skaha swallows that and returns an empty list, so `launch` logged
+    `FAILED` and the batch carried on with three bands that never existed.
+    `launch` now retries three times with a 10 s pause, and `do_run` exits
+    non-zero naming any band that still did not start, rather than returning
+    quietly under `--no-wait`.
+  * **`wait` no longer calls a job dead on an empty `info`.** A two-minute
+    DNS outage on the laptop (09:05-09:07) made three consecutive `info`
+    calls return `[]` -- skaha swallows network errors and answers with an
+    empty list, so an unreachable service is indistinguishable from a reaped
+    session -- and `wait` declared the *running* EGS leader `Gone`. The
+    campaign then moved on and tried to launch the six bands that were
+    waiting on the grids that leader was still building, which is the
+    `psf_dir` race the leader-first ordering exists to prevent. Only the
+    `SRC_VERSION` guard stopped it, and only by accident: the same outage
+    made the version unreadable, so `run` refused. `Gone` now requires
+    `still_listed()` to come back negative from a *non-empty* session
+    listing; an empty or failed listing means "unknown" and waiting
+    continues.
+  * **`sync` goes through the /arc mount, not a container.** Queue latency
+    dominates small work: the 1-core sync job sat `Pending` for 28 minutes,
+    twice, to do seconds of copying, while the sshfs mount turns out to be
+    writable and does the same unpack in 19 s. `run_root_local()` finds the
+    mounted run tree (`$CANFAR_RUN_LOCAL`, else `~/canfar_home`) and
+    `do_sync` unpacks there in the same order as `update_src.sh` - version
+    promoted only after the tar - with `--job` to force a container. Verified
+    byte-identical: the arc copies of `sed_stack.py`, `scene.py` and
+    `catalog.py` sha-match `git show main:<path>`. The hazard is unchanged
+    from the container path, since both rewrite source under running jobs.
+  * **CANFAR runs a commit, not a working tree.** `do_push` tarred `src/`
+    off disk, so the 06:05 push carried another session's uncommitted
+    `sed_stack.py` and `scene.py` and would have shipped them to 17
+    full-field jobs. `push` now ships `git archive` of `main` (`--ref` for
+    another commit, `--worktree` to opt back in, loudly). Provenance runs
+    end to end: `push` uploads `SRC_VERSION.pending`, the unpack step
+    promotes it to `SRC_VERSION` -- deliberately after untarring, so the
+    file means "installed" and not "uploaded" -- `run.sh` prints it at the
+    top of every job log, and `do_run` refuses to submit when it does not
+    match the local ref. That last check is the one with teeth: `push`
+    uploads but does not unpack, so a push without a sync leaves every job
+    importing the previous campaign's code with entirely normal-looking
+    outputs. Verified here: the arc source was four hours older than the
+    memory fix the full-field runs depend on.
+  * `submit.py kill` -- destroying every session took two rounds, because
+    skaha does not list a session until the service registers it and a
+    `--no-wait` campaign registers over several minutes. `kill` sweeps until
+    N consecutive passes come back empty (`--sweeps`, default 3) and spares
+    the `sync` job by default. There was no stop command at all before.
+  * `push --src-only`. Only `setup_env.sh` unpacks `psf.tar`, so a `push`
+    before a `sync` uploads several hundred MB (732 here) that never reach
+    `$RUN/PSF`. Nothing is lost by skipping it: `PSFFactory` skips grid files
+    that already exist unless `overwrite` is set.
+  * `campaign.has_shared_grids` counted only local grids, but the run reads
+    `$RUN/PSF` on arc. COSMOS has its 30" halo pair on arc and none locally,
+    so the check said "missing" and would have serialised one full-field band
+    ahead of the other five for nothing. It now takes the arc listing too
+    (`arc_psf_names`, falling back to local if the listing fails). Verified:
+    cosmos False -> True, egs correctly still False, uds unchanged.
+  * `campaign.py --skip` -- `--from` can only drop a prefix of the chain, so
+    there was no way to re-arcify without also re-staging.
+  * cores default 2 -> 4 (`cores_for`), and the memory guidance in
+    `README.md`/`MANUAL.md` replaced with the measured full-field numbers.
+  Also documented: skaha appends a `-1` replica index to session names, so
+  `mophongo-uds-f770w-v1-0` lists as `mophongo-uds-f770w-v1-0-1`.
+  No tests: `examples/canfar/` is not covered by the suite. Verified by
+  invoking each changed path (`kill --help`, `push --help`, a `--skip`
+  dry-run, and `arc_psf_names` against the live listing).
 - [x] Verification v9: all four UDS MIRI bands at r < 3' (2026-08-13,
   commit `ff1447a`, `examples/minerva/verification/v9/`). Same code and PSF
   grids as v8's F770W re-run, applied to every band, at the trial radius the

--- a/STATUS.md
+++ b/STATUS.md
@@ -3,24 +3,44 @@
 This file records completed implementations, validation runs, and the current work state.
 
 ## Current Work
-- [x] Array-lifetime audit, `docs/MEMORY_LIFETIMES.md` (2026-08-13). No code
-  changes; companion to `docs/SCALING_FIXED_MEMORY.md`, which proposes the
-  decomposition. This one inventories every full-field array a run allocates,
+- [x] Array-lifetime audit and five memory fixes, `docs/MEMORY_LIFETIMES.md`
+  (2026-08-13). Companion to `docs/SCALING_FIXED_MEMORY.md`, which proposes the
+  decomposition; this one inventories every full-field array a run allocates,
   records where each is born and last read, and separates what is still needed
-  from what is merely still referenced. Findings feeding `TODO.md`:
-  * `weights_i` (3.5 GB upsampled ivar) is dead after `run:4061` but is pinned
-    by `Scene.weights` through the stamp write, which is where the full-field
-    runs die.
-  * `get_bg_and_ivar` copies its inputs on byte order: FITS is big-endian, so a
-    memmap arrives as `>f4` and `np.asarray(x, dtype=np.float32)` copies. The
-    detection-band call transiently allocates ~12 GB on a full field.
-  * The `isfinite` sweep at `pipeline.py:3838` has an inverted image branch
-    (dead) and a weight branch that touches all 876 Mpx for a guard
-    `load_data` already applied.
-  * `wht_hi`/`ivar_hi`/`weights[0]` are not three arrays: the first is a
-    transient memmap and the last two are the same object. The only true
-    information duplicate in a run is `weights[1]` against `weights_i` -- the
-    same weights on two grids, both alive to the end.
+  from what is merely still referenced. Changes made, in the order they run:
+  * The band weight map is released once nothing reads it.
+    `Pipeline._release_scene_weights` clears `Scene.weights` across a band;
+    `run` calls it after `predicted_errors` when the run draws no scene
+    figures, `write_outputs` after the figures. `weights_i` was 3.5 GB of dead
+    weights held by every `Scene` through the stamp write -- the stage where
+    the unexplained full-field failures occur. `Scene.residual`/`Scene.plot`
+    mask on the weights only when they are still attached; `Scene.solve` still
+    refuses to run without them.
+  * `write_outputs` writes the stamps last, after the scene figures rather than
+    before. The products are independent, and a run that dies in the stamp
+    write now keeps its figures.
+  * The residual accumulates straight into its own output file
+    (`_residual_memmap`): header written, file extended sparsely with
+    `truncate`, data section mapped big-endian. `write_outputs` flushes instead
+    of writing. Falls back to anonymous memory for API-driven runs and on any
+    mapping error.
+  * The repair replays its patch table onto a fresh copy-on-write map instead
+    of holding the two full-field mosaics `repair_saturated_holes` returns
+    (`saturate.py:733`). Fresh and cache-reuse paths now share
+    `_apply_repair_patches`; astropy maps a read-only HDU copy-on-write, so the
+    input mosaic on disk is untouched.
+  * `write_stamps` streams: offsets from the shapes recorded in the first pass,
+    datasets created at final size, each stamp written into its slot. Removes a
+    full extra copy of every stamp (12 GB full-field) at the end of the run.
+  * Also: the `isfinite` sweep at the top of `run` is gone (inverted, dead
+    image branch; weight branch re-checked a guard `load_data` had applied).
+  * `poetry run pytest`: 362 passed. New tests cover the residual memmap
+    round-trip end to end, the API fallback, copy-on-write patch replay, and
+    stamp pixel equality after a round trip.
+  * Still open, in `TODO.md`: the byte-order copies in `get_bg_and_ivar` (FITS
+    is big-endian, so `np.asarray(x, dtype=np.float32)` copies rather than
+    views -- ~12 GB transient on the detection band); ivar as
+    `(memmapped wht, scale, mask)`; `weights[1]` after the upsample.
 - [x] `PSFFactory.date_mode` now defaults to `"all"`, and configs can set it
   (2026-08-13). The default was `"modal"` -- the centre of the densest 5-day
   window, i.e. exactly *one* date per (detector, filter). Since the grids are

--- a/TODO.md
+++ b/TODO.md
@@ -818,28 +818,38 @@ This file tracks future desired features, checks, and investigations.
     the widest); float32, or accumulate straight into the residual.
   - [ ] Bound scene *extent*, not only `scene_max_size`: the widest buffer came
     from a 25-template scene whose anchors spanned 18.8 Mpx.
-  - [ ] `write_stamps` still builds the complete `vla` list before writing --
-    a full extra copy of every stamp (12 GB full-field) at the end of the run.
-    `8ca21f5` moved the file to HDF5, so the per-source offsets a scene-local
-    read needs already exist and only the incremental *write* is left: append
-    each band's flat buffer as tiles complete rather than concatenating at the
-    end. That turns the stamps file into working storage for the streaming
-    solve, not just an output.
+  - [x] `write_stamps` no longer builds the complete `vla` list before writing
+    (2026-08-13) -- that was a full extra copy of every stamp, 12 GB
+    full-field, at the end of the run. Offsets come from the shapes recorded in
+    the first pass and each stamp is written into its slot. What remains for
+    the streaming solve is appending as *tiles* complete rather than as
+    templates complete, which needs the tiled build to exist first.
   - [ ] Upsampled band on demand instead of materialised: `_upsample_boxed`
     holds 7 GB for the sci/ivar pair and is where COSMOS OOMs. The array is a
     pure function of the lo-res pixels and is only ever read as
     `image[slices_original]`.
-  - [ ] Residual as a `np.memmap` over the output file rather than 3.5 GB of
-    dirty anonymous pages.
-  - [ ] Release the dead weights after `run:4061`. `weights_i` (3.5 GB
-    upsampled ivar) is last read by `Templates.predicted_errors`; nothing in
-    the residual, aperture photometry, catalog update, `write_outputs` or
-    `write_stamps` touches it again. It survives because every `Scene` holds
-    `self.weights` (`scene.py:957`) and `self.all_scenes` holds every scene, so
-    it sits through the stamp write -- the stage where the full-field runs die.
-    Conditional on `scene_plots`/diagnostics being off: `Scene.plot` and
-    `Scene.residual_image` do read it (`scene.py:1302,1553`). See
-    `docs/MEMORY_LIFETIMES.md`.
+  - [x] Residual as a `np.memmap` over the output file rather than 3.5 GB of
+    dirty anonymous pages (2026-08-13; `Pipeline._residual_memmap`).
+  - [x] Release the band weight map once nothing reads it (2026-08-13).
+    `weights_i` (3.5 GB upsampled ivar) was last read by
+    `Templates.predicted_errors` but held by every `Scene`, so it sat through
+    the stamp write. `Pipeline._release_scene_weights` clears it; `run` calls
+    it after `predicted_errors` when no scene figures are drawn, and
+    `write_outputs` after the figures. See `docs/MEMORY_LIFETIMES.md`.
+  - [x] `write_outputs` writes the stamps last (2026-08-13), after the scene
+    figures rather than before, so the weights can go before the run's other
+    memory peak and a run that dies in the stamp write keeps its figures.
+  - [x] Residual accumulates into its own output file (2026-08-13).
+    `_residual_memmap` writes the header, extends the file sparsely and maps
+    the data section; `write_outputs` flushes instead of writing. Falls back to
+    anonymous memory for API-driven runs and on any mapping error.
+  - [x] Repair replays its patch table onto a fresh copy-on-write map
+    (2026-08-13) instead of holding the two full-field mosaics
+    `repair_saturated_holes` returns (`saturate.py:733`). Fresh and cache-reuse
+    paths now share `_apply_repair_patches`.
+  - [x] `write_stamps` streams (2026-08-13): offsets from the recorded shapes,
+    datasets created at final size, each stamp written into its slot. Removes
+    the 12 GB `vla`-plus-concatenate copy at the end of the run.
   - [ ] Avoid the byte-order copies in `get_bg_and_ivar`. FITS is big-endian,
     so a memory-mapped float32 image arrives as `>f4` and
     `np.asarray(x, dtype=np.float32)` (`catalog.py:267-268`) copies rather than
@@ -848,17 +858,12 @@ This file tracks future desired features, checks, and investigations.
     upstream. The full-resolution arrays are only used by `_valid_block_means`,
     a strided median sample and the final `w * scale`, all of which work on
     `>f4` directly.
-  - [ ] Detection ivar as `(memmapped wht, scale, invalid mask)` rather than a
-    3.5 GB anonymous array: the calibration is one scalar plus a mask
+  - [ ] ivar as `(memmapped wht, scale, invalid mask)` rather than a 3.5 GB
+    anonymous array: the calibration is one scalar plus a mask
     (`catalog.py:369-372`). Composes with the on-demand upsampled band above --
     with both, neither ivar array exists.
-  - [ ] Repair path: reopen the cached repaired mosaic as a memory map instead
-    of holding `rep["sci"]` anonymously. The cache file is already written at
-    `load_data:1599`.
-  - [ ] Fix or delete the `isfinite` sweep at `pipeline.py:3838-3842`. The
-    image branch is inverted (fires only when the image is `None`, then calls
-    `np.isfinite(None)`); the weight branch touches all 876 Mpx of `ivar_hi`
-    and duplicates the guard `load_data:1652-1664` already applied.
+  - [ ] Drop `weights[1]` after the upsample, which needs `source_products`
+    pointed at the reference-grid array rather than the native one.
   - [ ] Timers inside `Scene.solve`. `56530f2` added the per-section wall-time
     breakdown for `run()`, which covers the outer split (templates, convolve,
     generate scenes, astrometry passes, final flux solve, residual). Still

--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,62 @@
 
 This file tracks future desired features, checks, and investigations.
 
+- [ ] Decide whether to rebuild the existing PSF grids in `all` mode
+  (2026-08-13). The default is now `all`, but the grids already on disk (and
+  on arc, and on `/fred`) were built in `cluster` mode -- UDS F770W has 9
+  where `all` wants 17, COSMOS F444W 44 against 78. `_load_epsf` autobuilds
+  only when *nothing* matches the pattern, so those bands will never gain the
+  missing dates on their own: they have to be deleted and rebuilt, about 416
+  grids and an estimated 9 hours of nice'd login-node CPU. Until then a
+  release mixes `cluster`-mode grids (UDS, COSMOS F444W/F770W) with `all`-mode
+  ones (everything autobuilt from now on). Worth measuring first whether the
+  difference is detectable in the photometry: if the wavefront drift between
+  adjacent cluster dates is small, `cluster` is the cheaper convention and the
+  default should arguably be reconsidered rather than the grids rebuilt.
+
+- [ ] `PSFFactory` autobuild is silent about incompleteness. A band with one
+  grid and one with seventeen both "match the pattern", so a partially built
+  grid set looks identical to a complete one at load time. `_load_epsf` could
+  compare the dates it loaded against `dates_from_csv(csv, mode=cfg.psf_date_mode)`
+  and warn when grids are missing; that is how the 2026-08-13 single-epoch
+  problem would have announced itself instead of being found by hand.
+
+- [ ] Measure the OzStar side of the campaign (2026-08-13). `examples/ozstar/`
+  is written and running but has no measured numbers in it yet: staging wall
+  time and volume per field, peak RSS per full-field band from
+  `sacct --format=MaxRSS`, and whether 16 cores buys anything over 4 now that
+  the inputs sit on Lustre rather than an NFS-mounted `/arc` (the CANFAR
+  measurement of 0.2 of a core was dominated by waiting on `/arc`). Those
+  belong in `examples/ozstar/README.md` next to the request defaults.
+
+- [ ] `examples/ozstar/` has no test coverage, for the same reasons and with
+  the same one worth testing as the CANFAR toolkit: `has_shared_grids` is pure
+  given a name list. It is now duplicated in both campaign scripts because the
+  OzStar one must ignore local grids (nothing uploads them there) - if a test
+  is written, that is the moment to decide whether the two should share an
+  implementation.
+
+- [ ] Confirm the EGS full-field memory ceiling and give `campaign.py` a
+  per-field RAM (2026-08-13). This applies to both platforms; the OzStar
+  campaign requests 64 GB by default and its nodes hold 191-256 GB, so a
+  resubmission there is cheap, while CANFAR's 48 GB is the constrained case.
+  EGS is 1221 Mpx against UDS's 876, and UDS
+  full field measures 46.5 GB, so EGS extrapolates over the 48 GB request
+  and its bands are expected to OOM (silently, with no traceback). The
+  agreed response for the v1.0 campaign is to resubmit those at `--ram 64`
+  by hand, because 48 GB and up have queued for hours when the platform is
+  busy and raising the request everywhere costs wall clock. If EGS does need
+  64, `--ram` should become per-field rather than one number for the whole
+  campaign, and the measured peak per field belongs in `README.md` next to
+  the UDS number.
+
+- [ ] `examples/canfar/` has no test coverage. The 2026-08-13 changes
+  (`kill`, `push --src-only`, arc-aware `has_shared_grids`, `--skip`) were
+  verified by invoking them, not by tests. `has_shared_grids` is the one
+  worth a real test: it is pure given a name list, so it needs no network,
+  and getting it wrong either serialises a field for hours or lets several
+  bands race on one `psf_dir`.
+
 - [ ] `AlignedCutout.downsample`/`upsample` pass `self.wcs` (this cutout's
   WCS) as the parent WCS of a new cutout built on a full-shape dummy, the
   same pattern fixed in `Template.convolve_cutout` and
@@ -690,6 +746,21 @@ This file tracks future desired features, checks, and investigations.
       reconstructions, a continuum-residual contrast view, and machine-readable
       stack products are implemented in
       `examples/minerva/plot_uds_sed_stack.py`
+    - [x] Add MIRI-specific visibility/QC for F560W, F770W, and F1000W with a
+      shared local display stretch, empirical SEM/counts, gentle field-local
+      winsorization, population-scatter-regularized weighting, and explicit
+      raw/capped inverse-variance failure diagnostics
+    - [x] Compare 0.05/0.035/0.025 fractional redshift bins and repeated
+      split-half equal/winsor/scatter-weighted/IVW estimators; keep 0.035 as an
+      experimental companion, 0.5% winsorization as the conservative robust
+      view, and formal IVW only as a demonstrated failure control
+    - [ ] Add whole-galaxy field-stratified bootstrap uncertainty (500 final
+      draws), delete-one-field checks, and spatial 4x4 tile jackknives; preserve
+      each galaxy's correlated wavelength cells during every resample
+    - [ ] Add labeled redshift-quality sensitivity stacks (spec-z or narrow
+      EAzY posterior), and use full P(z) multiple imputation only when the exact
+      EAzY posterior files are staged; do not weight the primary stack by
+      photo-z risk or pretend quantiles are Gaussian PDFs
   - [ ] add in residuals in core for improved flux measurements (shift / psf errors)
 - [ ] investigate blending in detection image
 - [ ] Investigate template extension methods (Moffat fit and PSF dilation)
@@ -760,6 +831,34 @@ This file tracks future desired features, checks, and investigations.
     `image[slices_original]`.
   - [ ] Residual as a `np.memmap` over the output file rather than 3.5 GB of
     dirty anonymous pages.
+  - [ ] Release the dead weights after `run:4061`. `weights_i` (3.5 GB
+    upsampled ivar) is last read by `Templates.predicted_errors`; nothing in
+    the residual, aperture photometry, catalog update, `write_outputs` or
+    `write_stamps` touches it again. It survives because every `Scene` holds
+    `self.weights` (`scene.py:957`) and `self.all_scenes` holds every scene, so
+    it sits through the stamp write -- the stage where the full-field runs die.
+    Conditional on `scene_plots`/diagnostics being off: `Scene.plot` and
+    `Scene.residual_image` do read it (`scene.py:1302,1553`). See
+    `docs/MEMORY_LIFETIMES.md`.
+  - [ ] Avoid the byte-order copies in `get_bg_and_ivar`. FITS is big-endian,
+    so a memory-mapped float32 image arrives as `>f4` and
+    `np.asarray(x, dtype=np.float32)` (`catalog.py:267-268`) copies rather than
+    views. The detection-band call transiently allocates ~12 GB on a full field
+    (`s`, `w`, two bool masks, `ivar_new`), undoing every memmap saving
+    upstream. The full-resolution arrays are only used by `_valid_block_means`,
+    a strided median sample and the final `w * scale`, all of which work on
+    `>f4` directly.
+  - [ ] Detection ivar as `(memmapped wht, scale, invalid mask)` rather than a
+    3.5 GB anonymous array: the calibration is one scalar plus a mask
+    (`catalog.py:369-372`). Composes with the on-demand upsampled band above --
+    with both, neither ivar array exists.
+  - [ ] Repair path: reopen the cached repaired mosaic as a memory map instead
+    of holding `rep["sci"]` anonymously. The cache file is already written at
+    `load_data:1599`.
+  - [ ] Fix or delete the `isfinite` sweep at `pipeline.py:3838-3842`. The
+    image branch is inverted (fires only when the image is `None`, then calls
+    `np.isfinite(None)`); the weight branch touches all 876 Mpx of `ivar_hi`
+    and duplicates the guard `load_data:1652-1664` already applied.
   - [ ] Timers inside `Scene.solve`. `56530f2` added the per-section wall-time
     breakdown for `run()`, which covers the outer split (templates, convolve,
     generate scenes, astrometry passes, final flux solve, residual). Still

--- a/docs/MEMORY_LIFETIMES.md
+++ b/docs/MEMORY_LIFETIMES.md
@@ -1,0 +1,222 @@
+# Array lifetimes in a pipeline run
+
+Audit note, 2026-08-13, written against `b7bec1e`; sections 4 to 6 revised
+after the five changes described in section 6 landed.
+
+Companion to `docs/SCALING_FIXED_MEMORY.md`, which proposes a decomposition that
+bounds the peak by the largest scene rather than by the field. This note is
+narrower: it inventories every full-field array a run allocates, records where
+each one is born and where it is last read, and separates the arrays that are
+still needed from the ones that are merely still referenced.
+
+Sizes are for the full-field MINERVA UDS grid: 34560 x 25344 = 876 Mpx, so
+3.5 GB per float32 plane and the same for an int32 segmentation map. Arrays on
+the fitted band's native grid are `3.5/k^2` GB, where
+`k = bin_factor_from_wcs(wcs[0], wcs[ifilt])` (`pipeline.py:3715`); for MIRI
+F770W against the NIRCam detection grid that is around 0.4 GB.
+
+## 1. Anonymous versus file-backed
+
+The distinction runs through the whole table, so it is worth stating once.
+
+A **memory-mapped** array is a window onto a file. Pages fault in on first
+touch, they are clean (identical to what is on disk), and the kernel can evict
+them at any time and re-read them later. Two processes mapping the same file
+share one set of pages. Such an array inflates RSS while resident but is not a
+hard claim on memory.
+
+An **anonymous** array — anything from `np.zeros`, `np.empty`, or arithmetic —
+has no file behind it. Its pages are dirty by definition, so the only relief
+under pressure is swap, and without swap the process is killed. It is not
+shared across processes.
+
+Two consequences matter here. First, a peak figure is not one number: the
+memory-mapped share is soft and the anonymous share is the ceiling. Second,
+`np.zeros` on a large shape is anonymous but not yet resident, because the
+kernel maps every page copy-on-write to a single shared zero page; reading is
+free and only writing faults a real page. That is why `_read_image` can
+allocate a full-mosaic shape and cost only the box it fills
+(`pipeline.py:381`), and why the code insists on `np.zeros` over
+`np.zeros_like` at `pipeline.py:1643` and `4046` — `zeros_like` is
+`empty_like` plus a memset, which writes every page and materialises the whole
+grid.
+
+Full-field reads hand over memory maps: `_read_image` with no box returns
+`np.asarray(hdu.data)` over an open `memmap=True` HDU (`pipeline.py:378`), and
+`as_label_array` returns an integer segmentation map untouched for exactly this
+reason (`utils.py:44-54`).
+
+## 2. Lifetime table
+
+| array | size (GB) | backing | born | last real read | released |
+|---|---|---|---|---|---|
+| `sci_hi` -> `images[0]` | 3.5 | memmap (copy-on-write over the repair patches) | `load_data:1524` | scene plots, `write_outputs` | no |
+| `segmap` | 3.5 | memmap (`>i4`); anon int32 (COSMOS float64) | `load_data:1530` | as above | no |
+| `wht_hi` (raw) | 3.5 | memmap | `_load_detection_ivar:1471` | inside `get_bg_and_ivar` | yes, on return |
+| `wht0` (raw, repair path) | 3.5 | memmap | `load_data:1565` | repair + cache write | yes, `del wht0:1609` |
+| `ivar_hi` = `weights[0]` | 3.5 | anon | `load_data:1656` | template build | yes, `run:3862` |
+| `wht_lo` (raw) | 3.5/k^2 | memmap | `load_data:1526` | bg/ivar, footprint cut | yes, scope exit |
+| `bg` (lo) | 3.5/k^2 | anon | `load_data:1633` | `load_data:1647` | yes, scope exit |
+| `ivar` = `weights[1]` | 3.5/k^2 | anon | `load_data:1633` | `_convolved_templates:3730` | **no** |
+| `sci_fit` = `images[1]` | 3.5/k^2 | anon | `load_data:1646` | `_convolved_templates:3730` | yes, rebound |
+| `weights_i` (upsampled ivar) | 3.5 | anon | `_convolved_templates` | `predicted_errors`, then the scene figures | yes, `_release_scene_weights` |
+| `images[1]` (upsampled sci) | 3.5 | anon | `_convolved_templates:3730` | `run:4057` | no |
+| `res` | 3.5 | **memmap over `f_residual`** | `_allocate_residual` | `write_outputs` | flushed; stays mapped |
+| hi-res template set | ~6 | anon | `_prepare_hi_templates` | `write_stamps` | no |
+| convolved template set | ~6 | anon | `_convolved_templates` | `write_stamps` | no |
+| `_data_unshifted` | ~6 | anon | astrometric passes | last shift applied | yes, in `run` |
+| model image | 3.5 | anon, cached | `_ModelImages` | diagnostics only | no |
+
+## 3. What the weight-map names actually are
+
+The four names that look like four weight maps for one band are two bands, and
+two of them are the same object.
+
+Detection band:
+
+```
+wht_hi      raw on disk, memmap, transient
+   |  get_bg_and_ivar:  ivar_new = w * scale, zeroed where invalid
+ivar_hi     anon, 3.5 GB
+   |  Pipeline.__init__(weights=[ivar_hi, ivar])
+weights[0]  the same array; a list slot, not a copy
+```
+
+Fitted band:
+
+```
+wht_lo      raw on disk, memmap, transient
+   |  _bg_and_ivar_boxed
+ivar  ==  weights[1]       anon, 3.5/k^2
+   |  _upsample_boxed (block replicate, weights x k^2)
+weights_i                  anon, 3.5
+```
+
+So one persistent weight array for the detection band and two for the fitted
+band. The calibration itself is a scalar and a mask (`catalog.py:369-372`):
+
+```python
+scale    = np.float32(1.0) / (sigma_true * sigma_true + np.float32(1e-30))
+ivar_new = np.multiply(w, scale, dtype=np.float32)
+np.copyto(ivar_new, np.float32(0.0), where=~valid)
+```
+
+Raw weights are read directly in only two places, both appropriate.
+`get_bg_and_ivar` reads them because they are what it calibrates.
+`repair_in_memory` reads them (`load_data:1590`) because `saturate.py` uses a
+weight map only as a validity mask, `wht > 0` (`saturate.py:108,222,281,394,462`),
+and as relative weights inside a stamp ring (`saturate.py:298,413`). Both are
+invariant under the global scale factor that calibration supplies, so an
+uncalibrated map is not a defect there. The ordering is forced the same way
+round: repair fills saturated cores and restores their weights, changing which
+pixels are valid, so the calibration must run on the repaired map. It does —
+`_load_detection_ivar(tmpl_hi, wht_hi=wht_hi_repaired)` at `load_data:1656`.
+
+Nothing on the fit side ever sees an uncalibrated weight.
+
+## 4. Dead but still referenced
+
+**`weights[1]`, 3.5/k^2 GB.** Dead once `_convolved_templates` has upsampled
+it. Retained deliberately: `source_products` handles a native-grid weight map
+as well as a reference-grid one, and rebins when it gets the former. Low
+priority at 0.4 GB, but it is the only true information duplicate left in the
+set — the same weights on two grids.
+
+**`images[1]` and `res`, 3.5 GB each.** Once the residual has been formed the
+pair is redundant with the model, which `_ModelImages` reconstructs as
+`images[i+1] - residuals[i]` on demand. Only one of the three is independent,
+and touching the model allocates and caches a third full plane. `res` is now
+file-backed, so the standing anonymous cost here is one plane, not two.
+
+**`weights_i`, 3.5 GB — fixed.** It used to survive to the end of the process:
+last read by `Templates.predicted_errors`, but held by every `Scene` through
+`self.all_scenes`, so 3.5 GB of dead weights sat through the stamp write. See
+section 6.
+
+## 5. Two costs that are not in the table
+
+**Byte-order copies inside `get_bg_and_ivar`.** FITS stores big-endian, so a
+memory-mapped float32 image arrives as `>f4`. The function opens with
+(`catalog.py:267-268`):
+
+```python
+s = np.asarray(sci, dtype=np.float32)
+w = np.asarray(wht, dtype=np.float32)
+```
+
+`>f4` and `float32` differ in byte order, so `asarray` copies rather than
+viewing. Confirmed directly: `np.asarray(np.zeros(4, dtype='>f4'),
+dtype=np.float32)` does not share memory with its input. The detection-band
+call on a full field therefore allocates 3.5 GB for `s`, 3.5 GB for `w`,
+0.88 GB each for `valid_w` and `valid`, and 3.5 GB for `ivar_new` — about
+12 GB transient inside one call, and every memory-map saving upstream is undone
+for its duration.
+
+The full-resolution arrays are used for `_valid_block_means`, a strided median
+sample, and the final `w * scale`. All three work on `>f4` directly, at a small
+arithmetic cost, so the copies are avoidable. Still open.
+
+**Template stamps are the largest anonymous term left.** Two full sets, ~6 GB
+each, alive together from the convolution to the stamp write. Bounding them is
+what `SCALING_FIXED_MEMORY.md` sections 3 and 8 are about; nothing here changes
+it.
+
+## 6. Changes made
+
+Five, in the order they run. All five are in `b7bec1e`'s successor; the suite
+is 362 passing.
+
+1. **The band weight map is released once nothing reads it.**
+   `_release_scene_weights` clears `Scene.weights` across a band. `run` calls it
+   straight after `predicted_errors` when the run draws no scene figures;
+   `write_outputs` calls it for everything else, after the figures and before
+   the stamps. `Scene.residual` and `Scene.plot` now null zero-weight pixels
+   only when the weights are still attached, and `Scene.solve` still refuses to
+   run without them — the intended failure, since the fit is over.
+
+2. **`write_outputs` writes the stamps last.** The stamps were written before
+   the scene figures, which is what forced the weights to stay alive through
+   the run's other memory peak. Reordering costs nothing (the products are
+   independent) and has a second benefit: a run that dies in the stamp write
+   now has its figures already on disk.
+
+3. **The residual accumulates into its own output file.** `_residual_memmap`
+   writes the FITS header, extends the file with `truncate` — leaving it
+   sparse, so a trial patch costs the patch — and maps the data section big
+   endian. `run` accumulates scene models into that map and subtracts in place;
+   `write_outputs` flushes instead of writing. API-driven runs and bands past
+   the first fall back to anonymous memory, as does any `OSError` on the map.
+
+4. **The repair replays its patch table onto a fresh map.**
+   `repair_saturated_holes` returns full-field copies of sci and segmap
+   (`saturate.py:733`), which the run then held for its whole length even
+   though they differ from the inputs only over the saturated cores.
+   `load_data` now re-reads both inputs and applies the patch table that
+   `_save_repair_cache` just computed, which is exactly what the cache-reuse
+   path already did — the two paths now produce the same representation
+   through the same helper, `_apply_repair_patches`. This is safe because
+   astropy maps a read-only HDU copy-on-write: the patched pages go private and
+   the input mosaic on disk is untouched, which
+   `test_repair_patches_do_not_write_through_to_the_input` pins.
+
+5. **`write_stamps` streams.** Offsets are computed from the shapes recorded in
+   the first pass, each dataset is created at its final size, and every stamp
+   is written straight into its slot. The old form collected every flattened
+   stamp in a list and concatenated — a full extra copy of every stamp, 12 GB
+   on a MINERVA field, at the very end of the run.
+
+Two smaller things went with them: the `isfinite` sweep at the top of `run` is
+gone (its image branch was inverted and unreachable, and its weight branch
+re-checked a guard `load_data` had already applied), and the stamps test now
+asserts pixel equality after a round trip, which is what would catch an offset
+error in the streaming write.
+
+## 7. Still open
+
+- The byte-order copies in `get_bg_and_ivar` (section 5).
+- ivar as `(memmapped wht, scale, invalid mask)` rather than a materialised
+  array, for both bands. Composes with the on-demand upsampled band in
+  `SCALING_FIXED_MEMORY.md` section 5 — with both, neither ivar array exists.
+- `weights[1]` after the upsample (section 4), which needs `source_products`
+  pointed at the reference-grid array.
+- The two template sets, the largest anonymous term left.

--- a/examples/canfar/arcify.py
+++ b/examples/canfar/arcify.py
@@ -35,10 +35,19 @@ log = logging.getLogger("arcify")
 
 from runroot import run_root
 
-# Run tree on arc; $CANFAR_RUN overrides the default home location.
-RUN, _ = run_root(Path(__file__).resolve().parent.parent.parent)
+REPO = Path(__file__).resolve().parent.parent.parent
 
 ARC = "arc:projects/minerva"
+
+
+def arc_run() -> str:
+    """Run tree on arc; ``$CANFAR_RUN`` overrides the default home location.
+
+    Resolved on demand rather than at import so that ``examples/ozstar``, which
+    reuses the arc indexing helpers below but has no CANFAR run tree, does not
+    have to set ``$CANFAR_USER`` to import this module.
+    """
+    return run_root(REPO)[0]
 
 # Config keys whose values are input file paths.
 PATH_KEYS = ["sci_hi", "wht_hi", "segmap", "catalog", "csv_hi", "sci_lo", "wht_lo", "csv_lo"]
@@ -132,6 +141,7 @@ def arcify(cfg_path: Path, index: dict[str, str], out_dir: Path,
     is kept — only the radius is overridden — so the patch stays where the
     source config put it.
     """
+    run = arc_run()
     raw = re.sub(r"(?m)^\s*#.*$", "", cfg_path.read_text())
     cfg = json.loads(raw)
     name = cfg.get("name", cfg_path.stem) + suffix
@@ -162,17 +172,17 @@ def arcify(cfg_path: Path, index: dict[str, str], out_dir: Path,
         if gzipped:
             # decompress once into the run's data dir, under the name the
             # config expects (which also fixes the f770 -> f770w spelling)
-            cfg[key] = f"{RUN}/data/{basename}"
+            cfg[key] = f"{run}/data/{basename}"
             stage.append((arc_path, basename))
         elif Path(arc_path).name != basename:
             # uncompressed but misnamed: copy rather than decompress
-            cfg[key] = f"{RUN}/data/{basename}"
+            cfg[key] = f"{run}/data/{basename}"
             stage.append((arc_path, basename))
         else:
             cfg[key] = arc_path  # read in place, no copy
 
-    cfg["psf_dir"] = f"{RUN}/PSF"
-    cfg["out_dir"] = f"{RUN}/out/{name}"
+    cfg["psf_dir"] = f"{run}/PSF"
+    cfg["out_dir"] = f"{run}/out/{name}"
 
     cfg_out = out_dir / f"{name}_canfar.json"
     cfg_out.write_text(json.dumps(cfg, indent=2) + "\n")

--- a/examples/make_minerva_configs.py
+++ b/examples/make_minerva_configs.py
@@ -284,6 +284,12 @@ def band_configs(rel: Release) -> list[dict]:
                 # MIRI bands want more, once the NIRCam grids are regenerated
                 # at a larger FOV.
                 "psf_size": 4.0,
+                # Stated explicitly rather than left to the default: these
+                # exposure lists span up to four years across a dozen or more
+                # epochs, the grids are MJD-tagged and looked up by nearest
+                # date, and any mode that collapses the list ("modal" returns
+                # a single date) throws that resolution away invisibly.
+                "psf_date_mode": "all",
                 "psf_blur_fwhm": "default",
                 "footprint_filter": True,
                 # In-memory saturation repair at load time: fill the wht=0

--- a/examples/ozstar/MANUAL.md
+++ b/examples/ozstar/MANUAL.md
@@ -1,0 +1,262 @@
+# Running mophongo on OzStar, from zero
+
+A start-to-finish guide, ending in a completed `uds_f770w` run on the current
+MINERVA release. It assumes an OzStar account and a CADC account; the data live
+on CANFAR and the compute is at Swinburne, so both are needed.
+
+Placeholders: `<user>` is your OzStar username, `<cadc>` your CADC username,
+`<project>` your group allocation (`oz030` here).
+
+---
+
+## Part 1 — Accounts and access
+
+### 1.1 OzStar
+
+Access is through Swinburne's supercomputing team; you need a login on
+`nt.swin.edu.au` and membership of a project with an allocation under `/fred`.
+Check both:
+
+```bash
+ssh <user>@nt.swin.edu.au
+ls -d /fred/<project>/<user>          # your directory in the allocation
+lfs quota -g <project> /fred          # what is left of the 10 TB
+```
+
+Put an ssh key in place (`ssh-copy-id`) — the toolkit here runs many short ssh
+commands and a password prompt on each is unworkable.
+
+### 1.2 CADC and the MINERVA group
+
+The inputs are copied from `arc:projects/minerva` on CANFAR, which needs a CADC
+account that is a member of the `minerva` group. `../canfar/MANUAL.md` Part 1
+covers getting both. You do not need Science Portal access for this — only read
+access to the data.
+
+Verify locally:
+
+```bash
+~/.venvs/canfar/bin/vls arc:projects/minerva/uds/mosaics/miri/m3.1
+```
+
+If that lists files, you are set. If `vls` is missing:
+
+```bash
+python -m venv ~/.venvs/canfar
+~/.venvs/canfar/bin/pip install vos cadcutils
+```
+
+---
+
+## Part 2 — One-time setup
+
+### 2.1 Environment
+
+```bash
+cd mophongo/examples/ozstar
+export OZSTAR_USER=<user>
+export OZSTAR_PROJECT=<project>          # default oz030
+P=~/.venvs/canfar/bin/python
+```
+
+The run tree defaults to `/fred/<project>/<user>/mophongo/run`; `OZSTAR_RUN`
+overrides it. It must be under `/fred` — `/home` has a 20 GB quota and one
+field's staged inputs are about 15 GB.
+
+### 2.2 Certificate
+
+```bash
+../../scratch/canfar/canfar-cert.sh      # prompts for the CADC password
+$P submit.py cert                        # copies it to OzStar
+```
+
+The certificate is valid for ten days and the staging job authenticates with it
+and nothing else. A campaign that outlives one needs both commands again; the
+symptom otherwise is a staging job failing immediately on every file.
+
+### 2.3 The run tree
+
+```bash
+$P submit.py push        # job scripts
+$P submit.py setup       # clone mophongo, build the two venvs
+```
+
+`setup` runs on the login node, which is the only place with both internet and
+the module system, and is idempotent. It builds:
+
+- `venv` — mophongo and its dependencies, from the `python/3.12.3` module. The
+  fits use this. Its `bin/python` is a symlink into the module tree, so the
+  same modules have to be loaded to use it.
+- `venv-vos` — the CADC transfer tools, from `/usr/bin/python3`. Staging uses
+  this, because it runs on the datamover partition and those nodes have no
+  `/apps` module tree at all.
+
+It also checks the STPSF reference data (about 250 MB, at
+`/fred/<project>/<user>/stpsf-data` by default, `OZSTAR_STPSF` to override).
+Compute nodes have no internet, so a run that has to build a PSF grid cannot
+fetch this itself: it has to be there first. `setup` prints the download
+command if it is missing.
+
+### 2.4 PSF grids
+
+Grids cannot be built inside a fit here, the way they are on CANFAR. Building
+one makes `stpsf` query MAST for the wavefront OPD at each exposure's date, and
+compute nodes have no DNS — the fit dies in half a minute with
+`NameResolutionError: Failed to resolve 'mast.stsci.edu'`. The login node is
+the only machine with both internet and the module stack.
+
+```bash
+$P submit.py push --psf                     # grids that already exist locally
+$P submit.py psf uds_f770w cosmos_f770w     # build the rest on the login node
+```
+
+The two compose — the build skips any grid whose file already exists — so ship
+what you have and build the gaps. Do not run them concurrently: scp writes
+straight to the destination name, and a half-written grid would be skipped by
+the build and later read as a truncated FITS.
+
+Once `$OZSTAR_RUN/PSF` is populated, fits need no network at all.
+
+---
+
+## Part 3 — One band, end to end
+
+### 3.1 Rewrite the config
+
+```bash
+$P ozify.py ../minerva/uds_f770w.json
+```
+
+writes `uds_f770w_ozstar.json` — the same config with every input path pointed
+at `$OZSTAR_RUN/data` — and `uds_f770w_stage.tsv`, the list of eight files to
+copy from arc.
+
+For a first pass use a small patch, which takes minutes rather than the better
+part of an hour and reads only its own pixels off disk:
+
+```bash
+$P ozify.py ../minerva/uds_f770w.json --r-trial 1.5 --suffix _trial
+```
+
+### 3.2 Stage the inputs
+
+```bash
+$P submit.py push  uds_f770w_trial
+$P submit.py stage uds_f770w_trial
+```
+
+This submits a job to the `datamover` partition, which copies each file from
+arc and decompresses the gzipped ones. About 15 GB per field; UDS takes tens of
+minutes. Files already present are skipped, so the job can be resubmitted after
+a timeout and will resume.
+
+Pass several bands of a field in one call and they share a single job — bands
+of a field share the F444W mosaic, its weight map and the segmap, and there is
+no point copying several GB more than once:
+
+```bash
+$P submit.py stage uds_f770w uds_f1280w uds_f1500w uds_f1800w
+```
+
+### 3.3 Run
+
+`stage` prints its job id; hang the fit off it so it cannot start on
+half-copied data:
+
+```bash
+$P submit.py run uds_f770w_trial --after <jobid> --time 06:00:00
+```
+
+or without `--after` if the inputs are already there. The defaults are 16 cores,
+64 GB and 24 hours.
+
+The first run of a band with no PSF grids builds them, which takes an extra
+half hour or so; they are cached in `$OZSTAR_RUN/PSF` and every later run of
+that field reuses them.
+
+### 3.4 Watch it
+
+```bash
+$P submit.py status                  # the queue
+$P submit.py status --done 2026-08-13   # finished jobs, with MaxRSS
+$P submit.py logs uds_f770w_trial    # tail the newest matching log
+```
+
+### 3.5 Results
+
+```bash
+$P submit.py fetch uds_f770w_trial   # fit table, scene catalog, log
+```
+
+The rest stays on `/fred` — a full field writes tens of GB of residual and
+stamps:
+
+| file | what |
+|---|---|
+| `<name>_fit_table.fits` | the photometry: `flux_<i>`, `flux_<i>_total`, `err_<i>` |
+| `<name>_residual.fits` | data minus model, the first thing to check |
+| `scenes/<name>_scene_*.png` | per-scene diagnostics |
+| `<name>_kernel.fits`, `<name>_psf_*.fits` | PSF and kernel maps |
+| `<name>.log` | the run log |
+
+---
+
+## Part 4 — A whole campaign
+
+```bash
+$P campaign.py --dry-run                        # the plan
+$P campaign.py                                  # trial patches, every config
+$P campaign.py --r-trial 0 --suffix _v1.0b      # the full-field release
+./release_v1.0b.sh                              # the same, arguments filled in
+```
+
+One command rewrites all 17 configs, uploads them, builds the environment,
+submits one staging job per field and one fit per config, and wires the
+dependencies. It returns immediately: everything afterwards is SLURM's.
+
+Two orderings are encoded and worth knowing:
+
+- each field's fits wait on that field's staging with `afterok`. A failed stage
+  therefore leaves its fits queued as `DependencyNeverSatisfied` until SLURM
+  cancels them, which is what you want and looks like jobs vanishing if you do
+  not expect it;
+- a field whose PSF grids do not exist yet sends one band ahead of the rest,
+  because with no grid matching the config pattern the pipeline builds one, and
+  several bands of a field would otherwise build the same grids concurrently
+  into a single `psf_dir`.
+
+To stop everything:
+
+```bash
+$P submit.py cancel        # by job-name prefix, not the whole account
+```
+
+To ship a code change mid-campaign:
+
+```bash
+$P submit.py sync          # git pull; the venv and running jobs are untouched
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause and fix |
+|---|---|
+| `Lmod has detected the following error: Parent modules not loaded` | Lmod is hierarchical: `python/3.12.3` needs `gcccore/13.3.0` first. The error names the parent |
+| Every `vcp` dies in `ImportError: libssl.so.1.1` | the EasyBuild shim on `PYTHONPATH` shadowed the venv. The job scripts `unset PYTHONPATH`; if you run something by hand, do the same |
+| Staging job runs on a compute node and fails on every file | `--partition=datamover` was only in a `#SBATCH` directive, which a site plugin overrides. It has to be on the `sbatch` command line |
+| `Memory specification can not be satisfied` for a stage job | datamover nodes advertise 4000 MB, so `--mem=4g` (4096) is impossible. Ask for 3 GB |
+| `bad interpreter: .../venv/bin/python: No such file` on a datamover node | those nodes have no `/apps`, so the module python is not there. Use `venv-vos` |
+| Fits stuck in `PENDING (DependencyNeverSatisfied)` | their staging job failed. Read its log, fix, resubmit staging, resubmit the fits |
+| Job dies with no Python traceback | out of memory. Resubmit with `--mem 96` or more; the nodes hold 191-256 GB |
+| `stpsf` cannot find its data | `STPSF_PATH`. Compute nodes have no internet, so it must already be on `/fred` |
+| Fit dies in 30 s with `NameResolutionError: Failed to resolve 'mast.stsci.edu'` | it tried to build a PSF grid, and stpsf resolves each exposure's OPD by querying MAST. Build the grids first: `submit.py push --psf` and/or `submit.py psf <configs>` (Part 2.4) |
+| `No such file or directory` for an input | the staging job has not finished, or the config was not re-pushed after `ozify.py` |
+
+## Reference
+
+- Cluster reference (partitions, modules, quotas, SLURM): `~/.claude/ozstar.md`
+- The CANFAR equivalent of this toolkit: `../canfar/README.md`, `../canfar/MANUAL.md`
+- What the MINERVA products are and where: `MINERVA/data/00WHERE`
+- Getting data off CANFAR: `MINERVA/data/00CANFAR`

--- a/examples/ozstar/README.md
+++ b/examples/ozstar/README.md
@@ -1,0 +1,190 @@
+# Running mophongo on OzStar
+
+The counterpart of `../canfar`, for Swinburne's OzStar / Ngarrgu Tindebeek.
+The difference that shapes everything here is that OzStar has no view of the
+MINERVA release: on CANFAR `/arc` is mounted inside the container and most
+inputs are read in place, while here every file a config names is copied from
+CANFAR onto `/fred` first. What you get in exchange is a real batch system —
+runs are `sbatch` jobs chained with `--dependency`, so a campaign is one
+dependency graph submitted in a single command and nothing afterwards depends
+on the laptop staying awake.
+
+## Layout
+
+```
+$OZSTAR_RUN/                        default /fred/<project>/<user>/mophongo/run
+├── venv/                  mophongo, built with the module python
+├── venv-vos/              CADC transfer tools, built with /usr/bin/python3
+├── mophongo/              the GitHub clone
+├── PSF/                   MJD-tagged ePSF grids, shared by every run
+├── jobs/                  setup_env.sh, stage.sh, run.slurm, ...
+├── data/                  staged inputs, shared between the bands of a field
+├── logs/                  SLURM job output
+├── <name>_ozstar.json     rewritten configs
+├── <name>_stage.tsv       per-config copy lists
+└── out/<name>/            run outputs
+```
+
+Two venvs, because the two kinds of node do not share a software stack. The
+datamover nodes, which are the only ones that can reach CANFAR, have no `/apps`
+module tree at all, so the module python the science venv is built against does
+not exist there; `venv-vos` is built from the OS python, which is on every node.
+
+Everything lives on `/fred`. `/home` has a 20 GB quota and a single field's
+staged inputs are about 15 GB.
+
+## Prerequisites
+
+```bash
+export OZSTAR_USER=<your cluster username>     # ssh key access to nt.swin.edu.au
+../../scratch/canfar/canfar-cert.sh            # CADC proxy certificate, 10 days
+```
+
+`ozify.py` needs the `vos` client locally, which lives in `~/.venvs/canfar`:
+
+```bash
+P=~/.venvs/canfar/bin/python
+```
+
+## Everything at once
+
+```bash
+$P campaign.py                        # every config in ../minerva, trial patches
+$P campaign.py --fields uds           # one field
+$P campaign.py --r-trial 0 --suffix _v1.0b     # the full-field release
+$P campaign.py --dry-run              # print the plan, submit nothing
+```
+
+It rewrites the configs, uploads them, builds the environment, submits one
+staging job per field and then one fit per config, wiring the dependencies:
+each field's fits wait on that field's staging, and a field with no PSF grids
+yet sends one band ahead of the others to build them. `release_v1.0b.sh` is the
+release recipe with the arguments already filled in.
+
+Then watch with `submit.py status` / `logs` / `fetch`.
+
+## Step by step
+
+The same thing done by hand:
+
+```bash
+$P submit.py cert                              # certificate -> OzStar
+$P submit.py setup                             # clone mophongo, build the venvs
+$P ozify.py ../minerva/uds_f770w.json          # rewrite paths, list the inputs
+$P submit.py push uds_f770w                    # upload config and job scripts
+$P submit.py stage uds_f770w                   # datamover job: arc -> /fred/data
+$P submit.py run   uds_f770w --after <jobid>   # the fit
+$P submit.py fetch uds_f770w                   # bring the small outputs home
+```
+
+A cheap smoke run on a small patch, without touching the source config:
+
+```bash
+$P ozify.py ../minerva/uds_f770w.json --r-trial 1.5 --suffix _trial
+$P submit.py push uds_f770w_trial
+$P submit.py run  uds_f770w_trial --time 06:00:00
+```
+
+To ship a code change into a campaign that is already set up, `submit.py sync`
+does a `git pull` in the run tree and leaves the venv alone. mophongo is
+installed editable, so that is enough. Jobs already running keep the code they
+imported; queued ones pick it up when they start.
+
+## What ozify.py does
+
+It indexes the relevant `arc:projects/minerva` subtrees — reusing
+`../canfar/arcify.py`, since finding the files is the same problem on both
+platforms — and then rewrites every input path in a local `RunConfig` to
+`$OZSTAR_RUN/data/<basename>`, writing the copy list to `<name>_stage.tsv`.
+Unlike the CANFAR version it lists *every* input, compressed or not: nothing
+can be read in place.
+
+Two mismatches it resolves on the way: most files on arc are gzipped and the
+pipeline wants plain FITS, so `stage.sh` decompresses them; and MIRI frame
+tables ship as `*_f770_wcs.csv` while the filter parser expects `f770w`, so the
+staged copy carries the expected name.
+
+## PSF grids must be built on the login node
+
+This is the one structural difference from CANFAR, where `psf_autobuild` just
+works inside a run. `PSFFactory` generates MJD-tagged grids, and for each
+exposure date `stpsf` resolves the wavefront OPD by querying MAST
+(`load_wss_opd_by_date` → `mast_wss_opds_around_date_query`). There is no
+offline path for that query, and it happens before any PSF is computed.
+
+So a run that has to build a grid dies seconds after starting, with
+`NameResolutionError: Failed to resolve 'mast.stsci.edu'`, on any node without
+DNS — which is every compute node. Datamover nodes do have internet, but no
+`/apps` module tree, so mophongo cannot run there either. The login node is the
+only machine with both.
+
+Two ways to get the grids in place, and they compose — the build skips any grid
+whose file already exists:
+
+```bash
+$P submit.py push --psf                  # ship grids that exist on the laptop
+$P submit.py psf uds_f770w cosmos_f770w  # build the rest on the login node
+```
+
+Copying is much cheaper than rebuilding when the grids are already local, so
+`push --psf` first and let `psf` fill the gaps. Do not run the two at once:
+scp writes straight to the destination name, the build skips a filename that
+exists, and a half-written grid then reaches a fit as a truncated FITS.
+
+Once `$OZSTAR_RUN/PSF` is populated the fits need no network at all, which is
+the point — the grids are cached there and every later run reads them.
+
+## Resources
+
+16 cores and 64 GB per fit, the default. The fitting path is largely serial, so
+the cores buy threaded BLAS and FFTs rather than a linear speed-up; the memory
+is what matters. No partition is requested, so the scheduler picks — skylake
+(36 cores / 191 GB) and milan (64 / 256) both hold this comfortably, and
+constraining the choice only lengthens the queue.
+
+Staging is different: it must be `--partition=datamover`, and that has to be
+given on the `sbatch` command line. A site plugin reassigns the partition of a
+job that names it in a `#SBATCH` directive alone, and the job then lands on a
+compute node with no route to CANFAR — the symptom is `vcp` failing on every
+file at once. Those nodes advertise 4000 MB, so `--mem=4g` (4096) is refused as
+an impossible node configuration; the script asks for 3 GB.
+
+## Notes
+
+- Compute nodes have no internet. Anything that must be downloaded — the
+  mophongo clone, pip wheels, the STPSF reference data — is fetched on the
+  login node by `setup`, and the inputs by a datamover job.
+- The venv's `bin/python` is a symlink into the module tree, so the same
+  modules must be loaded to use it. Every job script loads the same
+  `PYMODULES`; changing them means rebuilding the venv. Lmod here is
+  hierarchical, so `python/3.12.3` is invisible until `gcccore/13.3.0` is
+  loaded — the error names the parent, which is the only clue you get.
+- The python module puts an EasyBuild shim ahead of the venv on `sys.path`.
+  On some nodes that resolved `cryptography` to a build for another python and
+  failed on a missing `libssl.so.1.1`, which surfaces as every `vcp` dying in
+  an import. The job scripts `unset PYTHONPATH` after loading modules; the venv
+  is self-contained and does not need it.
+- `--dependency=afterok` means a failed stage leaves its fits queued as
+  `DependencyNeverSatisfied` until SLURM cancels them. That is the wanted
+  behaviour — no fit starts on half-copied data — but it reads as jobs silently
+  disappearing if you do not know it.
+- Staging is per field, not per band: the bands of a field share the F444W
+  mosaic, its weight map and the segmap. Fields are independent, so their
+  staging jobs run concurrently, one per datamover node.
+- A cancelled staging job leaves `.<name>.<pid>` temporaries of several GB.
+  The next staging job for that field sweeps the ones over six hours old;
+  fresher ones are left alone because a concurrent job's temporaries look the
+  same.
+- `submit.py cancel` cancels by job-name prefix (`moph`), not the whole
+  account, so it will not touch your other work on the cluster.
+- Outputs are large. A 3 arcmin patch of UDS writes 8.4 GB, of which 4.2 GB is
+  `stamps.fits` and 3.5 GB the residual; a full field scales with the source
+  count, roughly 8x. Set `save_stamps` or `scene_plots` false in the config
+  when the diagnostics are not wanted, and watch `lfs quota -g <project> /fred`.
+- The PSF and kernel maps are cached in `out_dir` and do not depend on the trial
+  patch, so `submit.py seed <patch-run>:<full-run>` links them across and saves
+  about half an hour per band.
+
+For the CANFAR equivalent and the reasoning behind the shared parts, see
+`../canfar/README.md`. Cluster-level reference (partitions, modules, quotas) is
+in `~/.claude/ozstar.md`.

--- a/examples/ozstar/campaign.py
+++ b/examples/ozstar/campaign.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python
+"""Launch a whole mophongo campaign on OzStar in one command.
+
+Wraps the individual steps - config rewrite, upload, environment, staging, run
+- so every band of every MINERVA field can be started at once::
+
+    python campaign.py                          # every config in ../minerva
+    python campaign.py --fields uds             # only that field
+    python campaign.py --bands f770w            # only that band
+    python campaign.py --from stage             # source and configs already up
+    python campaign.py --dry-run                # print the plan, submit nothing
+
+The whole campaign is submitted as one SLURM dependency graph and returns
+immediately: staging a field is a ``datamover`` job, and that field's fits wait
+on it with ``--dependency=afterok``. Nothing afterwards depends on the laptop.
+
+Three things this encodes:
+
+* staging is one job per *field*, not per band, because the bands of a field
+  share the F444W mosaic, its weight map and the segmap;
+* a field whose PSF grids are missing runs one band alone first, because with
+  no grid matching the config pattern the pipeline builds one, and several
+  bands of a field would build the same grids concurrently into one
+  ``psf_dir``;
+* ``afterok`` means a failed stage leaves its fits queued as
+  ``DependencyNeverSatisfied`` until SLURM cancels them - which is the wanted
+  behaviour, but reads as jobs silently disappearing if you do not know it.
+
+Progress afterwards: ``submit.py status``, ``submit.py logs <name>``,
+``submit.py fetch <name>``.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import ozroot
+import submit
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+log = logging.getLogger("campaign")
+
+HERE = Path(__file__).resolve().parent
+PYTHON = sys.executable
+STEPS = ["ozify", "push", "setup", "seed", "stage", "run"]
+
+#: A per-band run config is named ``<field>_f<band>w.json``. The directory also
+#: holds inputs that are not RunConfigs (``minerva_sed_fields.json``), which
+#: would fail deep inside ozify with a confusing key error.
+BAND_CONFIG = re.compile(r"^[a-z0-9]+_f\d+w$")
+
+
+def run_step(args: list[str], dry: bool) -> None:
+    """Run one toolkit command, stopping the campaign if it fails."""
+    printable = " ".join(str(a) for a in args)
+    log.info("+ %s", printable)
+    if dry:
+        return
+    result = subprocess.run([PYTHON, *args], cwd=HERE)
+    if result.returncode != 0:
+        raise SystemExit(f"failed: {printable}")
+
+
+def configs_for(fields: list[str] | None, bands: list[str] | None) -> list[Path]:
+    """The local MINERVA per-band configs to run."""
+    found = [p for p in sorted((HERE.parent / "minerva").glob("*.json"))
+             if BAND_CONFIG.match(p.stem)]
+    if fields:
+        found = [p for p in found if p.stem.split("_")[0] in fields]
+    if bands:
+        found = [p for p in found if p.stem.split("_")[1] in bands]
+    if not found:
+        raise SystemExit("no configs matched")
+    return found
+
+
+def psf_names_on_fred() -> list[str]:
+    """Grid filenames already in the run tree's ``PSF/`` directory.
+
+    Only the remote listing counts. Unlike the CANFAR toolkit, nothing here
+    uploads local grids - ``setup`` clones the source and the grids are built
+    on the node from the STPSF reference data - so a grid on the laptop says
+    nothing about what the run will find.
+
+    A missing or unreadable directory lists as empty, which costs one leader
+    run and nothing else.
+    """
+    return submit.ssh(f"ls {ozroot.run_root()}/PSF 2>/dev/null", check=False).split()
+
+
+def has_shared_grids(cfg_path: Path, names: list[str]) -> bool:
+    """Whether the field's *hi-res* PSF grids already exist on /fred.
+
+    Only ``pattern_hi`` matters. Every band of a field matches the same F444W
+    grids, so several bands building those at once write the same filenames
+    into one ``psf_dir``. The per-band MIRI grids of ``pattern_lo`` have
+    distinct names and can be built concurrently without racing.
+
+    With ``repair_saturated`` the 30" halo grids are shared the same way -
+    every band of the field derives the same ``_FOV30_GRID1_OS4`` names from
+    ``pattern_hi`` - so they count here too.
+    """
+    cfg = json.loads(re.sub(r"(?m)^\s*#.*$", "", cfg_path.read_text()))
+    pattern = cfg.get("pattern_hi")
+    if not pattern:
+        return True
+    patterns = [pattern]
+    if cfg.get("repair_saturated"):
+        # same derivation as Pipeline._repair_halo_pattern
+        patterns.append(cfg.get("repair_psf_pattern")
+                        or re.sub(r"_MJD.*$", r"_MJD\\d+_FOV30_GRID1_OS4", pattern))
+    return all(any(re.search(pat, n) for n in names) for pat in patterns)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--fields", nargs="+", help="restrict to these, e.g. uds cosmos")
+    ap.add_argument("--bands", nargs="+", help="restrict to these, e.g. f770w")
+    ap.add_argument("--from", dest="start", choices=STEPS, default="ozify",
+                    help="skip everything before this step")
+    ap.add_argument("--skip", nargs="+", choices=STEPS, default=[],
+                    help="drop these steps from the middle of the chain, e.g. "
+                         "--skip stage when the inputs are already on /fred")
+    ap.add_argument("--cores", type=int, default=16)
+    ap.add_argument("--mem", type=int, default=64, help="GB per run")
+    ap.add_argument("--time", default="24:00:00", help="walltime per run")
+    ap.add_argument("--stage-time", default="24:00:00", help="walltime per stage job")
+    ap.add_argument("--branch", default="main", help="mophongo branch to clone")
+    ap.add_argument("--r-trial", type=float, default=None,
+                    help="override the trial radius in arcmin; 0 runs the full field")
+    ap.add_argument("--suffix", default="",
+                    help="append to every run name, e.g. _trial, to keep outputs separate")
+    ap.add_argument("--seed-from", default=None, metavar="SUFFIX",
+                    help="seed PSF/kernel caches from the runs with this suffix "
+                         "(use '' for the unsuffixed ones); skips rebuilding them")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    todo = [s for s in STEPS[STEPS.index(args.start):] if s not in args.skip]
+    cfgs = configs_for(args.fields, args.bands)
+    names = [c.stem + args.suffix for c in cfgs]
+    log.info("campaign over %d config(s): %s", len(names), ", ".join(names))
+    log.info("run tree %s on %s", ozroot.run_root(), ozroot.ssh_target())
+
+    if "ozify" in todo:
+        ozify = ["ozify.py", *[str(c) for c in cfgs]]
+        if args.r_trial is not None:
+            ozify += ["--r-trial", str(args.r_trial)]
+        if args.suffix:
+            ozify += ["--suffix", args.suffix]
+        run_step(ozify, args.dry_run)
+    if "push" in todo:
+        log.info("+ submit.push(%d configs)", len(names))
+        if not args.dry_run:
+            submit.push(names)
+    if "setup" in todo:
+        run_step(["submit.py", "setup", "--branch", args.branch], args.dry_run)
+    if "seed" in todo and args.seed_from is not None:
+        pairs = [f"{c.stem}{args.seed_from}:{c.stem}{args.suffix}" for c in cfgs]
+        run_step(["submit.py", "seed", *pairs], args.dry_run)
+
+    stage_ids: dict[str, str] = {}
+    if "stage" in todo:
+        for field, bands in submit.by_field(names).items():
+            if args.dry_run:
+                log.info("+ stage %s: %s", field, " ".join(bands))
+                continue
+            stage_ids[field] = submit.stage(bands, walltime=args.stage_time)[0]
+    if "run" not in todo:
+        return
+
+    on_fred = [] if args.dry_run else psf_names_on_fred()
+    for field, bands in submit.by_field(names).items():
+        cfg = next(c for c, n in zip(cfgs, names) if n == bands[0])
+        dep = stage_ids.get(field)
+        leader_needed = not has_shared_grids(cfg, on_fred) and len(bands) > 1
+        if args.dry_run:
+            log.info("+ run %s%s%s", " ".join(bands),
+                     f" after {dep or 'nothing'}",
+                     " (first band alone: no shared PSF grids yet)" if leader_needed else "")
+            continue
+        if leader_needed:
+            log.info("%s: shared grids missing (F444W or the 30\" halo), "
+                     "running %s alone to build them", field, bands[0])
+            leader = submit.run([bands[0]], after=dep, cores=args.cores,
+                                mem=args.mem, walltime=args.time)[0]
+            submit.run(bands[1:], after=leader, cores=args.cores,
+                       mem=args.mem, walltime=args.time)
+        else:
+            submit.run(bands, after=dep, cores=args.cores, mem=args.mem,
+                       walltime=args.time)
+
+    log.info("submitted. watch with:  python submit.py status")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/ozstar/jobs/build_psfs.py
+++ b/examples/ozstar/jobs/build_psfs.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+"""Pre-build every ePSF grid a config's fit will ask for.
+
+Run on the login node, which is the only machine with both internet and the
+module stack. Compute nodes cannot do this: ``PSFFactory`` builds MJD-tagged
+grids and ``stpsf`` resolves each exposure date to a wavefront OPD by querying
+MAST, and a compute node has neither DNS nor a route.
+
+Three grid families, and the last two are why this exists rather than a bare
+``python -m mophongo.pipeline <cfg> psfs``:
+
+* ``pattern_hi``  - the F444W photometry grids, shared by every band of a field;
+* ``pattern_lo``  - the band's MIRI grids;
+* the 30" halo grids, when ``repair_saturated`` is on. Saturation repair runs
+  inside ``load_data``, not ``build_psfs``, so the ``psfs`` step never touches
+  them - and the pipeline's own fallback catches ``FileNotFoundError`` and
+  ``ValueError`` only, while a MAST lookup on a sealed node raises
+  ``ConnectionError``. A fit would therefore die rather than degrade.
+
+``PSFFactory`` is called directly, rather than through the pipeline's
+autobuild, for two reasons. It takes ``date_mode`` explicitly, so the grids are
+per-date whatever the deployed mophongo defaults to; and the autobuild only
+fires when *nothing* matches the pattern, so a band left holding one grid from
+an earlier single-date build would never gain the rest. The factory itself
+skips files that already exist, so re-running is cheap and additive.
+
+    python build_psfs.py [--date-mode all] <run>/<name>_ozstar.json [more ...]
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+import time
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+log = logging.getLogger("build_psfs")
+
+
+def halo_pattern(pattern_hi: str) -> str:
+    """The 30" halo pattern derived from ``pattern_hi``.
+
+    Mirrors ``Pipeline._repair_halo_pattern``: keep prefix/detector/filter,
+    swap the sampling tail for the single-position 30" layout.
+    """
+    from mophongo.pipeline import _PSF_PATTERN_RE
+
+    m = _PSF_PATTERN_RE.match(pattern_hi.strip())
+    if m is None:
+        return ""
+    return (f"{m.group('prefix')}_{m.group('det')}_{m.group('filt')}"
+            r"_MJD\d+_FOV30_GRID1_OS4")
+
+
+def build_for_pattern(pattern: str, csv: str, psf_dir: str, date_mode: str,
+                      fov_default: float | None) -> int:
+    """Build every grid implied by ``pattern`` and the exposure list."""
+    from mophongo.pipeline import _psf_factory_kwargs
+    from mophongo.psf_factory import PSFFactory, dates_from_csv
+
+    kw = _psf_factory_kwargs(pattern)          # same derivation the fit uses,
+    fov = kw.pop("fov_arcsec", fov_default)    # so the filenames match
+    want = len(dates_from_csv(csv, mode=date_mode))
+    before = len(list(Path(psf_dir).glob("*.fits")))
+    log.info("  %s: %d date(s) from %s", pattern, want, Path(csv).name)
+    PSFFactory(outdir=psf_dir, fov_arcsec=fov, date_mode=date_mode,
+               **kw).from_csv(csv, save=True)
+    return len(list(Path(psf_dir).glob("*.fits"))) - before
+
+
+def build_one(cfg_path: Path, date_mode: str) -> int:
+    """Build the hi, lo and halo grids for one config; return grids added."""
+    from mophongo.pipeline import RunConfig
+
+    cfg = RunConfig.from_json(str(cfg_path))
+    psf_dir = str(cfg.psf_dir)
+    Path(psf_dir).mkdir(parents=True, exist_ok=True)
+    added = 0
+    for pattern, csv in ((cfg.pattern_hi, cfg.csv_hi), (cfg.pattern_lo, cfg.csv_lo)):
+        if pattern:
+            added += build_for_pattern(pattern, str(csv), psf_dir, date_mode,
+                                       cfg.psf_fov_arcsec)
+    if getattr(cfg, "repair_saturated", False):
+        pat = cfg.repair_psf_pattern or halo_pattern(cfg.pattern_hi)
+        if pat and pat != cfg.pattern_hi:
+            added += build_for_pattern(pat, str(cfg.csv_hi), psf_dir, date_mode,
+                                       cfg.psf_fov_arcsec)
+    return added
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("configs", nargs="+", type=Path)
+    ap.add_argument("--date-mode", default="all",
+                    help="one grid per unique integer MJD by default; see "
+                         "psf_factory.dates_from_csv")
+    args = ap.parse_args()
+
+    for i, cfg_path in enumerate(args.configs, 1):
+        start = time.time()
+        log.info("=== [%d/%d] %s", i, len(args.configs), cfg_path.name)
+        try:
+            added = build_one(cfg_path, args.date_mode)
+        except Exception as exc:  # noqa: BLE001 - one bad config must not stop the rest
+            log.error("FAILED %s: %s: %s", cfg_path.name, type(exc).__name__, exc)
+            continue
+        log.info("=== [%d/%d] %s done in %.1f min, +%d grid(s)",
+                 i, len(args.configs), cfg_path.name, (time.time() - start) / 60, added)
+    log.info("PSF_BUILD_DONE")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/ozstar/jobs/build_psfs.sh
+++ b/examples/ozstar/jobs/build_psfs.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Build a config's ePSF grids into $RUN/PSF, on the login node, detached.
+#
+# This cannot be a SLURM job. PSFFactory generates MJD-tagged grids, and stpsf
+# resolves each exposure's date to a wavefront OPD by querying MAST
+# (load_wss_opd_by_date -> mast_wss_opds_around_date_query). There is no offline
+# path for that query, and compute nodes have neither DNS nor a route: the run
+# dies in NameResolutionError seconds after starting. The datamover nodes do
+# have internet but no /apps module tree, so mophongo cannot run there either.
+# The login node is the only machine with both.
+#
+# Detached with setsid+nohup, because this runs for hours and the first attempt
+# was killed partway through when the driving ssh connection dropped and the
+# remote bash took the SIGHUP with it. The caller gets a log path and polls it.
+#
+# `nice` because this is real CPU on a shared login node. Building the grids on
+# a laptop and shipping them with `push --psf` is quicker when they exist there.
+#
+# $CFGS is a space-separated list of config names.
+set -euo pipefail
+: "${RUN:?RUN not set}" "${CFGS:?CFGS not set}"
+# Lmod here is hierarchical: python/3.12.3 is only visible once its gcccore
+# parent is loaded. Unquoted on purpose - it is a list, not one name.
+PYMODULES=${PYMODULES:-"gcccore/13.3.0 python/3.12.3"}
+LOG=${LOG:-$RUN/logs/psfbuild-$(date +%Y%m%d-%H%M%S).log}
+
+module purge
+module load $PYMODULES
+unset PYTHONPATH   # keep the EasyBuild shim off sys.path; see setup_env.sh
+
+export MPLCONFIGDIR=$RUN/.mplconfig
+export MPLBACKEND=Agg
+export STPSF_PATH=${STPSF:-$RUN/stpsf-data}
+mkdir -p "$MPLCONFIGDIR" "$RUN/PSF" "$RUN/out" "$RUN/logs"
+cd "$RUN/out"
+
+configs=()
+for cfg in $CFGS; do
+    configs+=("$RUN/${cfg}_ozstar.json")
+done
+
+# Bands of a field share the hi-res grids, so the driver walks them one at a
+# time: concurrent builds would write the same filenames into one psf_dir.
+setsid nohup nice -n 10 "$RUN/venv/bin/python" "$RUN/jobs/build_psfs.py" \
+    --date-mode "${DATE_MODE:-all}" "${configs[@]}" > "$LOG" 2>&1 < /dev/null &
+
+echo "PSF build detached, pid $!"
+echo "LOG=$LOG"

--- a/examples/ozstar/jobs/run.slurm
+++ b/examples/ozstar/jobs/run.slurm
@@ -1,0 +1,47 @@
+#!/bin/bash
+#SBATCH --job-name=mophongo
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=16
+#SBATCH --mem=64g
+#SBATCH --time=24:00:00
+#
+# Fit one config. $CFG names the rewritten config, e.g. uds_f770w.
+#
+# 16 cores and 64 GB is the standard request. The fitting path itself is
+# largely serial, so the cores buy threaded BLAS and FFTs rather than a linear
+# speed-up; the memory is what actually matters, and a run that exceeds it is
+# killed by SLURM with no Python traceback. No --partition is set, so the
+# scheduler picks: both skylake (36 cores / 191 GB) and milan (64 / 256) hold
+# this comfortably, and constraining the choice only lengthens the queue.
+set -euo pipefail
+: "${RUN:?RUN not set}" "${CFG:?CFG not set}"
+# Lmod here is hierarchical: python/3.12.3 is only visible once its gcccore
+# parent is loaded. Unquoted on purpose - it is a list, not one name.
+PYMODULES=${PYMODULES:-"gcccore/13.3.0 python/3.12.3"}
+
+module purge
+module load $PYMODULES
+# The python module puts an EasyBuild shim ahead of the venv on sys.path, which
+# on some nodes resolves shared packages to a build for another python. The venv
+# is self-contained; drop the shim.
+unset PYTHONPATH
+
+export OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK:-1}
+export OPENBLAS_NUM_THREADS=$OMP_NUM_THREADS
+export MKL_NUM_THREADS=$OMP_NUM_THREADS
+export MPLCONFIGDIR=$RUN/.mplconfig
+export MPLBACKEND=Agg
+# Compute nodes have no internet: stpsf cannot fetch its reference data here,
+# so it has to be on /fred already (setup_env.sh checks).
+export STPSF_PATH=${STPSF:-$RUN/stpsf-data}
+
+mkdir -p "$MPLCONFIGDIR" "$RUN/out"
+cd "$RUN/out"
+
+echo "=== $CFG on $(hostname): ${SLURM_CPUS_PER_TASK:-?} cores, ${SLURM_MEM_PER_NODE:-?} MB"
+echo "=== mophongo $(git -C "$RUN/mophongo" rev-parse --short HEAD)"
+time "$RUN/venv/bin/python" -m mophongo.pipeline "$RUN/${CFG}_ozstar.json" all
+
+echo "=== outputs:"; ls -lh "$RUN/out/$CFG" | head -25
+echo "=== peak memory:"; sacct -j "${SLURM_JOB_ID}" --format=JobID,MaxRSS,Elapsed --noheader 2>/dev/null | head -3
+echo RUN_DONE

--- a/examples/ozstar/jobs/seed_cache.sh
+++ b/examples/ozstar/jobs/seed_cache.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Link cached PSF and kernel maps from one run directory into another.
+#
+# The maps are keyed on psf_size/blur and kernel method/reg, not on the trial
+# patch, so a full-field run can reuse what a patch run of the same band already
+# built - about half an hour per band. They live in out_dir and are named after
+# the run, so seeding a new run means linking with the prefix rewritten.
+#
+# PAIRS is a comma-separated list of src:dst run names.
+set -euo pipefail
+: "${RUN:?RUN not set}" "${PAIRS:?PAIRS not set}"
+
+linked=0
+IFS=',' read -ra items <<< "$PAIRS"
+for pair in "${items[@]}"; do
+    src="${pair%%:*}"; dst="${pair##*:}"
+    [[ -d "$RUN/out/$src" ]] || { echo "skip $src: no source dir"; continue; }
+    mkdir -p "$RUN/out/$dst"
+    for suffix in psf_hi.fits psf_hi.geojson psf_lo.fits psf_lo.geojson \
+                  kernel.fits kernel.geojson; do
+        s="$RUN/out/$src/${src}_${suffix}"
+        d="$RUN/out/$dst/${dst}_${suffix}"
+        [[ -s "$s" ]] || continue
+        [[ -e "$d" ]] && continue          # already seeded
+        # symlink, not copy: these are read-only inputs and the kernel maps run
+        # to hundreds of MB each
+        ln -s "$s" "$d" && linked=$((linked+1))
+    done
+    echo "seeded $dst from $src"
+done
+echo "linked $linked files"
+echo SEED_DONE

--- a/examples/ozstar/jobs/setup_env.sh
+++ b/examples/ozstar/jobs/setup_env.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Build the run tree on /fred: clone mophongo from GitHub and make the venvs.
+#
+# Runs on the login node, which is the only place with both internet and the
+# module system. Idempotent: re-running updates the clone in place and leaves
+# the venvs alone unless REBUILD=1.
+#
+# Two venvs, because the two kinds of node do not share a software stack:
+#
+#   venv      mophongo, built with the module python. Used by the fits, which
+#             run on ordinary compute nodes. Its bin/python is a symlink into
+#             the module tree, so the same modules must be loaded to use it -
+#             which is why every script here loads the same PYMODULES, and why
+#             changing them means rebuilding.
+#   venv-vos  the CADC transfer tools, built with /usr/bin/python3. Used by the
+#             staging job, which runs on the datamover partition - and those
+#             nodes have no /apps module tree at all, so the module python is
+#             simply not there. The OS python is on every node.
+set -euo pipefail
+: "${RUN:?RUN not set}"
+# Lmod here is hierarchical: python/3.12.3 is only visible once its gcccore
+# parent is loaded. Unquoted on purpose - it is a list, not one name.
+PYMODULES=${PYMODULES:-"gcccore/13.3.0 python/3.12.3"}
+REPO_URL=${REPO_URL:-https://github.com/ivolabbe/mophongo.git}
+BRANCH=${BRANCH:-main}
+STPSF=${STPSF:-}
+
+module purge
+module load $PYMODULES
+# The python module puts an EasyBuild shim ahead of the venv on sys.path, which
+# on some nodes resolves shared packages (cryptography, and so anything using
+# TLS) to a build for another python and fails on a missing libssl. The venv is
+# self-contained; drop the shim.
+unset PYTHONPATH
+
+mkdir -p "$RUN"/{PSF,data,out,logs,jobs}
+
+echo "=== source"
+if [[ -d $RUN/mophongo/.git ]]; then
+    git -C "$RUN/mophongo" fetch --quiet origin "$BRANCH"
+    git -C "$RUN/mophongo" checkout --quiet "$BRANCH"
+    git -C "$RUN/mophongo" reset --hard "origin/$BRANCH"
+else
+    git clone --quiet --branch "$BRANCH" "$REPO_URL" "$RUN/mophongo"
+fi
+echo "mophongo $(git -C "$RUN/mophongo" rev-parse --short HEAD) on $BRANCH"
+
+echo "=== venv (mophongo, module python, compute nodes)"
+if [[ ${REBUILD:-0} == 1 ]]; then
+    rm -rf "$RUN/venv" "$RUN/venv-vos"
+fi
+if [[ ! -x $RUN/venv/bin/python ]]; then
+    python -m venv "$RUN/venv"
+    "$RUN/venv/bin/pip" -q install -U pip
+fi
+# Editable, so `sync_src.sh` (a git pull) is enough to ship a code change.
+"$RUN/venv/bin/pip" install -q -e "$RUN/mophongo"
+
+echo "=== venv-vos (CADC tools, OS python, datamover nodes)"
+if [[ ! -x $RUN/venv-vos/bin/python ]]; then
+    /usr/bin/python3 -m venv "$RUN/venv-vos"
+    "$RUN/venv-vos/bin/pip" -q install -U pip
+fi
+"$RUN/venv-vos/bin/pip" install -q vos cadcutils
+"$RUN/venv-vos/bin/vcp" --help > /dev/null && \
+    echo "$("$RUN/venv-vos/bin/python" -c 'import vos; print(vos.version.version)') ok"
+
+echo "=== versions"
+"$RUN/venv/bin/python" -c "
+import astropy, numpy, photutils, psutil, drizzlepac
+print('astropy', astropy.__version__, 'numpy', numpy.__version__,
+      'photutils', photutils.__version__, 'psutil', psutil.__version__,
+      'drizzlepac', drizzlepac.__version__)
+from mophongo.pipeline import RunConfig
+print('mophongo imports ok')
+"
+
+# STPSF reference data (~250 MB). Compute nodes have no internet, so a run that
+# has to build a PSF grid cannot fetch this itself: it must be here first.
+if [[ -n $STPSF ]]; then
+    if [[ -d $STPSF && -d $STPSF/NIRCam ]]; then
+        echo "stpsf data: $STPSF ($(du -sh "$STPSF" | cut -f1))"
+    else
+        echo "WARNING: no STPSF data at $STPSF."
+        echo "  Runs that build a PSF grid will fail on the compute nodes,"
+        echo "  which have no internet. Fetch it once on the login node:"
+        echo "    curl -LO https://stsci.box.com/shared/static/stpsf-data-LATEST.tar.gz"
+        echo "    mkdir -p $STPSF && tar xzf stpsf-data-LATEST.tar.gz -C $(dirname "$STPSF")"
+    fi
+fi
+
+echo ENV_DONE

--- a/examples/ozstar/jobs/stage.sh
+++ b/examples/ozstar/jobs/stage.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+#SBATCH --job-name=moph-stage
+#SBATCH --partition=datamover
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=3g
+# 3 GB, not 4: a datamover node advertises 4000 MB and "--mem=4g" is 4096, which
+# is refused outright as an impossible node configuration.
+#SBATCH --time=24:00:00
+#
+# Copy one field's inputs from CANFAR arc into $RUN/data, decompressing the
+# gzipped ones on the way.
+#
+# This runs on the *datamover* partition. Ordinary compute nodes have no
+# internet, so they cannot reach arc at all; datamover nodes can, and unlike the
+# login node they are meant to hold a transfer open for hours. They have only
+# 4 GB of RAM, which is why the decompression is streamed rather than buffered,
+# and no /apps module tree, which is why the transfer tools live in venv-vos,
+# built from /usr/bin/python3 - the module python does not exist on these nodes.
+#
+# The partition has to be requested on the sbatch command line: a site plugin
+# reassigns the partition of a job that only names it in a #SBATCH directive,
+# and the job then lands on a compute node with no route to CANFAR.
+#
+# $CFGS is a space-separated list of config names whose manifests to process.
+# Bands of a field share the F444W mosaic, the weight and the segmap, so all of
+# a field's bands belong in one job: the destination list is deduplicated and
+# each file transfers once. Already-present files are skipped, so a job that
+# ran out of time can simply be resubmitted.
+set -euo pipefail
+: "${RUN:?RUN not set}" "${CFGS:?CFGS not set}"
+JOBS=${JOBS:-6}
+
+export PATH="$RUN/venv-vos/bin:$PATH"
+unset PYTHONPATH
+command -v vcp > /dev/null || { echo "no vcp; run 'submit.py setup' first" >&2; exit 1; }
+
+[[ -s $HOME/.ssl/cadcproxy.pem ]] || {
+    echo "no CADC certificate at $HOME/.ssl/cadcproxy.pem" >&2
+    echo "run 'python submit.py cert' from the laptop (it expires after 10 days)" >&2
+    exit 1
+}
+
+D=$RUN/data
+mkdir -p "$D"
+
+# A cancelled or timed-out job leaves its ".<name>.<pid>" temporaries behind,
+# and they are several GB each. Sweep only the old ones: a concurrent staging
+# job's temporaries look the same and are still being written.
+find "$D" -maxdepth 1 -name '.*.[0-9]*' -mmin +360 -delete 2>/dev/null || true
+
+manifests=()
+for cfg in $CFGS; do
+    m=$RUN/${cfg}_stage.tsv
+    [[ -s $m ]] || { echo "no manifest: $m" >&2; exit 1; }
+    manifests+=("$m")
+done
+
+# One file: fetch to a private temp name, decompress if gzipped, move into
+# place. Concurrent jobs of different fields can want the same file, so the
+# move is a no-clobber move and a loser just drops its copy.
+fetch_one() {
+    local src="$1" dst="$2" tmp
+    if [[ -s $D/$dst ]]; then echo "have     $dst"; return 0; fi
+    tmp="$D/.$dst.$$"
+    for attempt in 1 2 3; do
+        if [[ $src == *.gz ]]; then
+            echo "fetch    $dst (gz, attempt $attempt)"
+            vcp "$src" "$tmp.gz" && gunzip -c "$tmp.gz" > "$tmp" && rm -f "$tmp.gz" && break
+        else
+            echo "fetch    $dst (attempt $attempt)"
+            vcp "$src" "$tmp" && break
+        fi
+        rm -f "$tmp" "$tmp.gz"
+        [[ $attempt == 3 ]] && { echo "FAILED   $dst" >&2; return 1; }
+        sleep 20
+    done
+    if [[ -s $D/$dst ]]; then
+        echo "         ($dst arrived meanwhile, discarding)"
+        rm -f "$tmp"
+    else
+        mv -n "$tmp" "$D/$dst"
+        rm -f "$tmp"
+    fi
+}
+export -f fetch_one
+export D
+
+# One CANFAR stream is much slower than the link, hence several at once.
+# -d '\n' so xargs splits on lines only and leaves quoting alone.
+sort -u "${manifests[@]}" | awk -F'\t' '!seen[$2]++' | tr '\t' '\n' |
+    xargs -d '\n' -P "$JOBS" -n 2 bash -c 'fetch_one "$0" "$1"'
+
+echo "=== staged:"
+cut -f2 "${manifests[@]}" | sort -u | while read -r f; do
+    [[ -n $f ]] && ls -lh "$D/$f"
+done
+du -sh "$D"
+echo STAGE_DONE

--- a/examples/ozstar/jobs/sync_src.sh
+++ b/examples/ozstar/jobs/sync_src.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Pull the latest mophongo into the run tree, leaving the venv alone.
+#
+# mophongo is installed editable, so the venv imports straight from
+# $RUN/mophongo and a code change needs no reinstall. Use this rather than
+# setup_env.sh REBUILD=1 while jobs are queued: already-running jobs keep the
+# code they imported, and queued ones pick this up when they start - which is
+# worth knowing before pulling mid-campaign.
+set -euo pipefail
+: "${RUN:?RUN not set}"
+# Lmod here is hierarchical: python/3.12.3 is only visible once its gcccore
+# parent is loaded. Unquoted on purpose - it is a list, not one name.
+PYMODULES=${PYMODULES:-"gcccore/13.3.0 python/3.12.3"}
+BRANCH=${BRANCH:-main}
+
+module purge
+module load $PYMODULES
+unset PYTHONPATH   # keep the EasyBuild shim off sys.path; see setup_env.sh
+
+git -C "$RUN/mophongo" fetch --quiet origin "$BRANCH"
+git -C "$RUN/mophongo" checkout --quiet "$BRANCH"
+git -C "$RUN/mophongo" reset --hard "origin/$BRANCH"
+echo "mophongo $(git -C "$RUN/mophongo" log --oneline -1)"
+
+"$RUN/venv/bin/python" -c "
+from mophongo.pipeline import RunConfig
+from mophongo.utils import as_label_array
+print('imports ok')
+"
+echo UPDATE_DONE

--- a/examples/ozstar/ozify.py
+++ b/examples/ozstar/ozify.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+"""Rewrite a local mophongo run config to run on OzStar, and list its inputs.
+
+Unlike CANFAR, where ``/arc`` is mounted inside every container and most inputs
+are read in place, OzStar has no view of the MINERVA release at all: every file
+a config names has to be copied to ``/fred`` first. So this writes two things
+per config:
+
+* ``<name>_ozstar.json`` - the config with every input path pointed at
+  ``$RUN/data``, ``psf_dir`` at ``$RUN/PSF`` and ``out_dir`` at
+  ``$RUN/out/<name>``;
+* ``<name>_stage.tsv`` - ``<vospace uri>\\t<destination basename>`` for every
+  one of those inputs, which ``jobs/stage.sh`` copies from CANFAR and, where
+  the arc copy is gzipped, decompresses.
+
+Finding the files on arc is the same problem ``examples/canfar/arcify.py``
+solves, so its index is reused rather than duplicated: ``roots_for`` maps a
+local staged path to the arc subtrees that could hold it, and ``resolve``
+handles the gzipped names and the ``_f770_wcs.csv`` / ``_f770w_wcs.csv``
+spelling mismatch.
+
+Usage::
+
+    python ozify.py ../minerva/uds_f770w.json [more configs ...]
+    python ozify.py ../minerva/uds_f770w.json --r-trial 1.5 --suffix _trial
+
+Needs a CADC proxy certificate locally (only to *list* arc; the copying itself
+happens on OzStar with the certificate pushed by ``submit.py cert``).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import sys
+from pathlib import Path
+
+from vos import Client
+
+HERE = Path(__file__).resolve().parent
+# The arc index is the same problem for both platforms, so canfar/arcify.py is
+# imported rather than copied. Appended, not prepended: arcify imports canfar's
+# own `runroot`, and this directory's equivalent is deliberately named
+# `ozroot` so the two cannot shadow each other.
+sys.path.append(str(HERE.parent / "canfar"))
+
+from arcify import PATH_KEYS, arc_index, resolve, roots_for  # noqa: E402
+
+from ozroot import run_root  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+log = logging.getLogger("ozify")
+
+
+def vos_uri(arc_path: str) -> str:
+    """``/arc/projects/minerva/...`` -> ``arc:projects/minerva/...``.
+
+    The vos tools address arc by URI and the SSH endpoint by chrooted POSIX
+    path; ``arc_index`` returns the POSIX form, and ``vcp`` wants the URI.
+    """
+    return "arc:" + arc_path[len("/arc/"):]
+
+
+def ozify(cfg_path: Path, index: dict[str, str], out_dir: Path, run: str,
+          r_trial: float | None = None, suffix: str = "") -> tuple[Path, Path]:
+    """Write the OzStar config and its staging list for one local config.
+
+    ``r_trial`` overrides the trial-patch radius in arcmin (0 means the full
+    field) and ``suffix`` keeps a trial run's outputs separate from the full
+    one's. The config's own ``trial.center`` is kept - only the radius moves -
+    so the patch stays where the source config put it.
+    """
+    raw = re.sub(r"(?m)^\s*#.*$", "", cfg_path.read_text())
+    cfg = json.loads(raw)
+    name = cfg.get("name", cfg_path.stem) + suffix
+    if r_trial is not None:
+        if r_trial <= 0:
+            cfg["trial"] = None  # full field
+        else:
+            trial = dict(cfg.get("trial") or {})
+            if not trial.get("center"):
+                raise SystemExit(
+                    f"{cfg_path.name}: --r-trial needs a trial.center in the "
+                    'config: "trial": {"center": [ra, dec], "radius": <arcmin>}'
+                )
+            trial["radius"] = r_trial
+            cfg["trial"] = trial
+    cfg["name"] = name
+
+    stage: list[tuple[str, str]] = []  # (vospace source, staged basename)
+    for key in PATH_KEYS:
+        value = cfg.get(key)
+        if not value:
+            continue
+        basename = Path(value).name
+        hit = resolve(basename, index)
+        if hit is None:
+            raise SystemExit(f"{cfg_path.name}: {key} not found on arc: {basename}")
+        arc_path, _gzipped = hit
+        # Everything is copied, compressed or not: /fred has no view of arc.
+        # The destination carries the name the config expects, which also fixes
+        # the f770 -> f770w frame-table spelling.
+        cfg[key] = f"{run}/data/{basename}"
+        stage.append((vos_uri(arc_path), basename))
+
+    cfg["psf_dir"] = f"{run}/PSF"
+    cfg["out_dir"] = f"{run}/out/{name}"
+
+    cfg_out = out_dir / f"{name}_ozstar.json"
+    cfg_out.write_text(json.dumps(cfg, indent=2) + "\n")
+    tsv_out = out_dir / f"{name}_stage.tsv"
+    tsv_out.write_text("".join(f"{src}\t{dst}\n" for src, dst in stage))
+    log.info("%-18s -> %s  (%d files to stage)", name, cfg_out.name, len(stage))
+    return cfg_out, tsv_out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("configs", nargs="+", type=Path, help="local RunConfig JSON files")
+    ap.add_argument("--out-dir", type=Path, default=HERE,
+                    help="where to write the rewritten configs")
+    ap.add_argument("--r-trial", type=float, default=None,
+                    help="override the trial-patch radius in arcmin (0 = full field)")
+    ap.add_argument("--suffix", default="",
+                    help="append to the run name, e.g. _trial, to keep outputs separate")
+    args = ap.parse_args()
+
+    cert = Path.home() / ".ssl/cadcproxy.pem"
+    if not cert.exists():
+        raise SystemExit(f"no CADC certificate at {cert}; run canfar-cert.sh first")
+
+    run = run_root()
+
+    # Collect the subtrees every config needs, then index each one once: the
+    # bands of a field overlap almost completely.
+    roots: list[str] = []
+    for cfg_path in args.configs:
+        cfg = json.loads(re.sub(r"(?m)^\s*#.*$", "", cfg_path.read_text()))
+        for key in PATH_KEYS:
+            for root in roots_for(cfg.get(key) or ""):
+                if root not in roots:
+                    roots.append(root)
+    log.info("indexing %d arc subtrees:", len(roots))
+    index = arc_index(Client(vospace_certfile=str(cert)), roots)
+
+    for cfg_path in args.configs:
+        ozify(cfg_path, index, args.out_dir, run, args.r_trial, args.suffix)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/ozstar/ozroot.py
+++ b/examples/ozstar/ozroot.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+"""Where an OzStar campaign lives, and how to reach the cluster.
+
+OzStar (Ngarrgu Tindebeek) has two storage areas and only one of them is usable
+for a campaign: ``/home`` has a 20 GB quota and is for configs, while ``/fred``
+is the 10 TB group allocation everything actually runs from. The default run
+root is therefore ``/fred/<project>/<user>/mophongo/run``.
+
+Environment overrides, all optional except ``OZSTAR_USER``::
+
+    OZSTAR_USER      cluster username (no default; there is nothing to guess)
+    OZSTAR_HOST      login node, default nt.swin.edu.au
+    OZSTAR_PROJECT   group allocation, default oz030
+    OZSTAR_RUN       run tree, default /fred/<project>/<user>/mophongo/run
+    OZSTAR_STPSF     STPSF reference data, default /fred/<project>/<user>/stpsf-data
+
+``OZSTAR_RUN`` must be under ``/fred``: a run tree in ``/home`` fills the quota
+partway through the first field.
+"""
+from __future__ import annotations
+
+import os
+
+
+def user() -> str:
+    """Cluster username from ``$OZSTAR_USER``."""
+    name = os.environ.get("OZSTAR_USER", "").strip()
+    if not name:
+        raise SystemExit("set OZSTAR_USER to your OzStar username")
+    return name
+
+
+def host() -> str:
+    """Login node hostname."""
+    return os.environ.get("OZSTAR_HOST", "nt.swin.edu.au")
+
+
+def ssh_target() -> str:
+    """``user@host`` for ssh, scp and rsync."""
+    return f"{user()}@{host()}"
+
+
+def project() -> str:
+    """Group allocation directory under ``/fred``."""
+    return os.environ.get("OZSTAR_PROJECT", "oz030")
+
+
+def run_root() -> str:
+    """The run tree on ``/fred``."""
+    root = os.environ.get("OZSTAR_RUN", "").rstrip("/")
+    if not root:
+        root = f"/fred/{project()}/{user()}/mophongo/run"
+    if not root.startswith("/fred/"):
+        raise SystemExit(
+            f"OZSTAR_RUN must be under /fred (got {root}); /home has a 20 GB quota"
+        )
+    return root
+
+
+def stpsf_dir() -> str:
+    """STPSF reference data, which compute nodes cannot download themselves."""
+    path = os.environ.get("OZSTAR_STPSF", "").rstrip("/")
+    return path or f"/fred/{project()}/{user()}/stpsf-data"

--- a/examples/ozstar/release_v1.0b.sh
+++ b/examples/ozstar/release_v1.0b.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# MINERVA mophongo release v1.0b on OzStar: every field, every MIRI band, full
+# field (no trial patch).
+#
+# COSMOS   f770w f1000w f1280w f1500w f1800w f2100w
+# EGS      f560w f770w f1000w f1280w f1500w f1800w f2100w
+# UDS      f770w f1280w f1500w f1800w
+#
+# 17 fits, each 16 cores and 64 GB, writing to $OZSTAR_RUN/out/<field>_<band>_v1.0b.
+# The whole thing is one SLURM dependency graph: each field's fits wait on that
+# field's staging, and a field whose PSF grids do not exist yet sends one band
+# ahead of the rest to build them without racing on psf_dir.
+#
+#   ./release_v1.0b.sh              # stage and run
+#   ./release_v1.0b.sh --skip-stage # inputs already on /fred
+#   ./release_v1.0b.sh --dry-run    # print the plan
+#
+# Any other argument is passed through to campaign.py, and MEM overrides the
+# request, so a field that needs more memory than the rest is a second call:
+#
+#   ./release_v1.0b.sh --skip-stage --fields uds cosmos
+#   MEM=96 ./release_v1.0b.sh --skip-stage --fields egs
+#
+# EGS is the one to watch: its detection grid is 1221 Mpx against UDS's 876, and
+# UDS full field measures a 46.5 GB footprint, so EGS is the band group that can
+# exceed a 64 GB request. A run that does is killed with no Python traceback.
+#
+# Watch it with:  python submit.py status
+set -euo pipefail
+
+SUFFIX=${SUFFIX:-_v1.0b}
+CORES=${CORES:-16}
+MEM=${MEM:-64}
+WALLTIME=${WALLTIME:-24:00:00}
+# ozify.py needs the vos client, which lives in this venv rather than on PATH.
+PYTHON=${PYTHON:-$HOME/.venvs/canfar/bin/python}
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+: "${OZSTAR_USER:?set OZSTAR_USER to your cluster username}"
+[[ -s $HOME/.ssl/cadcproxy.pem ]] || {
+    echo "no CADC certificate; run ../../scratch/canfar/canfar-cert.sh" >&2
+    exit 1
+}
+
+args=(--r-trial 0 --suffix "$SUFFIX" --cores "$CORES" --mem "$MEM" --time "$WALLTIME")
+for opt in "$@"; do
+    case "$opt" in
+        --skip-stage) args+=(--skip stage) ;;
+        --dry-run)    args+=(--dry-run) ;;
+        *)            args+=("$opt") ;;
+    esac
+done
+
+echo "release $SUFFIX: all fields, all MIRI bands, full field"
+exec "$PYTHON" campaign.py "${args[@]}"

--- a/examples/ozstar/submit.py
+++ b/examples/ozstar/submit.py
@@ -1,0 +1,450 @@
+#!/usr/bin/env python
+"""Drive mophongo runs on OzStar (Ngarrgu Tindebeek) over ssh and SLURM.
+
+OzStar is the opposite of CANFAR in the two ways that shape this file. Compute
+is ordinary ssh and ``sbatch`` rather than a REST API, so jobs chain with
+``--dependency`` instead of a laptop-side process blocking on each stage. And
+the MINERVA data are not there: everything a config names is copied from CANFAR
+arc onto ``/fred`` first, by a job on the ``datamover`` partition, because
+ordinary compute nodes have no internet at all.
+
+    python submit.py cert                    # push the CADC proxy certificate
+    python submit.py setup                   # clone mophongo, build the venv
+    python submit.py sync                    # git pull, leaving the venv alone
+    python submit.py push  uds_f770w ...     # upload job scripts and configs
+    python submit.py stage uds_f770w ...     # datamover job: arc -> /fred/data
+    python submit.py run   uds_f770w ...     # one SLURM job per config
+    python submit.py status                  # the queue
+    python submit.py logs  uds_f770w         # tail a job's log
+    python submit.py fetch uds_f770w         # pull the small outputs down
+    python submit.py cancel                  # scancel the campaign
+
+``stage`` and ``run`` print the job ids they submit and accept ``--after``, so a
+campaign is a dependency graph submitted in one go and nothing afterwards
+depends on the laptop staying awake.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import shlex
+import subprocess
+from pathlib import Path
+
+import ozroot
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+log = logging.getLogger("submit")
+
+HERE = Path(__file__).resolve().parent
+JOB_PREFIX = "moph"
+
+#: Staging needs internet, which only these nodes have. It has to be given on
+#: the sbatch command line: a site plugin reassigns the partition of a job that
+#: names it in a #SBATCH directive alone, and the job then lands on a compute
+#: node that cannot reach CANFAR. Fits leave the partition to the scheduler.
+STAGE_PARTITION = "datamover"
+
+#: Outputs small enough to be worth having locally. The residual, the stamps
+#: and the scene PNGs stay on /fred; a full field writes tens of GB of them.
+FETCH = ["{name}_fit_table.fits", "{name}_scene_catalog.csv", "{name}.log"]
+
+
+# --- plumbing ---------------------------------------------------------------
+
+
+def ssh(command: str, check: bool = True) -> str:
+    """Run one command on the login node and return its stdout."""
+    proc = subprocess.run(["ssh", ozroot.ssh_target(), command],
+                          capture_output=True, text=True)
+    if check and proc.returncode != 0:
+        raise SystemExit(f"ssh failed ({proc.returncode}): {proc.stderr.strip()}")
+    return proc.stdout
+
+
+def ssh_stream(command: str) -> int:
+    """Run one command on the login node with its output on the terminal."""
+    return subprocess.run(["ssh", ozroot.ssh_target(), command]).returncode
+
+
+def job_env(extra: dict[str, str] | None = None) -> str:
+    """``VAR=value ...`` prefix for a job script run directly on the login node."""
+    env = {"RUN": ozroot.run_root(), "STPSF": ozroot.stpsf_dir(), **(extra or {})}
+    return " ".join(f"{k}={shlex.quote(v)}" for k, v in env.items())
+
+
+def upload(paths: list[Path], subdir: str = "") -> None:
+    """Copy files into the run tree with scp.
+
+    scp rather than rsync: macOS ships openrsync, which does not have all of
+    rsync's flags, and everything uploaded here is small - the mophongo source
+    is cloned on the login node, not pushed.
+    """
+    if not paths:
+        return
+    dest = f"{ozroot.run_root()}/{subdir}".rstrip("/")
+    ssh(f"mkdir -p {shlex.quote(dest)}")
+    proc = subprocess.run(["scp", "-q", *[str(p) for p in paths],
+                           f"{ozroot.ssh_target()}:{dest}/"])
+    if proc.returncode != 0:
+        raise SystemExit(f"scp failed ({proc.returncode})")
+
+
+def sbatch(script: str, job_name: str, env: dict[str, str],
+           after: str | None = None, extra: list[str] | None = None) -> str:
+    """Submit one job and return its id.
+
+    Parameters go through ``--export`` rather than being baked into the script,
+    so one script serves every config.
+    """
+    run = ozroot.run_root()
+    exports = ",".join(f"{k}={v}" for k, v in
+                       {"RUN": run, "STPSF": ozroot.stpsf_dir(), **env}.items())
+    flags = ["--parsable", f"--job-name={job_name}",
+             f"--output={run}/logs/{job_name}-%j.out",
+             f"--export=ALL,{exports}"]
+    if after:
+        flags.append(f"--dependency=afterok:{after}")
+    flags += extra or []
+    command = (f"mkdir -p {shlex.quote(run)}/logs && cd {shlex.quote(run)} && sbatch "
+               + " ".join(shlex.quote(f) for f in flags)
+               + f" {shlex.quote(run)}/jobs/{script}")
+    jobid = ssh(command).strip().split(";")[0]
+    log.info("%-30s %s%s", job_name, jobid, f"  (after {after})" if after else "")
+    return jobid
+
+
+def by_field(names: list[str]) -> dict[str, list[str]]:
+    """Group config names by field, preserving order."""
+    groups: dict[str, list[str]] = {}
+    for name in names:
+        groups.setdefault(name.split("_")[0], []).append(name)
+    return groups
+
+
+# --- steps (importable by campaign.py, which needs the job ids) --------------
+
+
+#: PSF grid patterns worth shipping when they already exist locally: the F444W
+#: photometry grids, the 30" halo grids `repair_saturated` uses, and the
+#: per-band MIRI grids.
+PSF_GLOBS = ["*_NRC*_F444W_MJD*_GRID25_OS4.fits",
+             "*_NRC*_F444W_MJD*_FOV30_GRID1_OS4.fits",
+             "*_MIRI_*_MJD*_GRID9_OS4.fits"]
+
+
+def push(names: list[str], psf_globs: list[str] | None = None) -> None:
+    """Upload the job scripts and, if named, the rewritten configs.
+
+    The mophongo source is not uploaded: ``setup`` clones it from GitHub on the
+    login node, which reaches it far faster than a laptop uplink does.
+
+    ``psf_globs`` additionally ships local ePSF grids. That is an optimisation,
+    not a requirement - ``jobs/build_psfs.sh`` builds whatever is missing - but
+    building a grid needs a MAST query for the wavefront OPD and so can only
+    happen on the login node, one field at a time. Grids that already exist on
+    a laptop are much cheaper to copy than to rebuild.
+    """
+    scripts = sorted((HERE / "jobs").glob("*"))
+    upload(scripts, "jobs")
+    ssh(f"chmod +x {shlex.quote(ozroot.run_root())}/jobs/*")
+    files: list[Path] = []
+    for name in names:
+        for suffix in (f"{name}_ozstar.json", f"{name}_stage.tsv"):
+            path = HERE / suffix
+            if not path.exists():
+                raise SystemExit(f"missing {path}; run ozify.py first")
+            files.append(path)
+    upload(files)
+    log.info("pushed %d job script(s), %d config file(s)", len(scripts), len(files))
+    if psf_globs:
+        push_psf_grids(psf_globs)
+
+
+def push_psf_grids(psf_globs: list[str]) -> None:
+    """Ship local ePSF grids as one tarball.
+
+    Streamed through a single ssh rather than scp'd file by file: the grids are
+    a few hundred files of a few MB each, and per-file round trips over this
+    link ran at about four files a minute against a couple of minutes for the
+    whole tar. Extraction overwrites, so a partial earlier copy is repaired
+    rather than left truncated.
+    """
+    psf_dir = HERE.parent.parent / "data" / "PSF"
+    grids = sorted({g for pat in psf_globs for g in psf_dir.glob(pat)})
+    if not grids:
+        raise SystemExit(f"no PSF grids matched {psf_globs} under {psf_dir}")
+    total = sum(g.stat().st_size for g in grids)
+    dest = f"{ozroot.run_root()}/PSF"
+    ssh(f"mkdir -p {shlex.quote(dest)}")
+    log.info("shipping %d PSF grid(s), %.0f MB", len(grids), total / 1e6)
+    tar = subprocess.Popen(
+        ["tar", "-cf", "-", "-C", str(psf_dir), *[g.name for g in grids]],
+        stdout=subprocess.PIPE)
+    unpack = subprocess.run(
+        ["ssh", ozroot.ssh_target(), f"tar -xf - -C {shlex.quote(dest)}"],
+        stdin=tar.stdout)
+    tar.stdout.close()
+    if tar.wait() != 0 or unpack.returncode != 0:
+        raise SystemExit("PSF grid transfer failed")
+    log.info("PSF grids on %s: %s", dest,
+             ssh(f"ls {shlex.quote(dest)} | wc -l").strip())
+
+
+def build_psfs(names: list[str]) -> str:
+    """Start the login-node ePSF build and return its log path.
+
+    Not a SLURM job, and it cannot become one: stpsf resolves each exposure's
+    date to a wavefront OPD by querying MAST, compute nodes have no DNS or
+    route, and datamover nodes (which do have internet) have no module tree to
+    run mophongo from.
+
+    Detached rather than streamed. The build runs for hours, and the first
+    attempt died partway through when the driving ssh dropped and the remote
+    bash took the SIGHUP with it. Poll the returned log with ``psf-log``.
+    """
+    script = f"{ozroot.run_root()}/jobs/build_psfs.sh"
+    out = ssh(f"{job_env({'CFGS': ' '.join(names)})} bash {shlex.quote(script)}")
+    log.info("%s", out.strip())
+    for line in out.splitlines():
+        if line.startswith("LOG="):
+            return line[len("LOG="):].strip()
+    raise SystemExit(f"PSF build did not report a log path: {out.strip()}")
+
+
+def stage(names: list[str], after: str | None = None,
+          walltime: str = "24:00:00") -> list[str]:
+    """One datamover job per field; returns the job ids.
+
+    Per field, not per band: the bands of a field share the F444W mosaic, its
+    weight map and the segmap, several GB each that would otherwise cross the
+    Pacific once per band. Within a job the destination list is deduplicated,
+    and files already present are skipped, so resubmitting after a timeout
+    resumes rather than restarts.
+    """
+    return [sbatch("stage.sh", f"{JOB_PREFIX}-stage-{field}",
+                   {"CFGS": " ".join(bands)}, after=after,
+                   extra=[f"--partition={STAGE_PARTITION}", f"--time={walltime}"])
+            for field, bands in by_field(names).items()]
+
+
+def run(names: list[str], after: str | None = None, cores: int = 16,
+        mem: int = 64, walltime: str = "24:00:00", sync: bool = True) -> list[str]:
+    """One SLURM job per config; returns the job ids.
+
+    The source is pulled to the latest ``main`` first, unless ``sync`` is off.
+    A run must not silently use whatever happened to be cloned weeks ago, and
+    the pull is a second on the login node. It is safe mid-campaign: mophongo
+    is installed editable, so running jobs keep the code they imported and only
+    jobs that start afterwards pick this up.
+    """
+    if sync:
+        sync_src()
+    return [sbatch("run.slurm", f"{JOB_PREFIX}-{name.replace('_', '-')}",
+                   {"CFG": name}, after=after,
+                   extra=[f"--cpus-per-task={cores}", f"--mem={mem}g",
+                          f"--time={walltime}"])
+            for name in names]
+
+
+def sync_src(branch: str = "main") -> None:
+    """Pull the run tree's mophongo clone to the head of ``branch``."""
+    script = f"{ozroot.run_root()}/jobs/sync_src.sh"
+    code = ssh_stream(f"{job_env({'BRANCH': branch})} bash {shlex.quote(script)}")
+    if code != 0:
+        raise SystemExit(f"sync failed ({code})")
+
+
+# --- commands ---------------------------------------------------------------
+
+
+def do_cert(args: argparse.Namespace) -> None:
+    """Copy the local CADC proxy certificate to OzStar.
+
+    ``stage`` reads arc with the vos tools, which authenticate with this
+    certificate and nothing else. It is valid for ten days, so a campaign that
+    outlives one needs this again; the symptom is a staging job that fails
+    immediately with a permission error.
+    """
+    cert = Path.home() / ".ssl/cadcproxy.pem"
+    if not cert.exists():
+        raise SystemExit(f"no certificate at {cert}; run scratch/canfar/canfar-cert.sh")
+    ssh("mkdir -p ~/.ssl")
+    proc = subprocess.run(["scp", "-q", str(cert),
+                           f"{ozroot.ssh_target()}:.ssl/cadcproxy.pem"])
+    if proc.returncode != 0:
+        raise SystemExit("scp of the certificate failed")
+    ssh("chmod 600 ~/.ssl/cadcproxy.pem")
+    log.info("certificate installed, %s",
+             ssh("openssl x509 -in ~/.ssl/cadcproxy.pem -noout -enddate").strip())
+
+
+def do_push(args: argparse.Namespace) -> None:
+    push(args.names, PSF_GLOBS if args.psf else None)
+
+
+def do_psf(args: argparse.Namespace) -> None:
+    build_psfs(args.names)
+
+
+def do_setup(args: argparse.Namespace) -> None:
+    """Clone mophongo and build the venv, on the login node.
+
+    Not a SLURM job: compute nodes reach neither GitHub nor PyPI.
+    """
+    extra = {"BRANCH": args.branch}
+    if args.rebuild:
+        extra["REBUILD"] = "1"
+    script = f"{ozroot.run_root()}/jobs/setup_env.sh"
+    code = ssh_stream(f"{job_env(extra)} bash {shlex.quote(script)}")
+    if code != 0:
+        raise SystemExit(f"setup failed ({code})")
+
+
+def do_sync(args: argparse.Namespace) -> None:
+    """git pull the source in place; the venv and queued jobs are untouched."""
+    sync_src(args.branch)
+
+
+def do_seed(args: argparse.Namespace) -> None:
+    """Link cached PSF/kernel maps from one run into another."""
+    pairs = ",".join(f"{src}:{dst}" for src, dst in
+                     (p.split(":", 1) for p in args.pairs))
+    script = f"{ozroot.run_root()}/jobs/seed_cache.sh"
+    ssh_stream(f"{job_env({'PAIRS': pairs})} bash {shlex.quote(script)}")
+
+
+def do_stage(args: argparse.Namespace) -> None:
+    stage(args.names, args.after, args.time)
+
+
+def do_run(args: argparse.Namespace) -> None:
+    run(args.names, args.after, args.cores, args.mem, args.time, sync=not args.no_sync)
+
+
+def do_status(args: argparse.Namespace) -> None:
+    fmt = "%.12i %.30j %.10P %.9T %.11M %.11l %.5C %.9m %R"
+    print(ssh(f"squeue -u {ozroot.user()} -o {shlex.quote(fmt)}").rstrip())
+    if args.done:
+        print(ssh("sacct -X --format=JobID,JobName%30,State,Elapsed,MaxRSS,ReqMem "
+                  f"-S {shlex.quote(args.done)}").rstrip())
+
+
+def do_logs(args: argparse.Namespace) -> None:
+    """Tail the newest log for a run name, a job name or a job id.
+
+    Run names carry underscores (``uds_f770w``) and job names dashes
+    (``moph-uds-f770w``), so both spellings are tried.
+    """
+    run_dir = f"{ozroot.run_root()}/logs"
+    globs = " ".join(f"{run_dir}/*{p}*"
+                     for p in dict.fromkeys([args.name, args.name.replace("_", "-")]))
+    cmd = (f"f=$(ls -t {globs} 2>/dev/null | head -1); "
+           f'[ -n "$f" ] || {{ echo "no log matching {args.name} in {run_dir}"; exit 1; }}; '
+           f'echo "--- $f"; tail -n {args.lines} "$f"')
+    ssh_stream(cmd)
+
+
+def do_fetch(args: argparse.Namespace) -> None:
+    """Pull the small outputs down; the residual and the stamps stay on /fred."""
+    root = ozroot.run_root()
+    for name in args.names:
+        dest = HERE / "out" / name
+        dest.mkdir(parents=True, exist_ok=True)
+        got = 0
+        for template in FETCH:
+            remote = f"{root}/out/{name}/{template.format(name=name)}"
+            proc = subprocess.run(["scp", "-q", f"{ozroot.ssh_target()}:{remote}",
+                                   str(dest)], capture_output=True, text=True)
+            if proc.returncode == 0:
+                got += 1
+            else:
+                log.warning("  not on /fred: %s", Path(remote).name)
+        log.info("%s -> %s (%d/%d files)", name, dest, got, len(FETCH))
+
+
+def do_cancel(args: argparse.Namespace) -> None:
+    """Cancel this campaign's jobs by name prefix, not the whole account."""
+    rows = ssh(f"squeue -u {ozroot.user()} -h -o '%i %j'").splitlines()
+    ids = [r.split()[0] for r in rows
+           if len(r.split()) > 1 and r.split()[1].startswith(args.match)]
+    if not ids:
+        log.info("nothing queued matching %s", args.match)
+        return
+    ssh(f"scancel {' '.join(ids)}")
+    log.info("cancelled %d job(s)", len(ids))
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p = sub.add_parser("cert", help="copy the CADC proxy certificate to OzStar")
+    p.set_defaults(func=do_cert)
+
+    p = sub.add_parser("push", help="upload job scripts and rewritten configs")
+    p.add_argument("names", nargs="*")
+    p.add_argument("--psf", action="store_true",
+                   help="also ship the local ePSF grids, saving a login-node build")
+    p.set_defaults(func=do_push)
+
+    p = sub.add_parser("psf", help="build missing ePSF grids on the login node")
+    p.add_argument("names", nargs="+")
+    p.set_defaults(func=do_psf)
+
+    p = sub.add_parser("setup", help="clone mophongo and build the venv")
+    p.add_argument("--branch", default="main")
+    p.add_argument("--rebuild", action="store_true",
+                   help="delete and rebuild the venv (breaks jobs using it)")
+    p.set_defaults(func=do_setup)
+
+    p = sub.add_parser("sync", help="git pull the source, leaving the venv alone")
+    p.add_argument("--branch", default="main")
+    p.set_defaults(func=do_sync)
+
+    p = sub.add_parser("seed", help="link cached PSF/kernel maps between runs")
+    p.add_argument("pairs", nargs="+", metavar="SRC:DST")
+    p.set_defaults(func=do_seed)
+
+    p = sub.add_parser("stage", help="copy a field's inputs from arc to /fred")
+    p.add_argument("names", nargs="+")
+    p.add_argument("--after", help="SLURM job id to depend on")
+    p.add_argument("--time", default="24:00:00")
+    p.set_defaults(func=do_stage)
+
+    p = sub.add_parser("run", help="one SLURM job per config")
+    p.add_argument("names", nargs="+")
+    p.add_argument("--after", help="SLURM job id to depend on")
+    p.add_argument("--cores", type=int, default=16)
+    p.add_argument("--mem", type=int, default=64, help="GB")
+    p.add_argument("--time", default="24:00:00")
+    p.add_argument("--no-sync", action="store_true",
+                   help="do not pull the latest main first (it is pulled by default, "
+                        "so a run never uses a stale clone)")
+    p.set_defaults(func=do_run)
+
+    p = sub.add_parser("status", help="the queue")
+    p.add_argument("--done", metavar="YYYY-MM-DD",
+                   help="also list finished jobs since this date, with MaxRSS")
+    p.set_defaults(func=do_status)
+
+    p = sub.add_parser("logs", help="tail the newest log matching a name")
+    p.add_argument("name")
+    p.add_argument("-n", "--lines", type=int, default=60)
+    p.set_defaults(func=do_logs)
+
+    p = sub.add_parser("fetch", help="download the small outputs")
+    p.add_argument("names", nargs="+")
+    p.set_defaults(func=do_fetch)
+
+    p = sub.add_parser("cancel", help="cancel this campaign's queued jobs")
+    p.add_argument("--match", default=JOB_PREFIX)
+    p.set_defaults(func=do_cancel)
+
+    args = ap.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mophongo/catalog.py
+++ b/src/mophongo/catalog.py
@@ -207,6 +207,47 @@ def coarse_source_mask(
     return src_mask
 
 
+def _row_bands(shape: tuple[int, int], nbytes: int = 1 << 25):
+    """Yield row slices covering ``shape``, each about ``nbytes`` of float32.
+
+    Whole-array passes over a mosaic-sized image cost a full-resolution
+    temporary per operand; banding bounds them at the band instead, at no
+    change in result.
+    """
+    ny, nx = int(shape[0]), int(shape[1])
+    band = max(1, nbytes // max(4 * nx, 1))
+    for y0 in range(0, ny, band):
+        yield slice(y0, min(y0 + band, ny))
+
+
+def _as_float(a: np.ndarray) -> np.ndarray:
+    """Return ``a`` as a floating-point array without a byte-order copy.
+
+    ``np.asarray(a, dtype=np.float32)`` on a big-endian FITS memory map copies
+    the whole array, because ``'>f4'`` and ``'float32'`` are different dtypes.
+    Any float dtype works for everything downstream, so only a genuinely
+    non-float input (an integer weight map) is converted.
+    """
+    arr = np.asarray(a)
+    return arr if arr.dtype.kind == "f" else arr.astype(np.float32)
+
+
+def _valid_mask(s: np.ndarray, w: np.ndarray) -> np.ndarray:
+    """Boolean mask of pixels with finite science and positive finite weight.
+
+    One preallocated array filled band by band. The whole-array expression
+    holds two masks at once plus the temporaries of each ``isfinite`` and the
+    ``> 0`` comparison -- four full-resolution booleans to produce one.
+    """
+    valid = np.empty(s.shape, dtype=bool)
+    for rows in _row_bands(s.shape):
+        wb = w[rows]
+        np.isfinite(wb, out=valid[rows])
+        valid[rows] &= wb > 0
+        valid[rows] &= np.isfinite(s[rows])
+    return valid
+
+
 def get_bg_and_ivar(
     sci: np.ndarray,
     wht: np.ndarray,
@@ -264,14 +305,23 @@ def get_bg_and_ivar(
     # keeps the mask off the noise field
     min_npixels_faint = 3
 
-    s = np.asarray(sci, dtype=np.float32)
-    w = np.asarray(wht, dtype=np.float32)
-    valid_w = np.isfinite(w) & (w > 0)
+    # Byte order is left alone. FITS stores big-endian, so a memory-mapped
+    # float32 mosaic arrives as '>f4', and np.asarray(x, dtype=np.float32)
+    # differs from it in byte order and therefore COPIES -- 3.5 GB per input on
+    # a MINERVA detection grid, which undoes the memory mapping upstream for
+    # the length of this call. Nothing below needs native order: the block
+    # means read one band at a time and cast on the way into their float32
+    # output, and the returned ivar is written with an explicit float32 dtype.
+    s = _as_float(sci)
+    w = _as_float(wht)
     # One common mask: a pixel counts only where BOTH science and weight are
     # finite. Non-finite science is replaced here rather than downstream --
     # a single NaN otherwise spreads over its whole block in the mean, into
     # the median and MAD, and makes every statistic and both outputs NaN.
-    valid = valid_w & np.isfinite(s)
+    # Built one band at a time into a single array: the whole-array form holds
+    # two masks plus the temporaries of `isfinite` and `> 0`, which is four
+    # full-resolution booleans (3.5 GB on the detection grid) to produce one.
+    valid = _valid_mask(s, w)
 
     # 1) coarse block means, taken over the valid pixels of each block, so a
     #    bad pixel costs its block sample size instead of poisoning it.
@@ -365,12 +415,16 @@ def get_bg_and_ivar(
         )
         sigma_true = np.float32(1.0)
 
-    # 7) rescale full-res weights.  ``valid``, not ``valid_w``: the weights used
-    # above were masked by both, and a pixel whose science value is non-finite
-    # carries no information regardless of what its weight claims.
+    # 7) rescale full-res weights, masking on ``valid``: a pixel whose science
+    # value is non-finite carries no information regardless of what its weight
+    # claims. Scale and mask in one banded pass -- `where=~valid` would build a
+    # second full-resolution boolean (0.88 GB on the detection grid) for a
+    # mask that already exists.
     scale = np.float32(1.0) / (sigma_true * sigma_true + np.float32(1e-30))
-    ivar_new = np.multiply(w, scale, dtype=np.float32)
-    np.copyto(ivar_new, np.float32(0.0), where=~valid)
+    ivar_new = np.empty(w.shape, dtype=np.float32)
+    for rows in _row_bands(w.shape):
+        np.multiply(w[rows], scale, out=ivar_new[rows], dtype=np.float32)
+        np.copyto(ivar_new[rows], np.float32(0.0), where=np.logical_not(valid[rows]))
     # sigma_true = 1 exactly when the weight map is a calibrated inverse
     # variance; treat a 20% band as "consistent" (drizzle correlation and
     # normalisation conventions both land inside it when the map is honest)
@@ -406,7 +460,15 @@ def get_bg_and_ivar(
 
     # Linearly upsample bgmask to full resolution
     bg_img = expand_to_full(bg_img_bin.astype(np.float32), step, s.shape)
-    bg_img[~valid_w] = 0.0  # zero out invalid pixels
+    # zero out invalid pixels -- on the WEIGHT alone, unlike ivar above: where
+    # the weight is good the background is defined whatever the science pixel
+    # does, and a lone NaN should not punch a hole in a smooth surface. Banded,
+    # and recomputed rather than kept: this is the only use, it runs only when
+    # a full-resolution background was asked for, and holding the mask from the
+    # top of the function costs a full-resolution boolean throughout.
+    for rows in _row_bands(bg_img.shape):
+        wb = w[rows]
+        bg_img[rows][~(np.isfinite(wb) & (wb > 0))] = 0.0
 
     return bg_img, ivar_new
 

--- a/src/mophongo/pipeline.py
+++ b/src/mophongo/pipeline.py
@@ -160,6 +160,12 @@ class RunConfig:
     psf_size: float | None = 4.0
     psf_autobuild: bool = True  # generate missing PSF grids with PSFFactory
     psf_fov_arcsec: float | None = None  # PSFFactory field of view; None = backend default
+    # Which exposure dates get their own grid when autobuilding. "all" (one
+    # per unique integer MJD) is the default because the grids are MJD-tagged
+    # and looked up by nearest date: collapsing an exposure list that spans
+    # years onto one date ("modal") or a few ("cluster") silently discards
+    # that. See psf_factory.dates_from_csv for the full set of modes.
+    psf_date_mode: str | float = "all"
     # extra Gaussian broadening of the lo-res model PSF (FWHM arcsec);
     # "default" = mock_mosaic.DEFAULT_PSF_GAUSSIAN_FWHM_ARCSEC[filter_lo],
     # a number = that value, None = no broadening
@@ -999,7 +1005,8 @@ class Pipeline:
         # An _FOV token in the pattern carries its own field of view;
         # otherwise the config's psf_fov_arcsec applies.
         fov = kw.pop("fov_arcsec", cfg.psf_fov_arcsec)
-        PSFFactory(outdir=str(cfg.psf_dir), fov_arcsec=fov, **kw).from_csv(
+        PSFFactory(outdir=str(cfg.psf_dir), fov_arcsec=fov,
+                   date_mode=cfg.psf_date_mode, **kw).from_csv(
             str(csv), save=True
         )
         dpsf.epsf_obj.load_jwst_stdpsf(local_dir=str(cfg.psf_dir), filter_pattern=pattern)

--- a/src/mophongo/pipeline.py
+++ b/src/mophongo/pipeline.py
@@ -383,6 +383,21 @@ def _read_image(path: str | Path, box: tuple[int, int, int, int] | None = None):
         return full
 
 
+def _apply_repair_patches(
+    patches: Table, sci: np.ndarray, segmap: np.ndarray
+) -> None:
+    """Write a repair patch table's sci/segmap pixels into ``sci``/``segmap``.
+
+    Shared by the cache-reuse path and the fresh-repair path so both end up
+    with the same representation: the original mosaics, patched in place over
+    the saturated cores only.
+    """
+    yy = np.asarray(patches["y"])
+    xx = np.asarray(patches["x"])
+    sci[yy, xx] = np.asarray(patches["sci"], sci.dtype)
+    segmap[yy, xx] = np.asarray(patches["seg"], segmap.dtype)
+
+
 def _upsample_flux_conserving_image_and_ivar(
     image: np.ndarray,
     weight: np.ndarray | None,
@@ -1312,6 +1327,10 @@ class Pipeline:
         cache stores diffs, not mosaics: a PATCHES bintable of changed
         pixels (sci/wht/segmap values) and a FLAGS bintable of the
         catalog's ``FLAG_SATURATED_*`` columns by id.
+
+        The patch table is also left on the instance as ``_repair_patches``,
+        so :meth:`load_data` can replay it onto a fresh memory map instead of
+        holding the repaired mosaics in anonymous memory.
         """
         from astropy.io import fits
 
@@ -1344,6 +1363,7 @@ class Pipeline:
             "seg": np.asarray(rep["segmap"])[yy, xx].astype(np.int64),
         })
         cat = rep["catalog"]
+        self._repair_patches = patches
         flag_cols = [c for c in cat.colnames if c.startswith("FLAG_SATURATED_")]
         flags = Table({"id": np.asarray(cat["id"], np.int64)})
         for c in flag_cols:
@@ -1386,10 +1406,9 @@ class Pipeline:
             patches = Table(hdul["PATCHES"].data)
             flags = Table(hdul["FLAGS"].data)
         wht = wht0.copy()
+        _apply_repair_patches(patches, sci, seg)
         yy, xx = np.asarray(patches["y"]), np.asarray(patches["x"])
-        sci[yy, xx] = np.asarray(patches["sci"], sci.dtype)
         wht[yy, xx] = np.asarray(patches["wht"], wht.dtype)
-        seg[yy, xx] = np.asarray(patches["seg"], seg.dtype)
         by_id = {int(i): k for k, i in enumerate(cat["id"])}
         for col in flags.colnames:
             if col == "id":
@@ -1600,10 +1619,19 @@ class Pipeline:
                 # the pre-repair snapshots exist only to be written to the
                 # cache, and they are two mosaic-sized arrays
                 del sci0, seg0
-                tmpl_hi = rep["sci"]
                 wht_hi_repaired = rep["wht"]
                 cat = rep["catalog"]
-                segmap = as_label_array(rep["segmap"])
+                # `repair_saturated_holes` returns fresh full-field copies of
+                # sci and segmap (saturate.py:733), so holding them costs two
+                # mosaics of anonymous memory for a result that differs from
+                # the inputs only over the saturated cores. Replay the patch
+                # table onto fresh maps of the originals instead, exactly as
+                # the reuse path above does: astropy maps a read-only HDU
+                # copy-on-write, so only the patched pages go private and the
+                # rest stays evictable page cache.
+                tmpl_hi = _read_image(cfg.sci_hi, box_hi)
+                segmap = as_label_array(_read_image(cfg.segmap, box_hi))
+                _apply_repair_patches(self._repair_patches, tmpl_hi, segmap)
                 del rep
             # the raw hi-res weight map is superseded by the repaired one
             del wht0
@@ -1755,6 +1783,103 @@ class Pipeline:
             self.template_table = None
             logger.warning("no template table %s (older run?)", self.f_templates)
         return self
+
+    def _allocate_residual(self, image: np.ndarray, ifilt: int) -> np.ndarray:
+        """Zero-filled residual accumulator, file-backed where possible.
+
+        The residual is written to :attr:`f_residual` at the end of the run
+        either way, so mapping that file's data section costs no extra disk
+        and turns a full reference-grid array of dirty anonymous pages (3.5 GB
+        on a MINERVA field) into file pages the kernel can flush and evict.
+        The access pattern suits it: scattered writes over scene bounding
+        boxes, then one sequential subtract, then stamp-sized reads.
+
+        Falls back to anonymous memory for API-driven runs (no output path)
+        and for bands past the first, which have nowhere distinct to live.
+        """
+        if getattr(self, "run_config", None) is None or ifilt != 1:
+            return np.zeros(image.shape, dtype=image.dtype)
+        try:
+            return self._residual_memmap(image.shape)
+        except OSError as exc:
+            logger.warning(
+                "could not map %s (%s); accumulating the residual in memory",
+                self.f_residual.name, exc,
+            )
+            return np.zeros(image.shape, dtype=image.dtype)
+
+    def _residual_memmap(self, shape: tuple[int, int]) -> np.memmap:
+        """Create ``f_residual`` at full size and map its data section.
+
+        Writes the FITS header, then extends the file with ``truncate`` --
+        which leaves it sparse, so blocks are allocated only as pages are
+        written, and a trial patch costs the patch. The map is big-endian
+        because that is what FITS stores; numpy handles the mixed byte order
+        in the accumulate and the subtract, and :meth:`write_outputs` then has
+        only the header left to finish.
+        """
+        from astropy.io import fits
+
+        cfg = self.run_config
+        path = self.f_residual
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with _quiet_hierarch_warnings():
+            hdr = fits.getheader(cfg.sci_hi).copy()
+            for key in ("SIMPLE", "BITPIX", "NAXIS", "NAXIS1", "NAXIS2",
+                        "EXTEND", "BSCALE", "BZERO"):
+                hdr.remove(key, ignore_missing=True, remove_all=True)
+            hdu = fits.PrimaryHDU(data=np.zeros((1, 1), dtype=np.float32), header=hdr)
+            hdu.header["NAXIS1"] = int(shape[1])
+            hdu.header["NAXIS2"] = int(shape[0])
+            head = hdu.header.tostring(padding=True).encode("ascii")
+        nbytes = int(shape[0]) * int(shape[1]) * 4
+        total = len(head) + nbytes
+        with open(path, "wb") as fh:
+            fh.write(head)
+            fh.truncate(-(-total // 2880) * 2880)  # FITS pads to 2880 blocks
+        res = np.memmap(path, dtype=">f4", mode="r+", offset=len(head), shape=shape)
+        logger.info("residual accumulating into %s (%s, file-backed)",
+                    path.name, human_bytes(nbytes))
+        return res
+
+    def _scene_pixels_needed(self) -> bool:
+        """Whether anything after the solve still reads a scene's band pixels.
+
+        ``Scene.plot`` and ``Scene.residual`` mask on ``scene.weights``, so the
+        weight map survives the end of the solve only until the scene figures
+        are drawn. A run driven directly through the API (no ``run_config``)
+        keeps everything: the caller owns the instance and may plot at any
+        point.
+        """
+        cfg = getattr(self, "run_config", None)
+        return cfg is None or bool(cfg.scene_plots)
+
+    def _release_scene_weights(self, scenes: Sequence["Scene"] | None = None) -> None:
+        """Drop the band weight map from scenes once nothing reads it.
+
+        The weights are last read by ``Templates.predicted_errors`` and by the
+        scene figures; on the upsample path they are a full reference-grid
+        array (3.5 GB on a MINERVA field) that every ``Scene`` holds a
+        reference to, so without this they would stay alive to the end of the
+        process. ``Scene.solve`` refuses to run without them, which is the
+        intended failure: the fit is over.
+
+        Args:
+            scenes: One band's scenes. Defaults to every band recorded on the
+                instance.
+        """
+        bands = [scenes] if scenes is not None else (getattr(self, "all_scenes", []) or [])
+        released = 0
+        for band in bands:
+            for s in band:
+                if getattr(s, "weights", None) is not None:
+                    s.weights = None
+                    released += 1
+        if released:
+            logger.info(
+                "released the band weight map from %d scene(s); memory: %.1f GB",
+                released, memory(),
+            )
 
     def _template_fit_table(self) -> Table:
         """Per-template fit state of the first fitted band as a flat table.
@@ -2137,12 +2262,19 @@ class Pipeline:
         stem = self.out_dir / cfg.name
         # residual is on the hi-res reference grid (upsample path)
         with _quiet_hierarch_warnings():
-            fits.writeto(
-                self.f_residual,
-                self.residuals[0],
-                fits.getheader(cfg.sci_hi),
-                overwrite=True,
-            )
+            if isinstance(self.residuals[0], np.memmap):
+                # already written: run() accumulated straight into the file's
+                # data section (see _residual_memmap), so only the pages still
+                # held by the kernel are outstanding
+                self.residuals[0].flush()
+                logger.info("residual flushed to %s", self.f_residual.name)
+            else:
+                fits.writeto(
+                    self.f_residual,
+                    self.residuals[0],
+                    fits.getheader(cfg.sci_hi),
+                    overwrite=True,
+                )
             self.table.write(self.f_fit_table, overwrite=True)
 
             # per-template fit state: everything the solve produced that a
@@ -2150,8 +2282,6 @@ class Pipeline:
             # shifts, scenes)
             if getattr(self, "all_templates", None):
                 self._template_fit_table().write(self.f_templates, overwrite=True)
-            if cfg.save_stamps:
-                self.write_stamps()
 
         scene_dir = self.out_dir / "scenes"
         if cfg.scene_plots and self.scenes:
@@ -2223,6 +2353,19 @@ class Pipeline:
             import matplotlib.pyplot as plt
 
             plt.close(out[0])
+
+        # Everything that reads a scene's band pixels has now run. The stamps
+        # come last on purpose: writing them is the run's other memory peak
+        # (two full template sets, plus one stamp in flight), and the band
+        # weight map -- a full reference-grid array on the upsample path -- is
+        # dead from the moment the fluxes were solved. Releasing it here keeps
+        # it out of that peak. run() does the same release earlier for runs
+        # that plot nothing at all.
+        self._release_scene_weights()
+        if cfg.save_stamps:
+            with _quiet_hierarch_warnings():
+                self.write_stamps()
+
         logger.info("outputs written to %s", self.out_dir)
         return self
 
@@ -2358,7 +2501,6 @@ class Pipeline:
 
         wcs_hi = self.wcs[0] if self.wcs is not None else None
         rows: dict[str, list] = defaultdict(list)
-        vla = {"hi": [], "lo": []}
         for t_lo in conv:
             t_hi = hi_by_id.get(int(t_lo.id))
             if t_hi is None:
@@ -2372,18 +2514,19 @@ class Pipeline:
                 ra, dec = (float(v) for v in wcs_hi.wcs_pix2world(x, y, 0))
             for tag, t in (("hi", t_hi), ("lo", t_lo)):
                 if t is None:
-                    data = np.zeros((0, 0), dtype=np.float32)
+                    shape = (0, 0)
                     x0 = y0 = -1
                     xs = ys = np.nan
                 else:
-                    data = np.asarray(t.data, dtype=np.float32)
+                    # shape only: the pixels are written in the second pass
+                    # below, straight into their slot in the dataset
+                    shape = t.data.shape
                     # data[0, 0] sits at this original-grid pixel (may be
                     # negative for cutouts padded past the image edge)
                     x0, y0 = (int(v) for v in t._origin_original_true)
                     xs, ys = (float(v) for v in t.input_position_original)
-                vla[tag].append(data.ravel())
-                rows[f"ny_{tag}"].append(data.shape[0])
-                rows[f"nx_{tag}"].append(data.shape[1])
+                rows[f"ny_{tag}"].append(shape[0])
+                rows[f"nx_{tag}"].append(shape[1])
                 rows[f"x0_{tag}"].append(x0)
                 rows[f"y0_{tag}"].append(y0)
                 rows[f"xs_{tag}"].append(xs)
@@ -2412,24 +2555,31 @@ class Pipeline:
         # One flat float32 buffer per band plus per-source offsets, rather
         # than one dataset per source: 138,610 HDF5 datasets would spend more
         # on object headers than on pixels, and the ragged concatenation is
-        # what both readers want anyway. Chunked and gzipped -- template
-        # stamps are mostly zero outside the segment, so this compresses hard.
+        # what both readers want anyway.
+        #
+        # Offsets come from the shapes recorded above, so each dataset is
+        # created at its final size and every stamp is written straight into
+        # its own slot. Collecting the flattened stamps in a list and
+        # concatenating held a full extra copy of every stamp -- 12 GB on a
+        # MINERVA field -- at the very end of the run, on top of the two
+        # template sets that are still alive here.
         hdr = self._stamps_header(ifilt, len(conv))
-        npix = sum(a.size for a in vla["hi"]) + sum(a.size for a in vla["lo"])
+        offs = {}
+        for tag in ("hi", "lo"):
+            sizes = (np.asarray(rows[f"ny_{tag}"], dtype=np.int64)
+                     * np.asarray(rows[f"nx_{tag}"], dtype=np.int64))
+            offs[tag] = np.concatenate([[0], np.cumsum(sizes)]).astype(np.int64)
+        npix = int(offs["hi"][-1]) + int(offs["lo"][-1])
         with h5py.File(path, "w") as h5:
             for key in hdr:
                 if key in ("COMMENT", "HISTORY", ""):
                     continue
                 value = hdr[key]
                 h5.attrs[key] = value if isinstance(value, (int, float, str)) else str(value)
+            pixels = {}
             for tag in ("hi", "lo"):
-                flat = (
-                    np.concatenate(vla[tag]) if vla[tag]
-                    else np.zeros(0, dtype=np.float32)
-                )
-                sizes = np.array([a.size for a in vla[tag]], dtype=np.int64)
-                offs = np.concatenate([[0], np.cumsum(sizes)]).astype(np.int64)
                 grp = h5.create_group(f"tmpl_{tag}")
+                total = int(offs[tag][-1])
                 # chunks bounded independently of stamp size: a 1 Mi-element
                 # chunk is 4 MiB, and a stamp spans at most a few of them
                 # uncompressed: gzip-1 bought 26% on a full field (11.2 ->
@@ -2437,11 +2587,19 @@ class Pipeline:
                 # working products read back by the diagnostics, not archive.
                 # Chunked anyway, so a single-source read still touches only
                 # its own chunks.
-                grp.create_dataset(
-                    "pixels", data=flat, dtype="f4",
-                    chunks=(min(1 << 20, max(flat.size, 1)),),
+                pixels[tag] = grp.create_dataset(
+                    "pixels", shape=(total,), dtype="f4",
+                    chunks=(min(1 << 20, max(total, 1)),),
                 )
-                grp.create_dataset("offset", data=offs, dtype="i8")
+                grp.create_dataset("offset", data=offs[tag], dtype="i8")
+            for i, t_lo in enumerate(conv):
+                t_hi = hi_by_id.get(int(t_lo.id))
+                for tag, t in (("hi", t_hi), ("lo", t_lo)):
+                    o0, o1 = int(offs[tag][i]), int(offs[tag][i + 1])
+                    if o1 > o0:
+                        pixels[tag][o0:o1] = np.asarray(
+                            t.data, dtype=np.float32
+                        ).ravel()
             src = h5.create_group("sources")
             for name, values in rows.items():
                 arr = np.asarray(values)
@@ -3834,12 +3992,13 @@ class Pipeline:
         logger.info("Pipeline (start) memory: %.1f GB", memory())
         logger.info("Pipeline config: %s", config)
 
-        # test for NaN values in images and weights
-        for i in range(len(images)):
-            if images[i] is None:
-                assert np.all(np.isfinite(images[i])), "Image contains NaN values"
-            if weights[i] is not None:
-                assert np.all(np.isfinite(weights[i])), "Weights contain NaN values"
+        # No whole-array finiteness sweep here. The image branch of the old
+        # check was inverted (it fired only when the image was None, and then
+        # np.isfinite(None) raises), and the weight branch touched all 876 Mpx
+        # of the detection ivar to re-check a guard load_data:1649-1664 has
+        # already applied -- it zeroes non-finite pixels in image AND weight
+        # so they carry no information. Templates are still asserted finite
+        # after extraction (_prepare_hi_templates).
 
         with self._phase("catalog"):
             cat = self._fit_catalog(config)
@@ -4043,11 +4202,13 @@ class Pipeline:
                     released, memory(),
                 )
 
-            # build model in res first, then subtract from image. np.zeros,
-            # not np.zeros_like: zeros_like memsets every page, which on a
-            # trial run materialises the whole reference grid.
+            # build model in res first, then subtract from image. File-backed
+            # when the run has an output path (see _allocate_residual);
+            # np.zeros, not np.zeros_like, for the in-memory case: zeros_like
+            # memsets every page, which on a trial run materialises the whole
+            # reference grid.
             with self._phase("residual"):
-              res = np.zeros(images[ifilt].shape, dtype=images[ifilt].dtype)
+              res = self._allocate_residual(images[ifilt], ifilt)
               for s in scenes:
                 sl = _slices_from_bbox(s.bbox)
                 res[sl] += s.model_image()  # adds models in place
@@ -4059,6 +4220,16 @@ class Pipeline:
             fluxes = [t.flux for t in templates]
             errs = [t.err for t in templates]
             err_pred = Templates.predicted_errors(templates, weights_i)
+
+            # Last read of the band's inverse variance in the fit itself.
+            # Nothing after this point -- residual, aperture photometry,
+            # catalog update, write_outputs -- touches it except the scene
+            # figures, so a run that draws none can drop it here already;
+            # write_outputs releases it for the rest, after the figures and
+            # before the stamps.
+            if not self._scene_pixels_needed():
+                weights_i = None
+                self._release_scene_weights(scenes)
             throughput = _filter_psf_throughput(
                 psfs[ifilt] if psfs is not None else None,
                 None if psf_throughputs is None else psf_throughputs[ifilt],

--- a/src/mophongo/psf_factory.py
+++ b/src/mophongo/psf_factory.py
@@ -195,7 +195,12 @@ class PSFFactory:
         Write detector-sampled rather than oversampled PSFs. Default False.
     date_mode
         Default epoch-selection mode for :meth:`from_csv`; see
-        :func:`dates_from_csv`. Default ``'modal'``.
+        :func:`dates_from_csv`. Default ``'all'`` -- one grid per unique
+        integer MJD in the exposure list. The alternatives collapse an
+        exposure list that spans years onto one or a few dates, which
+        silently defeats the MJD-tagged lookup the grids exist for:
+        ``'modal'`` in particular returns a single date, so a band observed
+        over four years would be fitted with one epoch's wavefront.
     span
         Window width in days for ``'modal'``. Default 5.0.
     delta_day
@@ -214,7 +219,7 @@ class PSFFactory:
     oversample: int = 4
     fov_arcsec: float | None = None
     use_detsampled_psf: bool = False
-    date_mode: str | float | Time = "modal"
+    date_mode: str | float | Time = "all"
     span: float = 5.0
     delta_day: float = 2.0
     include_mjd: bool = True
@@ -340,7 +345,7 @@ class PSFFactory:
         date_mode
             See :func:`dates_from_csv`. May also be an iterable of modes /
             literals to combine (e.g. ``("modal", "median")``). Default =
-            factory's ``date_mode`` (``'modal'``).
+            factory's ``date_mode`` (``'all'``).
         span
             Window width (days) for ``'modal'``. Default = factory's ``span``.
         delta_day

--- a/src/mophongo/scene.py
+++ b/src/mophongo/scene.py
@@ -1299,7 +1299,8 @@ class Scene:
         model_cut = self.model_image()
         if residual_image is not None:
             res_cut = np.asarray(residual_image)[sl].copy()
-            res_cut[(self.weights[sl] <= 0) | np.isnan(self.weights[sl])] = 0.0
+            if self.weights is not None:
+                res_cut[(self.weights[sl] <= 0) | np.isnan(self.weights[sl])] = 0.0
         else:
             res_cut = self.residual()
         if null_mask is not None and null_mask.any():
@@ -1546,10 +1547,17 @@ class Scene:
         return model_scene
 
     def residual(self) -> np.ndarray:
-        """Return image-model residual over the scene's bounding box."""
+        """Return image-model residual over the scene's bounding box.
+
+        Zero-weight pixels are nulled when the weight map is still attached;
+        ``Pipeline.run`` releases it after the solve on runs that plot nothing
+        (see ``Pipeline._scene_pixels_needed``), and the raw residual is the
+        honest answer then.
+        """
         bb = self.bbox
         sl = _slices_from_bbox(bb)
         res_scene = self.image[sl] - self.model_image()
-        res_scene[(self.weights[sl] <= 0) | np.isnan(self.weights[sl])] = 0.0
+        if self.weights is not None:
+            res_scene[(self.weights[sl] <= 0) | np.isnan(self.weights[sl])] = 0.0
         return res_scene
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -26,3 +26,65 @@ def test_deblend_label_info_marks_children_split_from_parent():
     assert info[3] == (1, 2, True)
     assert info[4] == (1, 2, True)
     assert info[5] == (2, 1, False)
+
+
+def _noisy_field(seed=7, shape=(200, 160)):
+    """Science + weight pair with the awkward pixels: zero, NaN weight, NaN sci."""
+    rng = np.random.default_rng(seed)
+    sci = rng.normal(0.0, 2e-3, shape).astype(np.float32)
+    sci[40:52, 40:52] += 0.08  # something for the source mask to find
+    wht = np.full(shape, 3e5, np.float32)
+    wht[:4] = 0.0
+    wht[-3:] = np.nan
+    sci[15, 15] = np.nan
+    return sci, wht
+
+
+def test_get_bg_and_ivar_does_not_copy_on_byte_order():
+    """Big-endian input gives identical output and is not cast up front.
+
+    FITS stores big-endian, so a memory-mapped mosaic arrives as '>f4'.
+    Casting it to native float32 would copy the whole array -- 3.5 GB per
+    input on a MINERVA detection grid -- for a difference nothing downstream
+    needs.
+    """
+    from mophongo.catalog import _as_float, get_bg_and_ivar
+
+    big = np.zeros((4, 4), dtype=">f4")
+    assert _as_float(big) is big
+    # a non-float input still has to be converted
+    assert _as_float(np.zeros((2, 2), np.int32)).dtype == np.float32
+
+    sci, wht = _noisy_field()
+    for need_bg in (True, False):
+        bg_n, ivar_n = get_bg_and_ivar(sci, wht, need_bg=need_bg)
+        bg_b, ivar_b = get_bg_and_ivar(
+            sci.astype(">f4"), wht.astype(">f4"), need_bg=need_bg
+        )
+        assert np.array_equal(ivar_n, ivar_b)
+        assert ivar_n.dtype == ivar_b.dtype == np.float32
+        if need_bg:
+            assert np.array_equal(bg_n, bg_b)
+            assert bg_n.dtype == np.float32
+        else:
+            assert bg_n is None and bg_b is None
+
+
+def test_get_bg_and_ivar_masks_ivar_and_background_differently():
+    """ivar needs finite science; the background only needs a good weight.
+
+    A lone bad science pixel carries no information, so its inverse variance
+    is zeroed -- but the background surface there is still defined, and
+    punching a hole in a smooth fit would be worse than keeping it.
+    """
+    from mophongo.catalog import get_bg_and_ivar
+
+    sci, wht = _noisy_field()
+    bg, ivar = get_bg_and_ivar(sci, wht, need_bg=True)
+
+    assert ivar[0, 0] == 0.0        # zero weight
+    assert ivar[-1, 0] == 0.0       # NaN weight
+    assert ivar[15, 15] == 0.0      # NaN science
+    assert bg[0, 0] == 0.0          # zero weight
+    assert bg[-1, 0] == 0.0         # NaN weight
+    assert bg[15, 15] != 0.0        # NaN science: background still defined

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -268,3 +268,46 @@ def test_stamps_and_diag_cli_from_a_run_directory(run_dir, monkeypatch):
         [cat["ra"][0], cat["dec"][0]], abs=1e-9
     )
     assert (run_dir / "tiny_1_subphot.png").exists()
+
+
+def test_config_run_writes_the_residual_through_its_memmap(run_dir):
+    """End-to-end config run: the residual file IS the accumulator.
+
+    run() maps `f_residual` and accumulates scene models into it, so
+    write_outputs only flushes. What lands on disk must equal image - model,
+    and the band weight map must be gone from the scenes afterwards (nothing
+    plots in this run, so nothing reads it again).
+    """
+    from pathlib import Path
+
+    import numpy as np
+    from mophongo.pipeline import Pipeline
+    from mophongo.scene import _slices_from_bbox
+
+    pipe = Pipeline.from_config(run_dir / "tiny.json")
+    pipe.run()
+
+    res = pipe.residuals[0]
+    assert isinstance(res, np.memmap), "residual should be file-backed"
+    assert Path(res.filename) == pipe.f_residual
+
+    # this config plots scenes, so the weights survive run() -- the figures
+    # still mask on them -- and write_outputs releases them once drawn
+    assert pipe._scene_pixels_needed()
+    scene = pipe.all_scenes[0][0]
+    assert scene.weights is not None
+
+    expected = np.asarray(res).copy()
+    pipe.write_outputs()
+
+    assert all(s.weights is None for s in pipe.all_scenes[0])
+    # a scene still reports its residual without them, unmasked
+    sl = _slices_from_bbox(scene.bbox)
+    assert scene.residual().shape == scene.image[sl].shape
+
+    on_disk = fits.getdata(pipe.f_residual)
+    assert np.array_equal(on_disk, expected)
+    assert on_disk.shape == pipe.images[1].shape
+    # residual = image - model, and the model came from the fitted scenes
+    model = pipe.model_images[0]
+    assert np.allclose(on_disk, pipe.images[1] - model, atol=1e-6)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -357,6 +357,14 @@ def test_write_stamps_variable_size_single_file(tmp_path):
     assert len(recs) == len(conv)
     rec = recs[0]
     assert rec["tmpl_hi"].shape == hi_by_id[int(conv[0].id)].data.shape
+    # pixels land in the right slot: stamps are written straight into the
+    # dataset at offsets derived from the recorded shapes, so a mismatch
+    # between the shape pass and the pixel pass would shear every stamp
+    for rec, t_lo in zip(recs, conv):
+        t_hi = hi_by_id[int(t_lo.id)]
+        # exact at the file's own precision: stamps are stored float32
+        assert np.array_equal(rec["tmpl_lo"], np.float32(t_lo.data))
+        assert np.array_equal(rec["tmpl_hi"], np.float32(t_hi.data))
 
     # file attributes hold only the pointers load_fit needs
     with h5py.File(path, "r") as h5:

--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -227,6 +227,103 @@ def test_load_outputs_resume(tmp_path):
     assert "results: table 2 rows" in fresh.info()
 
 
+def test_residual_memmap_is_the_output_file(tmp_path):
+    """The residual accumulator writes through to ``f_residual``.
+
+    run() accumulates scene models straight into the output file's data
+    section rather than into anonymous memory, so what write_outputs has left
+    to do is flush. The file must be a valid FITS image with the detection
+    band's header, and reading it back must give the accumulated pixels.
+    """
+    import numpy as np
+    from astropy.io import fits
+    from astropy.wcs import WCS
+
+    hi = tmp_path / "hi.fits"
+    w = WCS(naxis=2)
+    w.wcs.crpix = [8.0, 6.0]
+    w.wcs.crval = [150.0, 2.0]
+    w.wcs.cdelt = [-1e-5, 1e-5]
+    w.wcs.ctype = ["RA---TAN", "DEC--TAN"]
+    hdr = w.to_header()
+    hdr["FILTER"] = "F770W"
+    fits.writeto(hi, np.zeros((11, 13), dtype=np.float32), hdr)
+
+    pipe = Pipeline.from_config(_write_config(tmp_path, {"sci_hi": str(hi)}))
+    res = pipe._residual_memmap((11, 13))
+    assert isinstance(res, np.memmap)
+    assert res.shape == (11, 13)
+
+    res[:] = 0.0
+    res[3, 4] = 2.5
+    res[10, 12] = -1.25
+    res.flush()
+
+    got, got_hdr = fits.getdata(pipe.f_residual, header=True)
+    assert got.shape == (11, 13)
+    assert got[3, 4] == 2.5 and got[10, 12] == -1.25
+    assert got.sum() == 1.25
+    # the detection band's WCS and provenance ride along
+    assert got_hdr["FILTER"] == "F770W"
+    assert WCS(got_hdr).wcs.crval[0] == 150.0
+
+
+def test_residual_allocation_falls_back_without_a_config():
+    """API-driven runs (no out_dir) keep the residual in memory."""
+    import numpy as np
+
+    from mophongo import pipeline as pl
+
+    pipe = pl.Pipeline.__new__(pl.Pipeline)
+    pipe.run_config = None
+    img = np.zeros((5, 6), dtype=np.float32)
+    res = pipe._allocate_residual(img, 1)
+    assert not isinstance(res, np.memmap)
+    assert res.shape == img.shape and res.dtype == img.dtype
+
+
+def test_repair_patches_do_not_write_through_to_the_input(tmp_path):
+    """Replaying a repair patch table leaves the input mosaics untouched.
+
+    load_data applies the patches to fresh maps of sci_hi/segmap rather than
+    holding the repaired mosaics, which is only safe because astropy maps a
+    read-only HDU copy-on-write.
+    """
+    import numpy as np
+    from astropy.io import fits
+    from astropy.table import Table
+
+    from mophongo.pipeline import _apply_repair_patches, _read_image
+
+    sci_path = tmp_path / "sci.fits"
+    seg_path = tmp_path / "seg.fits"
+    sci0 = np.arange(48, dtype=np.float32).reshape(6, 8)
+    seg0 = np.zeros((6, 8), dtype=np.int32)
+    fits.writeto(sci_path, sci0)
+    fits.writeto(seg_path, seg0)
+
+    patches = Table({
+        "y": np.array([1, 4], np.int32), "x": np.array([2, 7], np.int32),
+        "sci": np.array([-9.0, 3.5], np.float32),
+        "wht": np.array([0.0, 0.0], np.float32),
+        "seg": np.array([7, 7], np.int64),
+    })
+    sci = _read_image(sci_path)
+    seg = _read_image(seg_path)
+    _apply_repair_patches(patches, sci, seg)
+
+    assert sci[1, 2] == -9.0 and sci[4, 7] == 3.5
+    assert seg[1, 2] == 7 and seg[4, 7] == 7
+    # everything else is the original
+    untouched = np.ones((6, 8), bool)
+    untouched[[1, 4], [2, 7]] = False
+    assert np.array_equal(np.asarray(sci)[untouched], sci0[untouched])
+
+    del sci, seg
+    assert np.array_equal(fits.getdata(sci_path), sci0)
+    assert np.array_equal(fits.getdata(seg_path), seg0)
+
+
 def test_trial_pixel_box_and_partial_read(tmp_path):
     """Only the trial box is read, into a full-shape array.
 


### PR DESCRIPTION
## Summary

Two things, found together while standing up the MINERVA v1.0b campaign on OzStar.

**`PSFFactory.date_mode` defaulted to `"modal"`** — the centre of the densest five-day window, i.e. exactly one date. The grids are MJD-tagged and looked up by nearest date, so autobuilding a band whose exposures span years produced a single epoch's wavefront for all of them, silently. MINERVA exposure lists span up to 1460 days over 4–18 epochs, so every autobuilt band got one grid while the pre-built UDS F770W/F1800W had nine (those were made in `cluster` mode). A release built that way mixes two PSF conventions across its bands.

The default is now `"all"` (one grid per unique integer MJD), and the mode is reachable from a config for the first time via `RunConfig.psf_date_mode`, threaded into the `PSFFactory` call in `Pipeline._load_epsf`. `make_minerva_configs.py` writes it explicitly rather than relying on the default, so the generated MINERVA, CANFAR and OzStar configs all state it.

Grid counts implied, from the real exposure lists: **416 across the release** against 333 in cluster mode (UDS F770W 17 vs 9, COSMOS F444W 78 vs 44, EGS F444W 42 vs 2).

**`examples/ozstar/`** is the CANFAR toolkit's counterpart for Ngarrgu Tindebeek. Two differences drive the design: OzStar has no view of the MINERVA release, so every input is copied from CANFAR arc onto `/fred` first; and compute is ssh + SLURM rather than a REST API, so a campaign is one dependency graph submitted in a single command and nothing afterwards depends on the laptop.

## Modules modified or added

- `src/mophongo/psf_factory.py` — `date_mode` default `modal` → `all`
- `src/mophongo/pipeline.py` — new `RunConfig.psf_date_mode`, passed to `PSFFactory`
- `examples/make_minerva_configs.py` — emits `psf_date_mode`
- `examples/canfar/arcify.py` — run root resolved lazily so `ozify.py` can reuse the arc indexing without a CANFAR run root; behaviour unchanged
- `examples/ozstar/` — new: `ozroot.py`, `ozify.py`, `submit.py`, `campaign.py`, `release_v1.0b.sh`, `jobs/`

## Platform constraints encoded (all measured, not assumed)

| node | internet | `/apps` modules |
|---|---|---|
| login | yes | yes |
| datamover | yes | **no** |
| compute (skylake/milan) | **no DNS, no route** | yes |

Consequences, documented in `examples/ozstar/README.md`: PSF grids can only be built on the login node, because `stpsf` resolves each exposure's OPD by querying MAST; staging runs on datamover with its own `venv-vos` built from the OS python; Lmod is hierarchical (`python/3.12.3` needs `gcccore/13.3.0`); and a site plugin overrides a partition named only in a `#SBATCH` directive, silently sending transfers to a node with no route.

## Validation

- `poetry run pytest`: **358 passed**
- End-to-end on OzStar: `uds_f770w` 1.5′ trial completed (4,607 sources, 20 GB, 9m51s); `uds_f770w_v1.0b` full field completed (138,634 sources, 8,827 at SNR>5, **57.4 GB MaxRSS**, 56m19s)
- CPU measured at 6.1% of 16 cores throughout — the fit is serial; memory is the binding resource

## Follow-ups filed in TODO.md

- Grids already on disk are cluster-mode and will not upgrade themselves: autobuild fires only when *nothing* matches the pattern. Uniformity means deleting and rebuilding ~416 grids, worth measuring against the photometry first.
- Autobuild is silent about incompleteness — a band with one grid and one with seventeen both "match" — which is why this needed manual inspection to find.

The second commit carries `STATUS.md`/`TODO.md` edits that were already in the working tree before the session; drop it if they were not meant to ship yet.

https://claude.ai/code/session_01VJGNx91tzB7tE1uNvxpyoK

---

## Also on this branch: the full-field memory work (#107)

Merged into this branch after the above. An audit of every full-field array a
run allocates — where each is born, where it is last read, and whether it is
still needed or merely still referenced (`docs/MEMORY_LIFETIMES.md`) — plus six
fixes. Sizes are for the 876 Mpx MINERVA UDS detection grid, 3.5 GB per float32
plane.

1. **Release the band weight map once nothing reads it.** `weights_i` is last
   read by `Templates.predicted_errors`, but every `Scene` holds a reference
   and `self.all_scenes` holds every scene, so 3.5 GB of dead weights survived
   through the stamp write.
2. **Write the stamps last**, after the scene figures rather than before. This
   is what makes (1) useful: `scene_plots` defaults on, every production config
   sets it, and the figures were the last reader.
3. **Accumulate the residual into its own output file.** It was written to
   `f_residual` anyway, so mapping that file costs no extra disk; the file is
   extended sparsely, so a trial patch still costs the patch.
4. **Replay the repair patch table onto a copy-on-write map** instead of
   holding the two full-field mosaics `repair_saturated_holes` returns. This is
   what the cache-reuse path already did; both now share one helper.
5. **Stream `write_stamps`** into datasets created at final size, removing a
   full extra copy of every stamp (12 GB full-field) at the end of the run.
6. **Stop copying on byte order in `get_bg_and_ivar`.** FITS is big-endian, so
   a mapped float32 mosaic is `>f4` and `np.asarray(x, dtype=np.float32)`
   copies. Peak allocation falls **140.5 → 58.9 MB** on a 9 Mpx test, i.e.
   **13.6 → 5.7 GB** at 876 Mpx. Output is bit-identical to the previous
   implementation across sizes, both `need_bg` settings, and both byte orders.

Also drops the `isfinite` sweep at the top of `run`: its image branch was
inverted and unreachable, and its weight branch touched all 876 Mpx to
re-check a guard `load_data` had already applied.

`AGENTS.md` gains a **Branches And Commits** section: do not create a branch,
commit, push, or open a PR unless asked, and commit only the files belonging to
the task.

Suite: **364 passed** (358 before). New coverage for the residual memmap round
trip end to end, the anonymous fallback, copy-on-write patch replay, stamp
pixel equality after a round trip, and byte-order invariance of
`get_bg_and_ivar` with its two distinct masking rules.

Still open in `TODO.md`: ivar as `(memmapped wht, scale, mask)` rather than a
materialised array; `weights[1]` after the upsample; and the two template sets,
the largest anonymous term left.
