### PR TITLE
Weight astrometric anchors by how much they agree with each other

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,8 @@ Key components:
 - `astrometry.py`, `jwst_psf.py`: astrometric corrections and JWST PSF
   utilities. Deblending uses `photutils.segmentation.deblend_sources`,
   re-exported from `mophongo/__init__.py`.
+- `astrom_robust.py`: robust weighting of a scene's astrometric anchors,
+  selected by `FitConfig.astrom_robust`.
 
 ## Module Boundaries
 
@@ -134,6 +136,12 @@ Guiding rules:
   `templates.py`, `fit.py`, `catalog.py` or `pipeline.py`. Dispatch lives in
   `Templates.extract_templates` and `Pipeline._extend_scheme_kwargs` so a
   scheme can be adapted or removed as a unit.
+- `astrom_robust.py` is a leaf for the same reason: it takes an anchor table
+  (implied shifts, information, basis rows) as plain arrays and returns
+  weights, with no imports from `scene.py`, `fit.py` or `templates.py`. The
+  measurement that produces the table lives in `scene.py`, which is where the
+  template geometry is. Keeping the statistics separable is what lets the
+  non-joint path in `astrometry.py` reuse them.
 
 Concrete rule: if module A needs information that module B owns, prefer passing
 the result through a flat structure B already exposes rather than importing A

--- a/STATUS.md
+++ b/STATUS.md
@@ -3,6 +3,303 @@
 This file records completed implementations, validation runs, and the current work state.
 
 ## Current Work
+- [x] `FitConfig.astrom_robust` defaults to `True` (2026-08-16). The failure it
+  prevents is one-sided: anchor leverage grows as flux squared, so a single
+  bright extended source with an asymmetric colour gradient produces a
+  residual dipole indistinguishable from a shift and drags its scene's field.
+  The estimator costs a few percent of efficiency on clean anchors, which is
+  the cheaper of the two errors. Still gated on `scene_minimum_anchors`, so
+  scenes too small to judge fall back to `astrom_leverage_cap` as before, and
+  `astrom_isolation_thresh` is still needed ahead of it -- a blended anchor's
+  implied shift is shrunk coherently, so blended anchors agree with each other
+  and majority rule follows them. `astrom_robust=False` recovers the old
+  behavior, and `SCENES` carries `astrom_robust`/`astrom_nreject`/`astrom_neff`
+  for the A/B comparison. Docs updated in `docs/fitting.md`, `docs/pipeline.md`.
+
+- [x] `FitConfig.astrom_model` defaults to `"poly"` (2026-08-16). It was
+  `"gp"`, which never described what the default run does: the joint path is
+  on by default and takes its basis order straight from
+  `astrom_kwargs["poly"]["order"]` (`scene.py:1475`) without branching on the
+  model, so `"gp"` was reachable only by also setting
+  `fit_astrometry_joint=False`. A provenance dump therefore reported a model
+  the run had not used. No behavior change -- the joint path reads the same
+  order either way -- only the recorded and non-joint defaults now agree.
+  Docstrings in `fit.py` and the tables in `docs/fitting.md` and
+  `docs/pipeline.md` say which path reads the field. Making the joint path
+  honor `"gp"` needs a global cross-scene field; the design is in `TODO.md`.
+
+- [x] Scene catalogs say how well the shift was measured, not just what it was
+  (2026-08-16). `dx`/`dy` alone cannot be read: a 0.2 px shift means nothing
+  until you know whether it was measured to 0.02 px or to 0.5 px.
+  * `SceneFitter._shift_covariance` recovers the shift block's covariance,
+    which `_solve_flux_and_shifts` was computing (the Cholesky of `BB`) and
+    discarding. In whitened variables the shift block of the joint inverse is
+    `(I - AB_w' A_w^-1 AB_w)^-1`, i.e. after the fluxes absorb what they can;
+    unwhitened by `Linv' cov Linv`. Costs one sparse factorization plus `nB`
+    back-solves, and `nB` is 2 at order 0. Taking `BB^-1` instead would be
+    free but wrong by the flux-shift degeneracy, measured at tens of percent
+    when a neighbour sits about a FWHM from an anchor.
+  * `Scene.shift_error()` evaluates it at the basis origin, averaged over the
+    axes -> `sigma_shift`. It is the *last pass's* number: passes re-measure
+    the same pixels, so at convergence the accumulated shift is determined
+    about as well as any one pass determines it. Tests pin that it scales
+    linearly with the noise and brackets the true error (7 of 8 realizations
+    inside 3 sigma).
+  * `Scene.chi2_dof()` -> `chi2_dof`, reduced chi-square over the scene bbox
+    against the residual with *every* scene's model subtracted (`Scene.residual`
+    keeps the neighbours' light and would charge it to this scene), with one
+    free parameter per template plus the shift coefficients. Sorting on it is
+    the direct way to find the scenes worth looking at.
+  * `Scene.shift_scatter()` -> `shift_rms`, the spread of applied shifts about
+    their mean. At order 0 every template gets the same offset, so non-zero
+    means the field moved between passes -- the scene walked rather than
+    settled, which is a direct detector for the non-convergence in TODO.
+  * `is_bright` -> `n_anchor` in the CSV and `n_bright` -> `n_anchor` in the
+    SCENES extension: the count is templates passing the *anchor* cuts (SNR,
+    isolation, star exclusion), and isolation is not brightness. It is the
+    count before robust rejection; `astrom_neff` is after. `verification.py`
+    and `examples/compare_dr0_dr0.1.py` follow.
+- [x] Refit validated against the run on COSMOS F770W scene 1313 (2026-08-16):
+  107 of 107 templates rebuilt and the baseline within 0.035 px of the run's
+  own shift, so the frozen-membership refit path reproduces a normal scene.
+  Scene 16's 24-source shortfall is the `ff3b8d4` version skew, not a refit
+  defect. The robust pass declined 1313 (6 anchors, `n_eff` 4.9 below the
+  `scene_minimum_anchors` gate of 5) and was then an exact no-op: `dchi2` 0,
+  zero flux change on all 107 sources. Note the interaction -- a scene with
+  exactly `scene_minimum_anchors` anchors nearly always declines, because any
+  real disagreement pulls `n_eff` below the count.
+- [x] An upsampled band keeps its weight on the same grid as its image
+  (2026-08-16). `_convolved_templates` upsampled `images[ifilt]` onto the
+  reference grid and set `wcs[ifilt] = wcs[0]`, but the upsampled weight only
+  ever lived in a local: the instance was left holding a reference-grid image
+  beside a native-grid weight, and the collapsed WCS hid it, because the next
+  call computes `k = 1` and upsamples neither. `load_fit`'s replay of the same
+  transform had the same omission.
+  * A second pass over one band -- exactly what `_solve_frozen_scene` does --
+    then sliced an 80 mas weight map with 40 mas coordinates. Numpy clips
+    out-of-range slices rather than raising, so the read silently returned the
+    wrong region of sky.
+  * Symptoms on COSMOS F770W scene 16: 48 templates over covered sky pruned as
+    uncovered (236 -> 188), the scene residual masked over valid pixels with
+    the mask tracing a footprint offset from the data, and the fitted shift
+    corrupted to (+0.03, -0.92) px against the run's (-0.02, +0.00). After the
+    fix all 236 available templates survive, and the baseline lands at
+    (+0.22, -0.09) px. Found from the residual figure, not from a test.
+  * Both call sites now write the upsampled weight back, and
+    `_convolved_templates` raises when the weight and image shapes disagree
+    rather than trusting the pairing. Tests
+    `test_upsampled_band_keeps_its_weight_on_the_same_grid` and
+    `test_convolved_templates_rejects_a_weight_on_the_wrong_grid`.
+  * Every refit measurement taken before this is void.
+- [x] PSF settings moved into a `psf` config block, `expect_frames` removed
+  (2026-08-16). `RunConfig` carried ten flat `psf_*`/`pattern_*` keys; they
+  are now a nested `PsfConfig` (`dir`, `pattern_hi`, `pattern_lo`, `size`,
+  `autobuild`, `provenance`, `workers`, `fov_arcsec`, `date_mode`,
+  `blur_fwhm`), reached as `cfg.psf.<field>` and written as a JSON object the
+  way `fit` already was. The redundant `psf_` prefix is dropped inside the
+  block. `filter_lo` stays top-level: it names the band for figure labels as
+  well as for the blur lookup. A JSON dict is coerced by `__post_init__`,
+  unknown keys inside the block raise, and `from_json` raises on the old flat
+  keys naming their replacements rather than ignoring them.
+  * `expect_frames` is gone. It asserted the row counts of the same two WCS
+    csvs the run reads, so it could only fire when the exposure list changed
+    -- which is when a run wants the new frames, not a raise. The stale
+    COSMOS value (518 against the 288 frames now in the table) is what it
+    produced in practice. `_ensure_dpsfs` logs the two counts instead.
+  * Migrated: the five hand-written `examples/*.json`, the 18 generated
+    `examples/minerva/*.json`, `make_minerva_configs.py` (which no longer
+    counts csv rows), the ozstar/canfar `build_psfs.py`, `campaign.py`,
+    `ozify.py` and `arcify.py`, and the docs (`pipeline.md` gained a
+    "The `psf` block" reference section; `quickstart.md`, `psf.md`,
+    `repair.md`, `campaigns.md`, `psf_maps.md` and `TODO.md` follow the new
+    spelling). Full suite: 473 passed.
+  * `docs/conf.py` include_patterns gained `precision.md`, which was already
+    in the index toctree and had been warning on every build. `campaigns.md`
+    went the other way: it documents the MINERVA run campaigns, not mophongo,
+    so it is out of the index toctree and out of the build (the file stays in
+    `docs/` alongside `examples/ozstar` and `examples/canfar`, which live in
+    the repo for convenience and will move out later).
+- [x] `docs/quickstart.md` installation section now starts from the GitHub
+  checkout (clone -> `poetry install` / `pip install -e .`) and states how to
+  reach the `mophongo` console script (`poetry run`, `eval $(poetry env
+  activate)`, or sourcing `.venv/bin/activate`), since Poetry 2.x's
+  `poetry env activate` only prints the command instead of running it.
+- [x] `_solve_frozen_scene` refuses to rebuild a scene it cannot rebuild whole
+  (2026-08-16). Extraction is positions-driven, so a frozen source id that is
+  not a row of `self.catalog` contributes nothing: the scene came back short,
+  or -- when nothing matched -- empty, and the failure surfaced far downstream
+  as `ValueError: No templates to convolve`. It now raises where the mismatch
+  happens, naming the counts and the first missing ids. The usual cause is a
+  config whose footprint or trial cut differs from the run's, which is easy to
+  arrange when two configs share one `out_dir`: `examples/minerva`
+  `cosmos_f770w.json` (3' trial) and `cosmos_f770w_full.json` (full field)
+  both write to `cosmos_f770w/` under the name `cosmos_f770w`, so whichever
+  ran last owns the outputs and reloading with the other one silently
+  describes a different source set.
+- [x] A refit is refined exactly as the run refined it, and a scene's reported
+  shift is the shift it was actually given (2026-08-16).
+  * `Pipeline._refine_scene_astrometry` is new and shared: up to
+    `fit_astrometry_niter` solve/apply passes at `astrom_damping`, stopping at
+    `astrom_shift_tol`, then the closing flux-only solve. `run()` and
+    `_solve_frozen_scene` both go through it, where `_solve_frozen_scene` used
+    to take a single `scene.solve()`. A one-pass refit is not comparable with
+    anything the run wrote -- the scene catalog and scene figures report the
+    accumulated shift after the loop -- so a refit read as a large
+    disagreement when it was only an unfinished one. `run()`'s inline loop is
+    gone rather than duplicated, which is what let the two drift.
+  * `Scene.mean_shift()` is the scene's one reported shift: the plain mean of
+    `Template.shifted` over its members, at the centroid of those members.
+    The scene catalog's `dx`/`dy` and the annotation on the scene figure's
+    model panel both use it. Previously both refit a Chebyshev field of the
+    scene's order to the accumulated shifts and evaluated it at the centre.
+    That is an approximation of something already known exactly: accumulated
+    shifts are a sum of damped increments, each fitted at whatever the
+    previous pass left behind, so at order >= 1 the total is not in general
+    representable by the functional form of any single pass. The two can
+    differ by ~0.1 px. `_scene_shift_samples` keeps the field fit, which is
+    the right tool for the shift-field figure's spatial structure.
+- [x] `Templates.prune_outside_weight` no longer depends on the set it is
+  handed (2026-08-16). The drop threshold was `rtol * median(wnorm)` over the
+  templates being pruned, so a template's verdict depended on the company it
+  kept. Found through `Pipeline.refit_scene`: refitting scene 16 of the COSMOS
+  F770W run rebuilt 184 templates where the run recorded 260. The scene's
+  members are brighter than the field median, so pruning them on their own
+  raised the threshold and took 76 faint edge members with it -- and
+  `refit_scene`'s whole premise is that extracting a subset gives the same
+  pixels as extracting it alongside everything else.
+  * The test is now per-template and dimensionless: the fraction of a
+    template's own squared flux landing on positive weight, against `rtol`.
+    That is what the docstring always claimed the function did.
+  * `rtol` default 1e-8 -> 0.0, since it now means a coverage fraction rather
+    than a fraction of a population median; the two are not comparable. 0.0 is
+    the documented rule exactly -- a single usable pixel keeps the template,
+    and the sum is identically zero when there is none, so no tolerance is
+    needed. An intermediate 1e-3 was tried first on the reasoning that it
+    excluded mosaic-edge slivers "permissively"; measured on COSMOS F770W
+    scene 16 it cut 56 of 236 templates, because an edge scene's members
+    genuinely do have under a thousandth of themselves on usable pixels.
+    Raising it is a real cut, not a numerical guard.
+  * Tests `test_prune_outside_weight_is_subset_invariant` and
+    `test_prune_outside_weight_drops_templates_off_the_weight_map`.
+  * Anything that re-solved a subset was affected, not just refits.
+- [x] The solved shift field survives the figure loop (2026-08-16). A band that
+  dies drawing scenes has already solved its astrometry, and until now that
+  solution died with it: only the per-template applied shifts were persisted,
+  in `<name>_templates.fits`. `write_outputs` now also writes a `SCENES`
+  extension of `<name>_fit_table.fits`, and writes it *before* the first
+  figure, which is the point -- the figure loop is where three of the
+  seventeen bands of the overnight campaign stopped.
+  * `Pipeline._scene_fit_table` records `shift_coeff`, `shift_order` and the
+    `(x0, y0, sx, sy)` normalisation, which are exactly the arguments of
+    `AstroCorrect.build_poly_predictor`, plus `astrom_damping`, the per-scene
+    astrometry counters and the robust-pass verdict. Read it with
+    `Table.read(f_fit_table, hdu="SCENES")`.
+  * The coefficients are stored rather than recovered because the two are not
+    the same field. `_scene_shift_samples` refits a polynomial to the applied
+    shifts of every template; the solution was fitted on the scene's anchors.
+    Close enough to plot an arrow, not close enough to rebuild from.
+  * Two limits of what that field *is*, both now stated in the docstring.
+    `Scene.solve` overwrites `shifts` on every astrometric pass
+    (`scene.py:1512`, driven by the loop at `pipeline.py:4847`), so a scene
+    with `astrom_niter` above 1 kept only the final pass -- the accumulated
+    offset lives in the per-template `dx`, `dy` instead. And the coefficients
+    are undamped: the applied shift is `astrom_damping` times the field
+    (default 0.8), which is why the factor is stored beside them rather than
+    left to whichever config is loaded later.
+  * Order is per scene, not per run -- a saturated scene is forced to order 0
+    so its fragments move rigidly -- so `shift_coeff` is padded with NaN to
+    the widest order present and cut back with `n_coeff`. `shift_order` is -1
+    for a scene that solved no shifts.
+  * `_scene_catalog.csv` is trimmed to `id, n_templates, is_bright, ra, dec,
+    dx, dy, flag_astrom, minerva_link`. It is the file for reading; the
+    counters it lost are in the extension, which is the file for machines.
+  * The read side is wired. `load_outputs` picks up the extension as
+    `Pipeline.scene_fit`, `restore_scene_fit(scenes)` puts the coefficients,
+    basis and counters back onto scenes regrouped from `id_scene`, and
+    `write_scene_catalog` is now a public method both `write_outputs` and
+    `examples/canfar/jobs/scene_plots.py` call, so the recovered file is the
+    same file. The replot re-emits `_scene_catalog.csv` and `_shift_field.png`
+    when the extension is there, and skips both with a warning when it is not
+    -- which is the case for anything written before today, run2's three
+    replotted bands included.
+  * `_scene_catalog.csv` is trimmed to `id, n_templates, is_bright, ra, dec,
+    dx, dy, flag_astrom, minerva_link`. It is the file for reading; the
+    counters it lost are in the extension, which is the file for machines.
+  * `RunConfig.minerva_viewer` takes a full FITSMap URL, resolved against
+    `FITSMAP_URL` when given as a bare `<field>/<release>`. The fields do not
+    agree on whether the release belongs in the path -- COSMOS serves from
+    `/cosmos`, UDS from `/uds/DR0` -- so the derived guess is gone: None or ""
+    drops the column rather than writing a link that does not resolve.
+  * Log lines name the band. `upsampling image 1 by factor 2` was the only
+    place a run log identified an image by index; `_band_label` makes it
+    `upsampling f770w (cosmos-...-f770w_drz_sci.fits) by factor 2`, and falls
+    back to the index for a pipeline driven without a run config.
+  * Cost: a bare `Table.read(<name>_fit_table.fits)` now warns that multiple
+    tables are present before returning the fit table, which is still HDU 1.
+    `load_outputs` passes `hdu=1`; external readers should too.
+  * `poetry run pytest`: 466 passed. `tests/test_scene_fit_table.py` (17)
+    covers the order inversion, NaN padding across mixed orders, the
+    unsolved-scene case, the damping factor, the restore path and its no-op on
+    an older run; two tests in `tests/test_pipeline.py` drive the real
+    `write_outputs`, one checking that the stored coefficients reproduce the
+    live scene predictor exactly and one covering the viewer-URL spellings
+    including both drop cases. A manual round trip confirmed the re-emitted
+    scene catalog is byte-identical to the one the run wrote.
+- [x] Docs restructured after a read-through of the RTD pages (2026-08-16).
+  Reference material that had been duplicated in the getting-started pages now
+  lives with the component it belongs to: the `RunConfig` fields and the
+  `pipeline.run()` / `Pipeline.__init__` arguments are in `docs/pipeline.md`
+  only, and the `matching_kernel()` parameter list moved to `docs/psf.md`.
+  `docs/quickstart.md` and the overview keep the examples and a pointer.
+  `docs/templates.md` gained the general statement behind the normalization
+  order -- a correction supplying support outside a segment must not be
+  applied over a neighbouring segment, because segmentation does not deblend
+  and the neighbour's own template already models those pixels -- and a new
+  *Encircled energy of a template* subsection: `EE_tmpl = EE_psf` for a point
+  source, `EE_tmpl < EE_psf` for an extended one after convolution, with the
+  deficit measurable as `EE_tmpl_hi / EE_tmpl_lo` (the `psfcor_<i>` column).
+  The `flux_<i>` entry in `docs/outputs.md` now states what the column is and
+  refers to those sections instead of restating the normalization.
+- [x] run2 on CANFAR is complete at 17 of 17 bands, and the replot that
+  recovers a dead one works for the first time (2026-08-16). Three bands of
+  the overnight campaign -- `cosmos_f770w`, `cosmos_f1280w`, `egs_f2100w` --
+  fitted and then stopped partway through their scene figures with no
+  traceback, having written 196, 577 and 37 of them. All three now carry the
+  full set, along with `_stamps.h5`, `_scene_map.png` and `_scene_blobs.png`.
+  * `examples/canfar/jobs/scene_plots.py` had never drawn a figure.
+    `Scene.model_image` raises `RuntimeError("No solution available")` when
+    `solution` is None, and a scene regrouped from `id_scene` has never been
+    solved, so the first attempt spent 2h12m to report "wrote 0 of N" three
+    times over. `solution_from()` now carries the loaded per-source fluxes
+    onto each rebuilt scene. That guard is the only thing on this path that
+    reads `solution` -- the model accumulates from `t.flux` and `t.data`,
+    both of which `load_fit` restores -- so the fit's own numbers satisfy it
+    rather than a weakened check. The script's docstring claimed it populated
+    everything `Scene.plot` reads "because nothing is solved", which was the
+    false premise; it now says otherwise.
+  * The script also draws the two full-field partition views, from the same
+    `save_scene_overview` and `save_scene_blobs` helpers and under the same
+    names `write_outputs` uses, so a recovered band is not missing products a
+    band that finished on its own has.
+  * `_scene_catalog.csv` and `_shift_field.png` are deliberately not rebuilt
+    and stay missing on those three. Both carry per-scene astrometry -- `dx`,
+    `dy`, `astrom_niter`, `flag_astrom` -- recorded during the solve and not
+    persisted, so anything written would be a plausible file with invented
+    columns.
+  * CANFAR defaults are 16 cores and 96 GB, from 8 and 64 (82 for EGS).
+    `FIELD_RAM` is empty: EGS had more on the argument that its 1221 Mpx
+    detection grid needed it, but OzStar measured EGS at 29-59 GB, below the
+    other fields, and `egs_f2100w` died holding 82 anyway. 16 cores costs
+    little here because a skaha session is a Kubernetes pod rather than a
+    share of a node, so the request cannot change co-tenancy the way it does
+    in `examples/ozstar`; it only lengthens the queue.
+  * What killed the three bands in the first place is still unknown. The
+    replot reruns completed at 96 GB, but on a different code path, so that is
+    not evidence memory was the cause. `free -g` inside a pod reports the
+    node's memory -- 755 GB in these logs -- not the pod's limit, so the job
+    banner is not a headroom measurement. `GET /session/<id>` distinguishes
+    `OOMKilled` from `Evicted`, and is worth reading before the record ages
+    out the next time a band dies silently.
 - [x] The OzStar campaign takes the CANFAR shape (2026-08-16). The two
   platforms now expose the same steps, filters and flags, so one campaign
   reads the same way on either; what stays different is who enforces the order
@@ -39,16 +336,165 @@ This file records completed implementations, validation runs, and the current wo
     directory.
   * `examples/canfar/campaign.py` gained `--bands` and a `--mem` spelling of
     `--ram` for the same symmetry.
-- [x] `FitConfig.astrom_isolation_thresh` default 0.7 -> 0.6 (2026-08-16).
-  The cut is a floor on a source's own flux dominance within its footprint
-  before it may anchor a scene's shift, and at 0.7 it was leaving scenes with
-  few enough anchors that a single bright member set the shift on its own.
-  Loosening it admits mildly blended sources as anchors; the cross-anchor
-  terms in `assemble_scene_system_AB` are what handle their blending, so the
-  cut is protecting against the anchor's *own* contamination rather than
-  against overlap per se. Docs (`docs/pipeline.md`, `docs/fitting.md`)
-  updated. `examples/run_uds_770_wren.py` still passes 0.7 explicitly, which
-  is the wren fork value and stays as it is.
+  * `ozify.py --check-versions` reports configs pinned to an older release than
+    arc now holds, reusing `arcify.check_release_versions` the way the rest of
+    the arc index is reused. It rewrites nothing, and it runs on the laptop:
+    listing arc needs only the CADC certificate, and the datamover partition
+    exists to copy inputs to `/fred` rather than to see them. The advice it
+    prints is the OzStar one - a new release means a new `$OZSTAR_RUN` *and* a
+    re-stage, since `/fred` holds a copy of each input. Both flags are now
+    documented in the two READMEs; neither was before.
+  * Both `campaign.py` take `--check-versions` as a pre-flight: it reports what
+    is behind, then carries on with the pinned versions rather than refusing.
+    Moving onto a new release changes the photometry, so it is a deliberate act
+    belonging to a new run with a note saying why - not something a launch
+    should do, or block on, because a directory appeared upstream. It runs
+    under `--dry-run` too, which is when the answer is most useful.
+  * Each campaign accepts the other platform's name for the config-rewrite
+    step, so `--from arcify` works on OzStar and `--from ozify` on CANFAR, and
+    the CANFAR campaign gained `--ref`/`--force-stale` (passed to every
+    `submit.py run` dispatch, so one campaign checks one ref). What is left
+    platform-specific is only what has no counterpart: the OzStar walltimes
+    (`--time`, `--repair-time`, `--stage-time`) and `--push-psf`.
+- [x] Robust astrometric anchor weighting, `FitConfig.astrom_robust`
+  (2026-08-16, branch `shift-robust`, off by default). The shift field is
+  fitted by least squares, so an anchor's pull scales as its Fisher
+  information `I_i = alpha_i^2 <grad T_i, w, grad T_i>` -- as the *square* of
+  its flux. One bright extended source with an asymmetric colour gradient
+  therefore carries a scene: its residual is a dipole aligned with the
+  template gradient, formally indistinguishable from a displacement.
+  * `astrom_robust.py` (new leaf module) takes an anchor table -- implied
+    shift, information, basis row, misfit -- and returns a per-anchor weight.
+    It is an MM-estimator: a leverage-blind high-breakdown start
+    (`_robust_start`), then redescending Tukey steps that put the information
+    back. Both halves are needed, and this was found by test rather than by
+    reasoning: the first implementation started from the
+    information-weighted least-squares fit with a Huber warm-up, and a
+    400x-leverage liar defeated it outright. Huber's weights decay only as
+    `1/u`, so a tenfold downweight still left the liar holding 83% of the vote
+    and the fit walked back onto it. See
+    `test_scene_astrometry_robust.py::test_a_dominant_liar_pulls_the_scene_and_robust_weighting_stops_it`.
+  * The weight has two parts. A **systematic floor** `s`, estimated by robust
+    moment matching on the anchors' scatter about the fitted field, makes an
+    anchor's weight saturate at `1/s^2` however bright it is -- which is what
+    `astrom_leverage_cap` approximates with a quantile, now set by the data
+    instead. And **Tukey rejection** on disagreement with the field, the only
+    discriminator for a morphology-driven pseudo-shift: a real offset is
+    smooth in position, a pseudo-shift is random per source.
+  * `scene.measure_anchor_shifts` produces the table: one 3x3 fit per anchor
+    on `(T_i, -grad_x T_i, -grad_y T_i)` against the **flux-only** residual,
+    giving the implied shift, its flux-marginalized information, and
+    `chi2_red` -- what is left once a displacement is projected out. That last
+    quantity discriminates a source that moved from one whose template is
+    wrong, and it is why "residual size does not discriminate" (TODO, since
+    revised) was only half true: residual size *after removing the shift*
+    does.
+  * Measuring against the flux-only residual is exact, not an approximation.
+    Eliminating the fluxes from the joint system gives
+    `(B'WB - B'WA(A'WA)^-1 A'WB) beta = B'W r0`, so the flux-only residual is
+    precisely what the shift block responds to. Verified to 1.7e-15 at orders
+    0 and 1, with and without noise. That is what removes the need for an IRLS
+    loop around the joint solve: the weights are known before the joint system
+    is assembled. Cost is one extra flux-only solve and one union-bbox
+    residual buffer per scene per pass.
+  * `assemble_scene_system_AB` gained `anchor_weights`, multiplied into the
+    existing `lev_w`, and drops zero-weight anchors from the derivative
+    columns entirely rather than carrying them at zero, where they would still
+    enlarge the dense buffers. Hard rejection is also the one exactly
+    consistent case of the `lev_w` two-power split (see TODO).
+  * Works at any polynomial order; order enters only through the basis width.
+    Gated on `max(scene_minimum_anchors, 2 * n_terms)` anchors -- the same
+    number `merge_small_scenes` merges scenes up to, so a scene built to
+    support the shift model is by construction big enough to be judged.
+  * Where it applies it **supersedes** `astrom_leverage_cap` for that scene,
+    rather than composing with it: both bound one anchor's pull, but the cap
+    does it blind (it clips whichever anchors carry the most information,
+    usually the best ones) while the floor sets the same ceiling from the
+    anchors' measured scatter. The cap stays on wherever the robust pass
+    declines.
+  * `scene_minimum_anchors` default 5 -> None, i.e. derived from the
+    astrometric order as `(order+1)(order+2)+1`: 3 at order 0, 7 at order 1.
+    A hand-set 5 did not track the order it was supposed to support. At the
+    shipped order 0 this lowers the merge floor from 5 to 3, so scenes merge
+    less; `docs/fitting.md` now quotes 0.10 fit pixels for the weakest
+    admissible scene's centroid rather than 0.08.
+  * `astrom_isolation_thresh` stays 0.7 -- see the separate entry below. The
+    robust pass does *not* make it redundant: the two cover different
+    failures, and a blended majority defeats robustness by construction.
+  * The per-anchor measurement is **conditional on the anchor's
+    neighbourhood**, not marginal. Written the marginal way first, it was
+    badly wrong for exactly the anchors the isolation cut admits, in two
+    separate ways, both found by measurement rather than by reasoning:
+    - *A neighbour's free flux.* The residual arrives with fluxes already
+      fitted, and a neighbour to one side absorbs part of a dipole by
+      adjusting its brightness. A bright anchor with a faint blended
+      neighbour read 0.095 px against a true 0.20 -- half its shift, in the
+      blend direction, with `chi2_red ~ 0` to show for it -- while its
+      isolated twin read 0.20 exactly. Fixed by a flux column for every
+      overlapping template, fitted over their union footprint: 0.105 ->
+      0.013 px.
+    - *A neighbouring anchor's free shift.* Two overlapping anchors leave
+      overlapping dipoles; holding one at zero split them badly. A pair at
+      6 px read 0.089 and 0.039 px against 0.20 -- both low, both agreeing
+      with each other, and both carrying more information than the honest
+      anchors they disagreed with, which is the configuration most likely to
+      capture a robust fit. With each overlapping anchor given its own free
+      displacement: 0.171 and 0.151.
+    The numerator `<G_i, w, r0>` was right in every version; it is the
+    information divided by that has to be marginalized over everything local
+    and free. What remains (neighbours of neighbours, the union footprint
+    standing in for the global flux constraint) is smaller than the anchor's
+    own reported uncertainty in every case tested -- the property that
+    matters, since a bias inside the error bar cannot make a blend look like
+    a liar. Tests
+    `test_a_blended_anchor_is_measured_conditionally_on_its_neighbour`,
+    `test_two_blended_anchors_are_measured_against_each_other`,
+    `test_an_unmodelled_neighbour_shift_shows_up_as_misfit`,
+    `test_a_degenerate_blend_reports_its_own_uncertainty`.
+  * `chi2_red` is evaluated as an explicit residual rather than by the
+    cancellation `q - s'theta`, which in a well-fitting scene left roundoff.
+    Since the misfit inflation is a *ratio* to the scene median, roundoff
+    ratios were being amplified into real downweights; `CHI2_FLOOR = 1e-2`
+    now stands the inflation down when a scene already fits orders of
+    magnitude inside its own noise.
+  * Nothing here can help a scene whose only bright member is the offender:
+    with one anchor the weight is a global scale, and a global scale cannot
+    move the field. Only a veto could. Recorded in TODO.
+  * Built for A/B: one flag, off by default, and `False` leaves every code
+    path it touches untouched. The diagnostics are written either way so a
+    pair of runs differs in values rather than in schema -- fit table gains
+    `astrom_weight_<i>` (per source, the weakest weight among its templates),
+    the scene catalog gains `astrom_robust`, `astrom_nreject`,
+    `astrom_floor` and `astrom_neff`, and the stamps table carries
+    `astrom_weight` per template so `load_fit` restores it.
+  * Tests: `tests/test_astrom_robust.py` (23, synthetic anchor tables at
+    orders 0/1/2) and `tests/test_scene_astrometry_robust.py` (25, scene and
+    pipeline level, noiseless and noisy, including the end-to-end A/B
+    check). Full suite 445 passed.
+- [x] `FitConfig.astrom_isolation_thresh` stays at 0.7, now on measured
+  grounds rather than inheritance (2026-08-16). It was loosened to 0.6 and
+  then 0.5 on the reasoning that the cross-anchor terms in
+  `assemble_scene_system_AB` already handle blending and that `astrom_robust`
+  would catch whatever leaked through. A threshold scan (4 blended pairs at
+  3/5/7/9 px separation, sigma = 2.5 px, plus 4 isolated anchors, 6 seeds)
+  says otherwise -- the robust pass flips from harmful to helpful between
+  0.55 and 0.60:
+
+  | threshold | anchors | robust off | robust on |
+  | --- | --- | --- | --- |
+  | 0.50 | 12.0 | 0.0344 | 0.0714 |
+  | 0.55 | 12.0 | 0.0344 | 0.0714 |
+  | 0.60 | 10.2 | 0.0207 | 0.0171 |
+  | 0.70 | 10.0 | 0.0177 | 0.0139 |
+  | 0.90 |  6.0 | 0.0019 | 0.0024 |
+
+  (median |beta error| in fit pixels.) The cut is in effect a separation cut
+  -- dominance 0.54 at 0.8 PSF sigma, 0.59 at 1.2, 0.66 at 1.6, 0.73 at 2.0,
+  0.97 at 3.6 -- so 0.6 admits blends down to ~1.2 sigma and 0.7 to ~2. Same
+  shape at 5x the noise. The scan cannot set the upper end, which is fixed by
+  anchor availability on a real field rather than by this synthetic; 0.7 is
+  the shipped value and the one `examples/run_uds_770_wren.py` already passes
+  explicitly.
 - [x] The remote-access shell toolkit left the repo (2026-08-15).
   `canfar-cert.sh`, `canfar-common.sh`, `canfar-mount.sh`, `canfar-umount.sh`,
   `canfar-sync.sh`, `canfar.conf` and `ozstar-mount.sh` now live in
@@ -689,10 +1135,10 @@ This file records completed implementations, validation runs, and the current wo
     bound. Four tests in `tests/test_scene_max_size.py`.
   * Defaults: `scene_max_size` 800 -> 1000. The shift-basis order was already
     0 in `FitConfig.astrom_kwargs`, but two fallbacks disagreed with it --
-    `__post_init__` assumed 1 when deriving `scene_minimum_bright` and
+    `__post_init__` assumed 1 when deriving `scene_minimum_anchors` and
     `AstroCorrect` assumed 2 for the polynomial field (its own docstring said
     "an unmodified FitConfig supplies order 0"). Both now read 0, so a config
-    that omits the `poly` key derives `scene_minimum_bright` 3 rather than 7.
+    that omits the `poly` key derives `scene_minimum_anchors` 3 rather than 7.
   Order 0 means nB = 2: one rigid (dx, dy) per scene. That matters for memory
   because `assemble_scene_system_AB` holds nB float64 planes over the bright
   anchors' bounding box, doubled when the leverage cap clips -- 0.61 GB for
@@ -1582,7 +2028,7 @@ This file records completed implementations, validation runs, and the current wo
     offset, 0.05 converges in 4 passes and 0.1 in 3, both recovering
     (1.487, -0.791). 0.1 px also sits just above the ~0.08 px statistical
     floor of the weakest scene the anchor cuts admit (5 anchors at
-    `snr_thresh_astrom` = 15) and well below PSF-matching centroid
+    `astrom_minimum_snr` = 15) and well below PSF-matching centroid
     systematics, which are a bias no tolerance iterates away.
   * `flag_astrom` = 0 now means solved-and-converged, not never-moved. A
     flux-only run, and scenes with too few bright anchors to carry a shift
@@ -1821,7 +2267,7 @@ This file records completed implementations, validation runs, and the current wo
   from `FLAG_SATURATED_*`, and `generate_scenes` now groups saturated
   templates by it: one scene per saturated star (fragments fit jointly),
   own scene per template for legacy 0/1 flags, still created after
-  `merge_small_scenes` so exempt from `scene_minimum_bright`.
+  `merge_small_scenes` so exempt from `scene_minimum_anchors`.
   `Scene.plot` gained `null_segments`: the pipeline nulls the saturated
   stars' segments in every other scene's diagnostic (they'd dominate the
   stretch) while their own scene shows them. Tests: `test_repair.py`
@@ -3229,7 +3675,7 @@ This file records completed implementations, validation runs, and the current wo
   saturated ones are already isolated into their own scenes). Isolation now
   also applies at merge time: `generate_scenes(isolation_thresh=...)` folds
   `_astrom_isolation_mask` into the bright mask counted by
-  `merge_small_scenes`, so `scene_minimum_bright` counts bright & isolated
+  `merge_small_scenes`, so `scene_minimum_anchors` counts bright & isolated
   (& star-policy) sources and merged scenes are guaranteed usable anchors —
   the solve-time "astrometry skipped" branch becomes unreachable in
   practice. The full-field normal matrix makes merge-time dominance
@@ -3359,7 +3805,7 @@ This file records completed implementations, validation runs, and the current wo
   breaking the F770W giant (thresh ~0.1-0.16) moves bright fluxes 1-3%;
   elongated scenes are internally misaligned because offsets vary on ~arcmin
   scales. `uds_770_dr0.1.json`: `r_trial` 0.5' -> 0.6' (2242 sources),
-  fit overrides back to `{fit_astrometry_joint, scene_minimum_bright: 5,
+  fit overrides back to `{fit_astrometry_joint, scene_minimum_anchors: 5,
   aperture_diam}`. `scratch/wren/compare/` regenerated by
   `scratch/wren/make_compare.py` at the 0.6' circle.
 - [x] flux-estimator note v3 (`scratch/wren/flux_estimator_comparison_v3.tex`,
@@ -3445,7 +3891,7 @@ This file records completed implementations, validation runs, and the current wo
   `n3.0_v1.2` ACS+WEBB chi-mean segmap, `n3.0_m3.1_v1.2.1` SUPER catalog (wMIRI).
   Settings mirror `cosmos_770_dr0.1.json` so the two same-generation runs are
   comparable (`psf_size` null, blur "default", `fit_astrometry_joint`,
-  `scene_minimum_bright` 10, `aperture_diam` 0.5, `r_trial` 0.5'); frame counts
+  `scene_minimum_anchors` 10, `aperture_diam` 0.5, `r_trial` 0.5'); frame counts
   297 (F444W) / 229 (F770W). Trial patch `[34.34914, -5.27462]`, the deepest fully
   F770W-covered 0.5' patch of the v3.0 mosaic (median wht 1.30e8, 2.0x the footprint
   median), near the DR0 patch `[34.4, -5.26]`.
@@ -3515,7 +3961,7 @@ This file records completed implementations, validation runs, and the current wo
   possible. New config is `examples/cosmos_770_dr0.1.json` + `run_770_dr0.1.py`,
   mirroring the DR0 run in every setting that transfers (LW noise-equalised detection to
   match DR0's `faper_f277w+f356w+f444w` catalog, `psf_size` null, blur "default",
-  `fit_astrometry_joint`, `scene_minimum_bright` 10, `aperture_diam` 0.5, `r_trial` 0.5').
+  `fit_astrometry_joint`, `scene_minimum_anchors` 10, `aperture_diam` 0.5, `r_trial` 0.5').
   Unpacking notes, the S3 provenance of the NIRCam mosaic, and the two local fixes are
   documented in `MINERVA/data/DR0.1/README.md`.
   Data prep: the delivery's `n3.0/` (NIRCam) directory is **empty**, so the F444W
@@ -3733,7 +4179,7 @@ This file records completed implementations, validation runs, and the current wo
   and ruled out, with diagnostic scripts in `scratch/dipole_rootcause/`:
   - iteration count: increments decay geometrically to a stationary point at
     the biased value (`scene_shift_introspection.py`, 8 passes);
-  - faint templates biasing the shift blocks: `snr_thresh_astrom=15` gives
+  - faint templates biasing the shift blocks: `astrom_minimum_snr=15` gives
     identical outliers;
   - cross-scene flux contamination: chi2 scan on cleaned data (all other
     scene models subtracted) shows the same preference
@@ -3843,7 +4289,7 @@ This file records completed implementations, validation runs, and the current wo
 - [x] Fixed alpha0 scaling and Cholesky whitening in scene solver
 - [x] Fixed scene-solver flux-only path and `fit_astrometry_niter=0` handling
 - [x] Documented scene-solver flux regularization bug in `FLUXBUG.md`
-- [x] Reran mock validation with explicit `reg_flux=0.0` and `reg_astrom=0.0`
+- [x] Reran mock validation with explicit `reg_flux=0.0` and `astrom_reg=0.0`
 - [x] Hardened scene-solver flux and astrometric regularization against non-finite diagonals
 - [x] Renamed photometric regularization config from `reg` to `reg_flux`
 - [x] Removed stale tests targeting retired SparseFitter and GlobalAstroFitter APIs

--- a/TODO.md
+++ b/TODO.md
@@ -1295,3 +1295,15 @@ This file tracks future desired features, checks, and investigations.
   - [ ] split off real data as submodule?
   - [ ] other code review, misc refactoring, consolidation
   - [ ] remove unused modules, orphan code
+
+- [ ] Decide where the MINERVA SED estimator experiment belongs (2026-08-16).
+  `tests/test_sed_estimator_experiment.py` imports
+  `scratch.minerva_sed_estimator_experiment`, and `scratch/` is gitignored, so
+  the module is absent from every fresh checkout. That broke collection and
+  with it the whole CI run -- the suite reported one error and never ran, on
+  `main` as well as on branches. The import is now guarded with
+  `pytest.importorskip`, which stops it taking the run down but leaves the test
+  dead everywhere except a working tree that happens to have the experiment.
+  Either promote the estimator into `src/mophongo/` if it has become
+  reusable, or move the test into `scratch/` with it. `CLAUDE.md` is explicit:
+  tests are tracked and must not depend on scratch work.

--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,190 @@
 
 This file tracks future desired features, checks, and investigations.
 
+- [ ] Give badly determined scenes the shift their neighbours define, in a
+  robust pass after all scenes are fit (2026-08-16). Interim for the global
+  field below, and worth having on its own.
+
+  Three ways a scene's shift comes out untrustworthy today, and none of them
+  is visible in the catalog as such:
+
+  * **Starved.** `merge_small_scenes` chases `scene_minimum_anchors` but
+    `max_size` and `max_merge_radius` win over it (`scene.py:326-343`), so a
+    scene that cannot merge without breaching them is left short of anchors.
+    It then either solves a shift from one or two anchors, or -- with none --
+    falls through to flux-only and its templates are never shifted at all
+    (`scene.py:1552`), which biases its fluxes by whatever the local field was.
+  * **Unconverged.** `flag_astrom = 1`: still moving when the pass budget ran
+    out, so the stored shift is the last iterate.
+  * **Internally inconsistent.** A high `astrom_floor`: the anchors disagree
+    with each other beyond their formal errors, so the fitted shift is better
+    determined on paper than in fact.
+
+  `flag_astrom` is `-1` only when no shift was fitted at all, so a scene that
+  solved from two anchors converges and reports `0` like any other.
+
+  Do **not** gate on the failure modes separately. Unconverged is not the same
+  as wrong: the linearized solve captures only part of a large offset per pass
+  (`fit.py:48-57`), so a scene still moving at the budget may be tracking a
+  genuinely large *real* shift, and overwriting it with its neighbours' would
+  destroy a correct measurement. The question that decides the fill is whether
+  a scene's shift disagrees with its neighbours by more than both can explain.
+  That one test covers all three modes and spares the slow-but-right scene.
+
+  Fold the internal inconsistency into the scene's error instead of gating on
+  it. `astrom_floor` is per-anchor scatter *about the fitted field*, hence
+  incoherent by construction -- a coherent error would have been absorbed into
+  the field -- so it averages down over the anchors:
+
+      sigma_eff^2 = sigma_shift^2 + astrom_floor^2 / astrom_neff
+
+  All three are already in the `SCENES` extension. `sigma_eff` is then both the
+  honest uncertainty on the scene's shift and the right inverse-variance weight
+  for it as a donor.
+
+  Then run :func:`mophongo.astrom_robust.robust_anchor_weights` one level up,
+  with scenes as the anchors. It takes plain arrays --
+  ``(eps, info, basis, chi2_red=..., min_anchors=5)`` -- so the scene table
+  maps straight onto it: `eps` the per-scene `(dx, dy)`, `info` `1/sigma_eff^2`,
+  `basis` the shift-field basis evaluated at the scene centroids, `chi2_red`
+  the scene `chi2_dof`. One call returns the fitted field (`coeff`, and `field`
+  evaluated at every scene), the rejections, a field-level `sys_floor` and
+  `n_eff`. At anchor level `coeff` is documented as diagnostic only because the
+  joint solve refits with the weights; at scene level there is no refit, so
+  `field` *is* the fill value. `AGENTS.md` keeps the module a leaf taking plain
+  arrays precisely so the non-joint path can reuse it -- this is that reuse.
+
+  A robust fit also covers what a plain nearest-N mean does not: a donor whose
+  own shift is wrong. The redescending Tukey step rejects it; an average has no
+  defense. `min_anchors=5` already defaults to the natural neighbour count.
+
+  Run it either per bad scene on its local donor set (order 0 = robust weighted
+  mean, order 1 where the donors support it) or globally at low order. Local is
+  safer on a mosaic, where one low-order polynomial across the whole field is
+  too rigid; if run locally, weight donors by `exp(-d^2 / 2 L^2)` with
+  `L = astrom_kwargs["gp"]["length_scale"]` so the fill is evaluated at the
+  recipient's position rather than at the donors' centroid. Guard on the
+  nearest donor: past roughly `2L` the fill is extrapolation, and leaving the
+  scene unshifted beats moving it by a field never measured near it.
+
+  Then apply the shift and re-solve that scene flux-only, exactly as
+  `_refine_scene_astrometry` closes out a normal scene -- otherwise the fluxes
+  belong to the unshifted templates. One pass is enough: the donors are frozen
+  by the time the fill runs, so there is nothing to iterate against.
+
+  Unlike a global field this costs no barrier. It runs over the finished scene
+  list, after every scene has been solved and dropped, so the per-scene
+  independence that `docs/SCALING_FIXED_MEMORY.md` depends on survives.
+
+  Needs a new column rather than a new `flag_astrom` value: a scene can be both
+  starved and unconverged, and `flag_astrom` is a `0`/`1`/`-1` sentinel whose
+  meaning is already documented and inherited per source as `flag_astrom_<i>`.
+  Add `flag_shift_source` (`0` measured, `1` inherited from neighbours, `2` no
+  shift available) and inherit it the same way. A borrowed shift must not read
+  as a measured one.
+
+  With a global basis at scene centroids this interim *is* a global polynomial
+  shift field, so it is a step toward the Schur-complement solve below rather
+  than scaffolding to throw away.
+
+- [ ] Fit one global astrometric shift field across all scenes, by summing
+  per-scene Schur complements (2026-08-16). The field the joint path fits
+  today is scene-local: `make_scene_basis` (`scene.py:480`) centers and scales
+  a Chebyshev basis on the scene's own bright members, so every scene gets an
+  independent order-0 offset and scene boundaries acquire a statistical
+  meaning they should not have. `astrom_model` is inert here -- the joint path
+  reads `astrom_kwargs["poly"]["order"]` directly (`scene.py:1475`) and never
+  branches on the model -- so a GP is reachable only through the non-joint
+  `AstroCorrect` path, which measures shifts from residual centroids rather
+  than from the fit itself.
+
+  A global field does not require solving every scene at once. Fluxes are
+  block-disjoint across scenes, so each scene's flux block can be eliminated
+  on its own and the reduced systems added:
+
+      S_s   = BB_s - AB_s^T A_s^-1 AB_s
+      rhs_s = bB_s - AB_s^T A_s^-1 b_s
+      (sum_s S_s + K^-1) beta = sum_s rhs_s
+
+  `beta` holds the global field's coefficients and `K^-1` the GP prior
+  precision (identity times `astrom_reg` recovers the polynomial case). This
+  is exactly the joint solution over all scenes and one shared field, not an
+  approximation of it. Fluxes come back per scene by back-substitution, which
+  is the flux-only solve that already closes out each scene.
+
+  Work involved:
+
+  * `make_scene_basis` must evaluate global features at absolute positions
+    instead of scene-local Chebyshev rows, or scenes are not in a common
+    coordinate system. Fixed RBF centers (or random Fourier features) at
+    `astrom_kwargs["gp"]["length_scale"]` spacing; the existing polynomial
+    stays available as a global basis with a single center and scale.
+  * `assemble_scene_system_AB` (`scene.py:818`) sizes the shift block from
+    `len(cheb_basis(0, 0, order))` (`scene.py:947`); it must take `p` directly.
+  * New per-scene reduction: `A_s^-1 AB_s`, one solve with `2p` right-hand
+    sides, then accumulate into the global system. Use a compactly supported
+    kernel, or drop centers beyond a few length scales of the scene, so each
+    scene touches only a handful of features and the accumulation stays banded
+    -- otherwise `p` is mosaic-wide and the per-scene cost is prohibitive.
+  * `SceneFitter.solve` regularizes the shift block with scalar `astrom_reg`;
+    a GP prior needs a matrix precision.
+  * `AstroCorrect.build_poly_predictor` (`scene.py:1516`) needs a kernel
+    counterpart to evaluate the field at faint members.
+  * `_shift_amplitude` recovers the order by inverting `n_terms(order)`
+    (`scene.py:1724`), and `scene_minimum_anchors` is derived from the same
+    order (`fit.py:218`). Both break under a non-polynomial basis.
+  * Wire `astrom_model` into the joint path so 'gp' selects the kernel basis
+    rather than being silently ignored.
+
+  The structural cost is the loop nesting. Today the astrometric iteration is
+  entirely inside one scene -- `for scn in scenes: _refine_scene_astrometry(...)`
+  at `pipeline.py:5128` runs a scene's passes, its convergence test and its
+  closing flux solve as one self-contained unit, and the comment at
+  `pipeline.py:5110` records that the barrier was removed on purpose so a
+  scene can go to a worker process. A global field inverts that: assemble and
+  reduce all scenes, solve `beta`, apply to all scenes, test convergence,
+  repeat. Each pass is still parallel across scenes, but there is a sync point
+  per pass, and templates must stay resident across passes instead of being
+  dropped as each scene finishes -- which is the streaming property
+  `docs/SCALING_FIXED_MEMORY.md` depends on. Convergence also becomes global:
+  `Scene.astrom_converged` and `astrom_niter` stop meaning anything per scene,
+  and every scene pays the worst scene's pass count. Partly self-correcting,
+  since a sparse scene inherits its shift from its neighbours instead of
+  grinding out its own, but the memory argument does not recover.
+
+  A cheaper variant reaches the same fixed point by block coordinate descent:
+  pool the per-anchor implied shifts and Fisher information that
+  `measure_anchor_shifts` (`scene.py:593`) already computes from the flux-only
+  residual, fit the field to that global table, then apply and re-solve. The
+  anchor table is a diagonal approximation to `S_s` -- per-anchor 3x3 systems,
+  neighbour-conditioned but without the full scene coupling -- so it converges
+  to the joint answer without matching it pass for pass. It carries the same
+  barrier, so the only thing it buys is avoiding the Schur reduction. Worth
+  measuring before committing to either; `chi2_red` should gate entry to the
+  table in both, or one wrong template pollutes the field out to a length
+  scale.
+
+  Both variants still linearize `T(x + d) ~ T + d . grad T`, so the outer
+  `fit_astrometry_niter` loop stays.
+
+- [ ] Accumulate the shift coefficients across astrometric passes
+  (2026-08-16). `Scene.solve` overwrites `self.shifts` on every pass
+  (`scene.py:1512`), so a scene that took two passes keeps only the second,
+  and the `SCENES` extension inherits that. The total offset survives only as
+  the per-template `dx`, `dy`, which is why `_scene_shift_samples` refits
+  rather than evaluating the stored field. Accumulating would make the stored
+  coefficients the whole solution and let the catalog's `dx`, `dy` come from
+  it directly. Check first whether `make_scene_basis` returns the same
+  `(x0, y0, Sx, Sy)` on every pass -- it is built from `position_original`,
+  which does not move, so the coefficients should be addable, but the damping
+  factor has to go in on the way.
+
+- [ ] Point the MINERVA configs at their FITSMap roots (2026-08-16).
+  `RunConfig.minerva_viewer` takes a full URL and no longer guesses, so a
+  config that leaves it unset now writes no `minerva_link` column at all.
+  COSMOS serves from `/cosmos` and UDS from `/uds/DR0`; the 17 configs under
+  `examples/minerva` need the value filled in to get their links back.
+
 - [ ] Add direct tests of the `PSFFactory` public entry points (2026-08-14,
   from the Aperpy clean-implementation audit): `build()` called on its own
   rather than through `from_csv()`, and `filename()` across OS1/2/4/8 -- it
@@ -26,7 +210,7 @@ This file tracks future desired features, checks, and investigations.
   detectors, all four MIRI bands), plus COSMOS's 22+22 NIRCam and 16 F770W
   epochs -- at FOV4/FOV8 against FOV6/FOV11 elsewhere; EGS is already uniform.
   Nothing is wrong today: the epochs of a family are disjoint, so no MJD is
-  served by two grids, and the fit crops to `psf_size` either way (a 101-px
+  served by two grids, and the fit crops to `psf.size` either way (a 101-px
   build agrees with a 65-px one to 1.1e-4 of peak over the shared region).
   Rebuild them at the default so the set is one thing rather than two. The 124
   FOV30 halo grids stay as they are.
@@ -63,9 +247,9 @@ This file tracks future desired features, checks, and investigations.
   (2026-08-13). `PSFFactory(workers=N)` now fans out over `(detector, date)`,
   which is safe because each job writes a uniquely named file, and the OPD
   fetches are pre-warmed serially so the pool does not race MAST. What is
-  still serial is bands of a *field*: they all derive the same `pattern_hi`,
+  still serial is bands of a *field*: they all derive the same `psf.pattern_hi`,
   so `uds_f770w` and `uds_f1000w` build identical F444W filenames into one
-  `psf_dir` and would tear each other's files. Prep sidesteps it by building
+  `psf.dir` and would tear each other's files. Prep sidesteps it by building
   one band per field first. Doing better means a lock or a claim file per
   target path, at which point every band could build concurrently and prep
   would only need to exist for the repair.
@@ -78,7 +262,7 @@ This file tracks future desired features, checks, and investigations.
     already takes about 1.6 cores. Memory is a non-issue. Extrapolating, the
     ~416-grid release is about 4 hours serial and 2 hours on four workers --
     both well under the 9 hours estimated before measuring.
-  * `psf_workers` defaults to 1 everywhere. 4 is the number to set: it matches
+  * `psf.workers` defaults to 1 everywhere. 4 is the number to set: it matches
     a CANFAR container's `cores_for` of 4, and is modest enough for an OzStar
     login node, where the build runs `nice`d on a shared machine. 16 is wrong
     on both -- 4x oversubscription on CANFAR, antisocial on a login node.
@@ -92,7 +276,7 @@ This file tracks future desired features, checks, and investigations.
   `_load_epsf` used to autobuild only when *nothing* matched the pattern, so
   those bands could never gain the missing dates on their own.
   `Pipeline._missing_psf_dates` now asks the only question that matters:
-  `dates_from_csv(csv, psf_date_mode)` minus the `_MJD` tokens on disk. What
+  `dates_from_csv(csv, psf.date_mode)` minus the `_MJD` tokens on disk. What
   is missing is built, one factory call per epoch, and what is there is left
   alone. A band holding 99 of 100 epochs costs one grid.
   * This also retires the provenance experiment. Grids carry no
@@ -150,7 +334,7 @@ This file tracks future desired features, checks, and investigations.
   verified by invoking them, not by tests. `has_shared_grids` is the one
   worth a real test: it is pure given a name list, so it needs no network,
   and getting it wrong either serialises a field for hours or lets several
-  bands race on one `psf_dir`.
+  bands race on one `psf.dir`.
 
 - [ ] `AlignedCutout.downsample`/`upsample` pass `self.wcs` (this cutout's
   WCS) as the parent WCS of a new cutout built on a full-shape dummy, the
@@ -214,23 +398,112 @@ This file tracks future desired features, checks, and investigations.
   content vs fit-time templates disagree for those sources. Not touched by
   the 2026-08-12 convolution change; inspect write path.
 
-- [ ] Robust astrometry option: IRLS across scene anchors. Extended sources
-  with asymmetric colour gradients produce a residual dipole formally
-  identical to a shift, so no per-source test on residual size or shape
-  separates them; they pull the scene's shift field the wrong way. The
-  discriminator is coherence: a real offset is smooth in position (the
-  premise of the GP/poly field), while morphology-driven pseudo-shifts are
-  random per source. So reweight on *disagreement with the neighbours*, not
-  on residual size. Per pass: solve, compute each anchor's implied shift
-  `dx_i = -<Gx,w,r> / (a_i <Gx,w,Gx>)`, take the robust scatter of `dx_i`
-  about the fitted field, apply a Tukey/Huber weight to that anchor's
-  contribution to `AB`/`BB`/`bB`, re-solve. A genuinely offset region keeps
-  full weight because its neighbours agree with it; one galaxy disagreeing
-  with twenty anchors gets cut. Costs one extra assembly per pass. This is
-  the case `astrom_leverage_cap` (2026-08-12) cannot cover: the cap bounds
-  the influence of the brightest anchors without knowing which one is
-  wrong, and does nothing in a scene where the offender is the only bright
-  member.
+- [x] Robust astrometry option: IRLS across scene anchors. Implemented
+  2026-08-16 as `FitConfig.astrom_robust` and `mophongo.astrom_robust`; see
+  STATUS.md. Three things the original note got wrong, worth keeping:
+  * "no per-source test on residual size or shape separates them" is only
+    half right. Residual *size* does not separate them; residual size **after
+    the anchor's own displacement is projected out** does, because a pure
+    displacement lives entirely in the span of the two gradient columns.
+    That is `chi2_red` from `scene.measure_anchor_shifts`, and it is the
+    second of the two weighting layers.
+  * "Costs one extra assembly per pass" -- it costs none. Eliminating the
+    fluxes gives `(B'WB - B'WA(A'WA)^-1 A'WB) beta = B'W r0`, so the shift
+    block is driven by the *flux-only* residual and the weights can be
+    measured before the joint system is assembled. One extra flux-only solve,
+    no loop around the joint one.
+  * A plain IRLS as described would not have worked: started from the
+    information-weighted least-squares fit, the reweighting masks, because
+    the dominant anchor *is* that fit and the honest anchors carry the large
+    residuals. It needs a leverage-blind high-breakdown start first.
+
+- [ ] `astrom_robust` stays off by default until it is shown to help on real
+  scenes. First real-data test (2026-08-16, COSMOS F770W scene 16, refit
+  through `Pipeline.refit_scene`, 236 templates both sides) says it hurt:
+
+      run       (-0.017, +0.002) px, 1 pass
+      baseline  (+0.221, -0.088) px, 2 passes, converged
+      robust    (+0.879, -0.870) px, 3 passes, converged
+      chi2 182175 -> 295274   (dchi2 +113099)
+      11 anchors, 0 rejected, systematic floor 0.61 px
+      flux: median +0.000 sigma, one source 48 sigma
+
+  The mechanism is the one measured synthetically: 11 anchors scattering
+  0.61 px about the field is broad disagreement, not one liar, so the floor
+  absorbs it, flattens the weights and rejects nothing -- diluting information
+  rather than protecting against an outlier. 0.61 px is also six times
+  `astrom_shift_tol`, so this scene's anchors do not agree at the level the
+  loop is trying to converge to, which is worth understanding on its own.
+
+  An earlier version of this measurement was void: the band weight was on the
+  wrong grid (see STATUS), which corrupted the baseline astrometry to
+  (+0.03, -0.92) px and pruned 48 covered templates.
+
+  What the test cannot settle: one scene with 11 anchors is not a sample, and
+  24 of the run's 260 sources are unavailable to any refit (`ff3b8d4` version
+  skew). Needs a clean run on current code, several scenes, and at least one
+  scene of the shape the scheme is for -- one dominant bright anchor against
+  several agreeing ones.
+
+- [ ] Reduce the shrinkage bias on a blended anchor's implied shift.
+  `measure_anchor_shifts` fits each anchor conditionally on its neighbourhood
+  -- a flux column per overlapping template, a free displacement per
+  overlapping anchor -- but the local system still stops at one level of
+  overlap and uses the union footprint in place of the global flux
+  constraint. What survives is a *shrinkage toward zero*: at 4 px separation
+  (1.6 sigma) with dominance 0.65, blended anchors read 0.12-0.145 px against
+  a true 0.20, in both axes, whatever the pair's orientation.
+  Shrinkage being coherent is what makes it dangerous, and it is why
+  `astrom_isolation_thresh` cannot be retired in favour of the robust pass
+  (2026-08-16 measurement, see STATUS.md): every blended anchor is biased the
+  same way, so they agree with each other, and robust weighting is majority
+  rule. With 6 blended against 3 clean anchors the fit follows the blended
+  ones and the systematic floor moves weight further toward them (share
+  0.627 -> 0.690); beta error 0.052 -> 0.086 px with the robust pass on,
+  against 0.0017 px when the cut excludes them. Extending the local system to
+  two levels of overlap is the direct attack; the bias is a bias, not a
+  variance, so no amount of information weighting removes it.
+
+- [ ] Veto a scene's shift when its only anchor cannot be trusted. Robust
+  weighting cannot reach this case: with one anchor the weight is a global
+  scale, and a global scale cannot move where the field lands, so a scene
+  whose sole bright member is a colour-gradient galaxy still gets that
+  galaxy's pseudo-shift. The information is available -- `chi2_red` from
+  `scene.measure_anchor_shifts` is per-anchor and needs no neighbours -- but
+  it has to drive a decision rather than a weight: either fit no shift for
+  that scene, or shrink it toward a field-level prior taken from the
+  neighbouring scenes. The second is the better answer and needs cross-scene
+  state that `Scene.solve` does not currently have.
+
+- [ ] The `lev_w` two-power split is inconsistent under the flux
+  marginalization. `BB` scales as `sqrt(c_i c_j)` and the RHS correction
+  `AB' A^-1 b` as `c_i`, both correct, but the LHS correction `AB' A^-1 AB`
+  then scales as `c_i c_j` where the information it corrects scales as
+  `sqrt(c_i c_j)`. One `AB` matrix cannot satisfy both requirements. Measured
+  (2026-08-16, `scratch/astrom_robust/lev_sweep.py`): beta departs from a genuine
+  downweight by ~10% of the capped anchor's contribution at the shipped
+  `astrom_leverage_cap=0.9`, rising to ~36% at `c=0.5`, when a neighbour sits
+  about one FWHM from the anchor. Zero when nothing overlaps, zero at
+  `c_i = 0`, and bounded by the flux-shift degeneracy fraction as `c -> 0`.
+  The fix is two `AB` matrices (`sqrt(c_i)` for the LHS, `c_i` for the RHS)
+  and explicit Schur elimination in `SceneFitter._solve_flux_and_shifts`
+  instead of the single `K = sp.bmat(...)` solve -- roughly `nB + 2` sparse
+  back-solves, so not obviously more expensive. Worth doing if soft weights
+  are ever pushed well below 0.9; hard rejection is exact and sidesteps it.
+
+- [ ] `alpha0` for the derivative columns is the diagonal-only flux `b/d`, so
+  for a blended anchor it reads high by whatever leaks into its footprint and
+  the fitted shift comes back low in proportion. Measured 2026-08-16
+  (`scratch/astrom_robust/verify_claims.py`): 2.7% seed error, 2.5% shift
+  error, flat in shift magnitude. Feeding the joint solve's own fluxes back
+  and re-solving gives 0.02%, at the cost of a second joint solve. The
+  flux-only solve is *not* the fix -- it is worse above ~0.1 px (10.7% at
+  0.5 px), because the unmodelled dipole gets absorbed into the blended
+  neighbour's flux. Kept rather than dropped because it bites in two places
+  the damped iteration does not cover: a run with `fit_astrometry_niter=1`
+  takes the full 2.5%, and the error varies per anchor with contamination, so
+  it mis-weights anchors against each other by ~5% in information. Otherwise
+  low priority -- it is 2.5% of the *step*, and the fixed point is unaffected.
 
 - [ ] Scene shift iteration does not converge on r < 3' patches (found in
   verification v9, 2026-08-13; see `examples/minerva/verification/v9/README.md`
@@ -248,8 +521,12 @@ This file tracks future desired features, checks, and investigations.
   1061-template scene — so the cap is not the trigger. Candidates: make the
   size cap bind, scale `length_scale` with the scene, or raise
   `fit_astrometry_niter` / lower `astrom_damping` (currently 5 and 0.8).
-  Check the IRLS item above first: a walk driven by a few high-leverage
-  extended anchors would be cured by the same reweighting.
+  Try `astrom_robust=True` first (2026-08-16): a walk driven by a few
+  high-leverage extended anchors is exactly what it cures, and the
+  per-anchor table it logs (implied shift, information, misfit, weight) says
+  whether that is the cause before anything else is changed. Note the seed
+  bias measured below is *not* a candidate -- it under-estimates each step by
+  a fixed 2.5%, which slows convergence rather than driving a walk.
   `scene_max_merge_radius` (2026-08-13) is now the direct instrument for the
   scale-mismatch hypothesis: it bounds the scene's longer side rather than its
   template count, which is the quantity the GP length scale should be compared
@@ -448,7 +725,7 @@ This file tracks future desired features, checks, and investigations.
   the mean over that asymmetric tail inflates (F1800W raw-aperture mean +0.48,
   median +0.25, and +0.02 at SNR > 25). At SNR > 25 all four bands agree with
   IDL to 1-3%. `make_compare_idl_python.py` now quotes medians and adds an
-  SNR > 25 line. Still open, moved to its own items: `psf_size` = 4" at 18 um,
+  SNR > 25 line. Still open, moved to its own items: `psf.size` = 4" at 18 um,
   and whether the generated configs should keep 800/1000 (photometry is
   insensitive; solve time was not).
 - [ ] Confirm the photometric aperture for F560W, F1000W and F2100W. The
@@ -463,7 +740,7 @@ This file tracks future desired features, checks, and investigations.
   `DEFAULT_PSF_GAUSSIAN_FWHM_ARCSEC["f2100w"] = 0.30"` is an extrapolation
   along the F1280W-F1800W trend. Repeat the star test in COSMOS or EGS.
 - [ ] The generated MINERVA configs (`examples/make_minerva_configs.py`) fix
-  `psf_size` at 4.0" for every MIRI band because the same value sets the
+  `psf.size` at 4.0" for every MIRI band because the same value sets the
   hi-res support and the F444W grids are only 4.09" across. At F1800W/F2100W
   the MIRI PSF FWHM is ~0.6-0.7", so 4" is only ~6 FWHM and the wings are cut
   well inside where they still carry flux. Regenerate the NIRCam grids at a
@@ -507,10 +784,10 @@ This file tracks future desired features, checks, and investigations.
   would double-count.
 - [ ] The F444W PSF grids have a 4.09" FOV against F770W's 8.10", so the
   *detection* PSF model is the more truncated one: 4.3% of F444W light is
-  outside the model entirely versus 1.5% for F770W. Enlarging `psf_size` past
+  outside the model entirely versus 1.5% for F770W. Enlarging `psf.size` past
   ~4" for F444W measures the grid edge rather than the PSF. Regenerate the
   NIRCam grids at a larger FOV if the hi-side wings start to matter.
-- [ ] Decouple PSF support from kernel support. `psf_size` currently sets
+- [ ] Decouple PSF support from kernel support. `psf.size` currently sets
   both, so shrinking the stamp to save time also renormalizes the PSFs the
   kernel is derived from, which biases the kernel core by `S_hi/S_lo`:
   +6.3% at 2", +3.1% at the 4" default, -0.7% on the full parent grid
@@ -554,7 +831,7 @@ This file tracks future desired features, checks, and investigations.
   `CHECKLIST.md`; the mechanism is live here and recorded nowhere else).
 - [ ] The flux-block ridge biases faint sources low: -33% at
   `d_i/median = 1e-6` (also from wren's `CHECKLIST.md`). **Confirmed still
-  live** (2026-08-10): the `flux-bug` fix removed `reg_astrom=1e-4` leaking
+  live** (2026-08-10): the `flux-bug` fix removed `astrom_reg=1e-4` leaking
   into the photometric normal matrix, a different and larger term. What
   remains at `scene_fitter.py:178-181` is `lam_A = 1e-6 * median(diag(A))`,
   one absolute value per scene added *before* whitening, which is exactly the
@@ -678,7 +955,7 @@ This file tracks future desired features, checks, and investigations.
   F1800W) collapses to one constant 0.030 +/- 0.005 after dividing by median
   SNR and PSF area (`docs/SCENE_PARTITION.md`) — a noise-relative,
   area-normalized coupling score would remove the per-band tuning without any
-  new machinery. Template support (`psf_size`, currently null = 8" stamps) is
+  new machinery. Template support (`psf.size`, currently null = 8" stamps) is
   the real lever for scene size: wren's 3" stamps ran the full field at a
   fixed 1e-3.
 - [ ] `PSFSZ<i>` and `RCIRC<i>` in `cat.meta` are half their true value in
@@ -825,7 +1102,7 @@ This file tracks future desired features, checks, and investigations.
   measured spurious order-1 field (0.05 px rms, 0.16 px peak on a synthetic
   blend) is the right order of magnitude for the smaller offsets here.
   Ruled out before that fix: iteration count (converges to a stationary
-  biased point), faint templates in the shift blocks (`snr_thresh_astrom=15`
+  biased point), faint templates in the shift blocks (`astrom_minimum_snr=15`
   identical), cross-scene contamination (clean-data chi2 scan identical),
   kernel regions, and local mock painting errors. One case is a blend flux
   swap (ids 503/614); the others are dominated by a single bright extended

--- a/docs/CODE_REVIEW_2026-08-12.md
+++ b/docs/CODE_REVIEW_2026-08-12.md
@@ -237,7 +237,7 @@ Probe results:
 - classic retained 33 of 45;
 - lost fields included aperture, astrometry, scene, normalization, and solver
   settings; classic could even lose `extend_mode`, `reg_flux`, and
-  `reg_astrom`.
+  `astrom_reg`.
 
 **Impact.** `<out_dir>/<name>.json` is not a reproducible description of the
 executed run, contrary to `docs/pipeline.md:262-270`,

--- a/docs/FLUXBUG.md
+++ b/docs/FLUXBUG.md
@@ -17,10 +17,10 @@ self-consistency fit was already biased low, where no PSF-matching kernel is
 used. That made the kernel hypothesis impossible as the primary cause.
 
 The actual cause was an implementation error in the newer stateless scene
-solver. `SceneFitter.solve()` was using `config.reg_astrom` as a flux
-regularization term. `reg_astrom` is intended only for astrometric shift
+solver. `SceneFitter.solve()` was using `config.astrom_reg` as a flux
+regularization term. `astrom_reg` is intended only for astrometric shift
 parameters, but it was being added to the photometric normal matrix. With the
-default `reg_astrom=1e-4`, broad, low-norm Moffat templates had their fitted
+default `astrom_reg=1e-4`, broad, low-norm Moffat templates had their fitted
 fluxes suppressed.
 
 ## Observable Symptom
@@ -90,23 +90,23 @@ legacy solver, flux only:
   dilated3 hi=0.9746  lo=0.9864
 ```
 
-Then `reg_astrom` was scanned in the scene solver flux-only path:
+Then `astrom_reg` was scanned in the scene solver flux-only path:
 
 ```text
-scene flux-only, reg_astrom=1e-04:
+scene flux-only, astrom_reg=1e-04:
   hi=0.9324  lo=0.8991
 
-scene flux-only, reg_astrom=1e-08:
+scene flux-only, astrom_reg=1e-08:
   hi=0.9746  lo=0.9864
 
-scene flux-only, reg_astrom=0:
+scene flux-only, astrom_reg=0:
   hi=0.9746  lo=0.9864
 
-scene flux-only, reg_astrom=1e-02:
+scene flux-only, astrom_reg=1e-02:
   hi=0.1853  lo=0.0977
 ```
 
-That establishes causality: `reg_astrom` was regularizing the flux solve.
+That establishes causality: `astrom_reg` was regularizing the flux solve.
 
 ## Implementation Error
 
@@ -115,17 +115,17 @@ The erroneous implementation was in `src/mophongo/scene_fitter.py`.
 The buggy logic was effectively:
 
 ```python
-ridge = getattr(config, "reg_astrom", 0)
+ridge = getattr(config, "astrom_reg", 0)
 if ridge <= 0:
     ridge = 1e-6 * np.median(A.diagonal())
 Areg = A + sp.eye(A.shape[0], format="csr") * ridge
 ```
 
-Here `A` is the photometric normal matrix. Adding `reg_astrom` to this matrix
+Here `A` is the photometric normal matrix. Adding `astrom_reg` to this matrix
 mixes two different concepts:
 
 - `reg_flux`: photometric flux ridge regularization
-- `reg_astrom`: astrometric shift-block regularization
+- `astrom_reg`: astrometric shift-block regularization
 
 The shift-block regularization belongs only on the `BB` astrometric block.
 Applying it to `A` shrinks fitted fluxes. The shrinkage becomes visible when
@@ -151,7 +151,7 @@ path to skip the joint astrometric solve. The scene code checked
 ### 1. Use a strictly positive flux ridge for the flux matrix
 
 In `src/mophongo/scene_fitter.py`, the photometric normal matrix must use a
-photometric ridge, not `config.reg_astrom`. The default can be tiny, but it
+photometric ridge, not `config.astrom_reg`. The default can be tiny, but it
 should be strictly positive when used as numerical regularization:
 
 ```python
@@ -168,13 +168,13 @@ is positive semidefinite. Adding `lam_A * I` with a positive
 factor makes the regularized matrix positive definite, unless the matrix contains non-finite
 values. Filtering to finite, positive diagonal values avoids zero or NaN scale
 factors when many templates have zero support. The configured `config.reg_flux`
-is a dimensionless factor, analogous to `config.reg_astrom`, and must also be
+is a dimensionless factor, analogous to `config.astrom_reg`, and must also be
 checked explicitly: zero, negative, NaN, and infinity should all fall back to
 the finite positive default. Here `_finite_positive(value, default)` denotes a
 small helper that returns `float(value)` only when it is finite and positive,
 otherwise `default`.
 
-Keep `reg_astrom` only for the astrometric block. The existing pattern is the
+Keep `astrom_reg` only for the astrometric block. The existing pattern is the
 right idea for the shift block, but it should also filter non-finite diagonal
 values:
 
@@ -183,14 +183,14 @@ diag_BB = np.asarray(BB.diagonal(), dtype=float)
 pos_BB = diag_BB[np.isfinite(diag_BB) & (diag_BB > 0)]
 scale_BB = np.median(pos_BB) if pos_BB.size else 1.0
 
-lam_b = getattr(config, "reg_astrom", 1e-4) * scale_BB
+lam_b = getattr(config, "astrom_reg", 1e-4) * scale_BB
 BBreg = BB + sp.eye(BB.shape[0], format="csr") * lam_b
 ```
 
 The important separation is:
 
 - `lam_A = reg_flux * scale_A` regularizes the photometric flux block `A`.
-- `reg_astrom * scale_BB` regularizes the astrometric shift block `BB`.
+- `astrom_reg * scale_BB` regularizes the astrometric shift block `BB`.
 
 The line `scale_BB = np.median(diag_BB[diag_BB > 0]) ...` only protects the
 astrometric block scale. It does not provide any protection for the flux block
@@ -234,12 +234,12 @@ Add a focused unit test so this cannot recur:
 def test_scene_fitter_reg_astrom_does_not_regularize_flux():
     A = sp.csr_matrix([[1e-3]])
     b = np.array([1e-3])
-    cfg = FitConfig(reg_flux=0.0, reg_astrom=1e-2)
+    cfg = FitConfig(reg_flux=0.0, astrom_reg=1e-2)
     sol = SceneFitter.solve(A, b, config=cfg)
     np.testing.assert_allclose(sol.flux, [1.0], rtol=1e-5)
 ```
 
-This test is intentionally simple. If `reg_astrom` leaks into the flux matrix,
+This test is intentionally simple. If `astrom_reg` leaks into the flux matrix,
 the solved flux is strongly suppressed. If the implementation is correct, the
 answer remains one.
 

--- a/docs/FLUX_RECOVERY_DEBUG_SYNTHESIS_2026-05-03.md
+++ b/docs/FLUX_RECOVERY_DEBUG_SYNTHESIS_2026-05-03.md
@@ -113,23 +113,23 @@ kernel could not be the primary cause.
 
 ### Root Cause
 
-`SceneFitter.solve()` was using `config.reg_astrom` as a photometric ridge on
-the flux normal matrix. `reg_astrom` belongs only to the astrometric shift
+`SceneFitter.solve()` was using `config.astrom_reg` as a photometric ridge on
+the flux normal matrix. `astrom_reg` belongs only to the astrometric shift
 block. Applying it to fluxes suppresses broad, low-norm templates.
 
 Decisive scan:
 
 ```text
-scene flux-only, reg_astrom=1e-04:
+scene flux-only, astrom_reg=1e-04:
   hi=0.9324  lo=0.8991
 
-scene flux-only, reg_astrom=1e-08:
+scene flux-only, astrom_reg=1e-08:
   hi=0.9746  lo=0.9864
 
-scene flux-only, reg_astrom=0:
+scene flux-only, astrom_reg=0:
   hi=0.9746  lo=0.9864
 
-scene flux-only, reg_astrom=1e-02:
+scene flux-only, astrom_reg=1e-02:
   hi=0.1853  lo=0.0977
 ```
 
@@ -139,7 +139,7 @@ Separate photometric and astrometric regularization:
 
 ```text
 flux block:       reg_flux   * scale(A)
-astrometry block: reg_astrom * scale(BB)
+astrometry block: astrom_reg * scale(BB)
 ```
 
 Also fixed:
@@ -149,7 +149,7 @@ SceneFitter.solve_flux static signature
 fit_astrometry_niter=0 now reaches flux-only behavior
 ```
 
-Recommendation: keep `reg_astrom` completely out of any flux-only matrix.
+Recommendation: keep `astrom_reg` completely out of any flux-only matrix.
 Any future solver path must have a regression test proving this separation.
 
 ## 2. PSF Flux Conservation And Kernel Normalization

--- a/docs/FORK_DIFF_WREN.md
+++ b/docs/FORK_DIFF_WREN.md
@@ -86,7 +86,7 @@ returns per-subpixel ivar equal to the native ivar, while ours returns `k²`
 times that. Fitted fluxes are invariant to a global weight scale, but
 `err_<i>` and `err_pred_<i>` in wren come out **2× larger**, and the scene
 `snr_proxy = b/sqrt(diag A)` scales as `√w`, so at the same
-`snr_thresh_astrom=15` wren flags **half** the SNR and therefore far fewer
+`astrom_minimum_snr=15` wren flags **half** the SNR and therefore far fewer
 `is_bright` templates. Different scene partition, different astrometry sample.
 
 **(b) no block projection in wren.** Ours re-integrates each convolved template

--- a/docs/LWBUG_ANALYSIS.md
+++ b/docs/LWBUG_ANALYSIS.md
@@ -91,8 +91,8 @@ spline interpolation (`templates.py:800-820`).
 | `astrom_model` | `"gp"` | `"polynomial"` or `"gp"` |
 | `astrom_kwargs` | `{"poly": {"order": 0}}` | Order of the shift basis |
 | `scene_coupling_thresh` | `1e-3` | Off-diagonal threshold for scene split |
-| `scene_minimum_bright` | `5` | Bright sources needed per scene for astrometry |
-| `snr_thresh_astrom` | `15.0` | SNR cut defining "bright" |
+| `scene_minimum_anchors` | `5` | Bright sources needed per scene for astrometry |
+| `astrom_minimum_snr` | `15.0` | SNR cut defining "bright" |
 | `fft_fast` | `False` | If non-zero, crop kernel per source by encircled energy |
 | `fit_covariances` | `False` | Full off-diagonal errors via Hutchinson |
 | `aperture_diam` | `None` | Diameter for the aperture-photometry pass |
@@ -121,7 +121,7 @@ A `Scene` is a dataclass with a list of connected `Template`s, cached
 normal blocks (`A`, `b`), a bounding box, and a `SceneFitter`. Scene
 formation in `generate_scenes` (`scene.py:474`) builds the full normal
 matrix once, splits into connected components by coupling strength,
-then merges components with fewer than `scene_minimum_bright` bright
+then merges components with fewer than `scene_minimum_anchors` bright
 sources into their nearest neighbours via an STRtree-accelerated
 union-find. Inside `Scene.solve`, `make_scene_basis` constructs the
 Chebyshev basis evaluated at each bright template position (scaled to
@@ -287,7 +287,7 @@ bug.
 
 Both runs use the same config:
 `FitConfig(fit_astrometry_niter=2, fit_astrometry_joint=True,
-scene_minimum_bright=10, aperture_diam=0.5)`, the same detection image,
+scene_minimum_anchors=10, aperture_diam=0.5)`, the same detection image,
 and the same MINERVA catalogue. The only real difference in the user
 script is the PSF stamp size: `psf_size = 2.0"` (770) vs `size = 8.0"`
 (1500) — a concession to the broader F1500W PSF.
@@ -339,7 +339,7 @@ position-dependent sub-pixel residual everywhere.
 
 `examples/uds_1500/` contains a single scene plot
 (`uds_1500_scene_1.png`); `examples/uds_770/` contains ~164 scene
-plots. With `scene_minimum_bright=10` and `snr_thresh_astrom=15`, most
+plots. With `scene_minimum_anchors=10` and `astrom_minimum_snr=15`, most
 F1500W sources fail the SNR cut, and `merge_small_scenes`
 (`scene.py`) merges scenes until each has ≥ 10 bright sources — the
 field is small enough (trial radius 1′) that this collapses to a
@@ -394,7 +394,7 @@ after the joint astrometry tries to compensate.
 4. Rerun with `FitConfig(fit_astrometry_niter=0)`. If residuals *improve*,
    the astrometry solver is absorbing the kernel error as a bogus shift
    and making things worse.
-5. Rerun with `scene_minimum_bright=3` (or lower). If scenes split and
+5. Rerun with `scene_minimum_anchors=3` (or lower). If scenes split and
    per-scene shifts differ, the scene-collapse story is confirmed.
 6. Rerun with `astrom_kwargs={"poly": {"order": 1}}`. A linear shift
    field within the single mega-scene should absorb position-dependent

--- a/docs/SCENE_PARTITION.md
+++ b/docs/SCENE_PARTITION.md
@@ -12,12 +12,12 @@
    the threshold is raised only inside that component, the accepted local
    leakage is logged, and strong couplings elsewhere are never touched.
 2. **Merge small scenes.** `merge_small_scenes` merges scenes with fewer than
-   `scene_minimum_bright` bright members (SNR proxy above
-   `snr_thresh_astrom`) into their nearest scene by centroid, iterating until
+   `scene_minimum_anchors` bright members (SNR proxy above
+   `astrom_minimum_snr`) into their nearest scene by centroid, iterating until
    all scenes clear the floor. (Unchanged original; it has no cap, so merged
    scenes can exceed `scene_max_size` where bright sources are scarce.)
 
-Knobs: `scene_coupling_thresh` (floor), `scene_minimum_bright`, and the
+Knobs: `scene_coupling_thresh` (floor), `scene_minimum_anchors`, and the
 optional `scene_max_size`.
 
 ## Template support sets the coupling graph (the wren discrepancy)
@@ -49,7 +49,7 @@ fix that first.
 A session attempted to replace the per-band threshold with size-driven
 partitioning (`scene_max_size`). Sequence of designs, each fixing the
 previous one's failure on the UDS F770W dr0.1 trial patch (1549 templates,
-0.5' circle, 39 bright at `snr_thresh_astrom = 15`, `psf_size: null` 8"
+0.5' circle, 39 bright at `astrom_minimum_snr = 15`, `psf_size: null` 8"
 stamps):
 
 | design | failure |

--- a/docs/WREN.md
+++ b/docs/WREN.md
@@ -21,11 +21,11 @@ eb6b922 Fix aperture correction: use post-conv template total instead of pre-con
 
 **File:** `src/mophongo/scene_fitter.py` (+6 −7)
 
-**Problem.** `reg_astrom` (default `1e-4`) was being applied directly to the flux
+**Problem.** `astrom_reg` (default `1e-4`) was being applied directly to the flux
 block diagonal of `ATA`. For F1800W drizzled data `ATA[i,i] ≈ 1.33e-4`, so the
 regularizer was the *same order* as the diagonal — causing **~43% flux suppression**.
 
-**Fix.** Reserve `reg_astrom` for the *shift block only*. The flux block uses an
+**Fix.** Reserve `astrom_reg` for the *shift block only*. The flux block uses an
 adaptive regularizer scaled to ATA's magnitude:
 ```python
 flux_reg = 1e-6 * np.median(A.diagonal())
@@ -39,7 +39,7 @@ Areg = A + sp.eye(A.shape[0], format="csr") * flux_reg
 **Key diff:**
 ```python
 # OLD
-reg = getattr(config, "reg_astrom", 0)
+reg = getattr(config, "astrom_reg", 0)
 if reg <= 0:
     reg = 1e-6 * np.median(A.diagonal())
 Areg = A + sp.eye(A.shape[0], format="csr") * reg
@@ -157,14 +157,14 @@ def _astrom_isolation_mask(A, b, thresh):
 ### 4d. `generate_scenes` excludes stars from bright mask (so star-dominated scenes get merged into neighbours)
 ```python
 not_star = ~np.array([t.is_star for t in templates], dtype=bool)
-bright_mask = np.asarray(snr_proxy > snr_thresh_astrom, dtype=bool) & not_star
+bright_mask = np.asarray(snr_proxy > astrom_minimum_snr, dtype=bool) & not_star
 ```
 
 ### 4e. `Scene.solve` triple-cut bright mask + `has_shifts` guard
 ```python
 not_star = ~np.array([t.is_star for t in self.templates], dtype=bool)
 isolated = _astrom_isolation_mask(A, b, cfg.astrom_isolation_thresh)
-self.is_bright = (snr_proxy > cfg.snr_thresh_astrom) & not_star & isolated
+self.is_bright = (snr_proxy > cfg.astrom_minimum_snr) & not_star & isolated
 ```
 Wraps the entire shift-application block in `if self.shifts is not None and len(self.shifts) > 0:`,
 falling through to a warning for pathological all-blended scenes (with a TODO

--- a/docs/WREN_MERGE_PATH.md
+++ b/docs/WREN_MERGE_PATH.md
@@ -708,7 +708,7 @@ shift applied. Each is self-consistent in its own frame, but for an edge-clipped
 The audit records this as a defect documented nowhere on `main`. It is still accurate:
 `main` has not fixed it, and the `flux-bug` work fixed a different, larger term.
 
-`docs/FLUXBUG.md` records that `SceneFitter.solve` was adding `config.reg_astrom`
+`docs/FLUXBUG.md` records that `SceneFitter.solve` was adding `config.astrom_reg`
 (default `1e-4`) to the photometric normal matrix. That was removed. What remains at
 `scene_fitter.py:178-181` is
 

--- a/docs/campaigns.md
+++ b/docs/campaigns.md
@@ -32,17 +32,17 @@ it. Every example below is real `--dry-run` output.
 A field's bands are not independent, even though the fits are. Three things
 belong to the field rather than to any band:
 
-- the **F444W ePSF grids**, matched by `pattern_hi` — every band of a field
+- the **F444W ePSF grids**, matched by `psf.pattern_hi` — every band of a field
   fits against the same detection PSF;
 - the **30" halo grids**, when `repair_saturated` is on — their pattern is
-  derived from `pattern_hi`, so they are shared the same way;
+  derived from `psf.pattern_hi`, so they are shared the same way;
 - the **saturation repair**. `Pipeline._repair_provenance` keys the cache on
-  the detection image, its weight, `pattern_hi`, the halo pattern,
+  the detection image, its weight, `psf.pattern_hi`, the halo pattern,
   `repair_kwargs` and the trial box. Nothing in that varies between bands.
 
 Submit a field's bands together without preparing any of it and every band
 rebuilds the same grids and re-runs the same repair. Worse, they do it at the
-same time: several jobs write the same grid filenames into one `psf_dir`, and
+same time: several jobs write the same grid filenames into one `psf.dir`, and
 several write the same repair cache file. A half-written cache read by another
 job used to be fatal — `_load_repair_cache` now treats an unreadable file as
 absent and recomputes, but the wasted work remains.
@@ -58,20 +58,20 @@ Phase 1 costs one job per field and buys a clean parallel fan-out.
 ## The F444W race, and why prep is one band per field
 
 Everything about the two-phase shape follows from one fact: **a field's bands
-all derive the same `pattern_hi`**, so they all want to build the same F444W
-grids into the same `psf_dir`, under the same filenames.
+all derive the same `psf.pattern_hi`**, so they all want to build the same
+F444W grids into the same `psf.dir`, under the same filenames.
 
 The grid build itself parallelises cleanly. One `(detector, date)` pair is one
 independent job writing one uniquely named file, and each worker costs the
 stpsf wavefront propagation — tens to low hundreds of MB, nothing that scales
 with the field. `PSFFactory(workers=N)` fans those out, and
-`RunConfig.psf_workers` reaches it from a config.
+`PsfConfig.workers` reaches it from a config.
 
 What does **not** parallelise is two *bands of the same field* building at
-once. `uds_f770w` and `uds_f1000w` both resolve `pattern_hi` to
+once. `uds_f770w` and `uds_f1000w` both resolve `psf.pattern_hi` to
 `UDS_NRC.._F444W_MJD\d+_GRID25_OS4`, so both compute the same grids and both
 write the same paths. The same applies to the 30" halo grids, whose pattern is
-derived from `pattern_hi`. Interleaved writes to one FITS file give a torn
+derived from `psf.pattern_hi`. Interleaved writes to one FITS file give a torn
 file, and the loser's work is wasted either way.
 
 So the rule is: **serialise across patterns, parallelise within one.** That is
@@ -81,7 +81,7 @@ while `--workers` fans out inside each.
 
 Prep runs **F770W** where a field has it (`campaign.py`'s `prep_leader`). It is
 the shortest MIRI band, so it is the cheapest job that still builds everything
-shared. The band's own `pattern_lo` grids have per-band names and never
+shared. The band's own `psf.pattern_lo` grids have per-band names and never
 collide, so those are safe to build concurrently across bands afterwards.
 
 ## The pipeline steps behind it

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,7 @@ include_patterns = [
     "catalog.md",
     "preprocessing.md",
     "simulation.md",
+    "precision.md",
     "api.rst",
     "api/**",
 ]

--- a/docs/fitting.md
+++ b/docs/fitting.md
@@ -229,7 +229,7 @@ scenes, labels = generate_scenes(
     templates, image, weight,
     coupling_thresh=cfg.scene_coupling_thresh,
     max_size=cfg.scene_max_size,
-    minimum_bright=cfg.scene_minimum_bright,
+    minimum_bright=cfg.scene_minimum_anchors,
 )
 for scn in scenes:
     scn.set_band(image, weight, config=cfg)
@@ -297,7 +297,7 @@ arguments and results are returned, so the same instance serves every scene.
 {meth}`~mophongo.scene_fitter.SceneFitter.solve` returns a namespace with
 `flux`, `err`, `shifts`, `info`. The flux block receives a small adaptive
 ridge (`FitConfig.reg_flux`; `None` applies an adaptive `1e-6` times the matrix scale, `0.0` none at all) and
-the shift block a relative ridge `FitConfig.reg_astrom`; a scene with fewer
+the shift block a relative ridge `FitConfig.astrom_reg`; a scene with fewer
 than two bright members has empty shift blocks and falls back to the
 flux-only path, {meth}`~mophongo.scene_fitter.SceneFitter.solve_flux`, which
 whitens the matrix by its diagonal as described under
@@ -437,9 +437,9 @@ solve leaves the fitted shifts alone and costs one pass.
 
 The tolerance is a stopping rule, not an accuracy claim, and `0.1` fit-grid
 pixels is chosen against the noise rather than against the arithmetic. The
-weakest scene the anchor cuts admit — `scene_minimum_bright` = 5 members at
-`snr_thresh_astrom` = 15 — has a centroid good to roughly
-$\sigma_{\rm PSF}/({\rm SNR}\sqrt{N}) \approx 0.08$ fit pixels, so iterating
+weakest scene the anchor cuts admit — `scene_minimum_anchors` = 3 members at
+`astrom_minimum_snr` = 15 — has a centroid good to roughly
+$\sigma_{\rm PSF}/({\rm SNR}\sqrt{N}) \approx 0.10$ fit pixels, so iterating
 below that measures nothing; and the systematic floor from PSF and kernel
 mismatch is a bias, which no number of passes removes. Tightening the
 tolerance buys passes, not precision. Because the fit grid is the
@@ -526,17 +526,18 @@ page.
 | `astrom_shift_tol` | `float` | `0.1` | Stop iterating a scene once its largest per-template shift increment (fit-grid pixels) drops below this. |
 | `astrom_damping` | `float` | `0.8` | Factor applied to each pass's fitted shift increment before it is applied to the templates; `1.0` is undamped. |
 | `fit_astrometry_joint` | `bool` | `True` | Fit shifts jointly with fluxes inside each scene; if `False`, shifts come from the separate {class}`mophongo.astrometry.AstroCorrect` step. |
-| `reg_astrom` | `float` | `1e-4` | Ridge on the shift block, relative to its diagonal scale. |
-| `snr_thresh_astrom` | `float` | `15.0` | Minimum SNR proxy $b_i/\sqrt{A_{ii}}$ for a bright astrometric anchor; `0` keeps all. |
-| `astrom_isolation_thresh` | `float` | `0.6` | Minimum flux dominance (0–1) within its own footprint for a template to anchor astrometry; `0.0` disables the cut. |
+| `astrom_reg` | `float` | `1e-4` | Ridge on the shift block, relative to its diagonal scale. |
+| `astrom_minimum_snr` | `float` | `15.0` | Minimum SNR proxy $b_i/\sqrt{A_{ii}}$ for a bright astrometric anchor; `0` keeps all. |
+| `astrom_isolation_thresh` | `float` | `0.7` | Minimum flux dominance (0–1) within its own footprint for a template to anchor astrometry; `0.0` disables the cut. Roughly a separation cut: 0.6 admits blends down to ~1.2 PSF sigma, 0.7 to ~2. Not superseded by `astrom_robust` — see below. |
 | `astrom_leverage_cap` | `float \| None` | `0.9` | Cap each anchor's leverage at this quantile of the scene's anchor information. Bounds how much one bright source can move the shift field; `None` leaves the weights alone. |
+| `astrom_robust` | `bool` | `True` | Weight each anchor by how well it agrees with the shift field its neighbours define, and by how well its own stamp fits once it is allowed to move ({mod}`mophongo.astrom_robust`). Set `False` to recover the unweighted fit. |
 | `astrom_exclude_stars` | `bool` | `False` | Exclude `is_star` templates from the shift fit. Off by default: unsaturated stars are the best anchors, and saturated ones already sit in singleton scenes. |
-| `astrom_model` | `str` | `"gp"` | Model for the separate (non-joint) astrometry step: `"poly"` or `"gp"`; any other value raises `ValueError`. |
+| `astrom_model` | `str` | `"poly"` | Model for the separate (non-joint) astrometry step: `"poly"` or `"gp"`; any other value raises `ValueError`. The joint path ignores it and always uses the polynomial basis. |
 | `astrom_centroid` | `str` | `"centroid"` | Shift measurement for the separate step: `"centroid"` or `"correlation"`. |
 | `astrom_kwargs` | `dict` | `{"poly": {"order": 0}, "gp": {"length_scale": 400}}` | Per-model options; the joint scene fit reads `astrom_kwargs["poly"]["order"]`. |
 | `multi_resolution_method` | `str` | `"upsample"` | Multi-resolution handling (see {doc}`pipeline`). |
 | `normal` | `str` | `"tree"` | Normal-matrix builder; only `"tree"` is implemented. |
-| `scene_minimum_bright` | `int` | `5` | Minimum bright anchors per scene; smaller scenes are merged. `None` derives it from the polynomial order in `__post_init__`. |
+| `scene_minimum_anchors` | `int \| None` | `None` | Minimum bright anchors per scene; smaller scenes are merged. `None` derives it from the polynomial order as `(order+1)(order+2)+1` — 3 at order 0, 7 at order 1. Also the gate for `astrom_robust`. |
 | `run_scene_solver` | `bool` | `True` | Must remain `True`; the scene solver is the only fitting path and `False` raises. |
 | `scene_coupling_thresh` | `float` | `1e-3` | Leakage score above which templates share a scene. |
 | `scene_max_size` | `int \| None` | `800` | Soft cap on templates per scene, enforced by local threshold-raising. `None` disables. |

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,6 @@ pipeline
 repair
 outputs
 diagnostics
-campaigns
 ```
 
 ```{toctree}

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -55,17 +55,15 @@ copied through.
 ### Flux and error columns
 
 `flux_<i>`
-: Raw fitted template amplitude. Templates are normalized to unit sum and
-  convolved with unit-sum matching kernels, so this is the flux contained in
-  the modeled PSF support, without any correction for flux outside the finite
-  PSF stamp. Under the default `"psf_wings"` build scheme a template sums to
-  slightly less than one, because the wing flux that fell on a neighbouring
-  segment is dropped after the normalization and fitted by that neighbour's
-  own template; the amplitude is not rescaled for it (the blanked pixels
-  carry flux but almost no fitting weight — see `ee_tmpl` below). Each
-  amplitude is written to the catalog row carrying the template's `id`;
-  catalog deblend children are rows of their own, so a child keeps its own
-  flux instead of having it folded into its parent.
+: Raw fitted template amplitude: the flux inside the modeled PSF support,
+  with no correction for flux outside the finite PSF stamp. Templates and
+  matching kernels are unit-sum, which puts the amplitude on that scale; under
+  the default `"psf_wings"` scheme a template sums to slightly less than one
+  and the amplitude is not rescaled for it — the *Normalization order* section
+  of {doc}`templates` gives the reason. Each amplitude is written to the
+  catalog row carrying the template's `id`; catalog deblend children are rows
+  of their own, so a child keeps its own flux instead of having it folded into
+  its parent.
 
 `err_<i>`
 : 1-sigma uncertainty on `flux_<i>` from the solver:
@@ -93,7 +91,11 @@ copied through.
   low-resolution PSF stamp at that source's position. Templates whose
   `ee_psf_lo` is unset fall back to `throughput_<i>`. This is the number to
   use as a total flux; `flux_<i>` deliberately keeps the uncorrected amplitude
-  (see the shape-vs-throughput convention in {doc}`psf`).
+  (see the shape-vs-throughput convention in {doc}`psf`). The PSF encircled
+  energy is the right divisor for a point source; a source resolved at the
+  band's resolution loses a little more light past the same support, by the
+  factor `psfcor_<i>` below (*Encircled energy of a template* in
+  {doc}`templates`).
 
 `scene_<i>`
 : Id of the scene the source was fitted in, taken from the scene objects
@@ -117,6 +119,16 @@ copied through.
   converged solution. The run logs a warning naming the worst offenders, and
   `<name>_scene_catalog.csv` carries the same verdict per scene along with
   `astrom_niter` (passes used) and `astrom_step` (last increment, pixels).
+
+`astrom_weight_<i>`
+: The weight this source carried as an astrometric anchor, from
+  `FitConfig.astrom_robust`: `1.0` when the robust pass is off, declined the
+  scene, or found nothing to downweight, and `0.0` for a rejected anchor.
+  Non-anchors read `1.0` — they never had a vote to lose. Where a source has
+  several templates the weakest is taken, so the column answers "was any part
+  of this source thrown out of the shift fit". The column is written whether
+  or not the pass is enabled, so an A/B pair of runs differs in the values
+  rather than in the schema.
 
 ### Aperture columns
 
@@ -228,19 +240,72 @@ high-resolution science header. The matching model images are in
 ## Scene catalog
 
 `<name>_scene_catalog.csv` has one row per fitted scene ({doc}`fitting`):
-`id` (scene id), `n_templates`, `is_bright` (number of bright anchor sources),
-`ra`, `dec` of the scene center, the total astrometric shift `dx`, `dy` at
-that center in reference-grid pixels (NaN where the scene solved no
-astrometry), plus a URL column linking each position to an external sky
-viewer. `dx`, `dy` is the *accumulated* shift, the same quantity as the
-per-template table's `dx`, `dy` — `Scene.shifts` holds only the last
-iteration's increment and is never written.
+`id` (scene id), `n_templates`, `n_anchor` (sources that passed the
+astrometric anchor cuts — SNR, isolation, and optional star exclusion — so it
+counts more than brightness despite the older `is_bright` spelling), `ra`,
+`dec` of the scene center, the total astrometric shift `dx`, `dy` at that
+center in reference-grid pixels (NaN where the scene solved no astrometry),
+`sigma_shift`, `shift_rms`, `chi2_dof`, and a URL column linking each position
+to an external sky viewer.
+
+`dx`, `dy` is the mean shift actually applied to the scene's templates, at
+the centroid of those templates. It is not a field evaluation: accumulated
+shifts are a sum of damped increments, each fitted at whatever the previous
+pass left behind, so at order >= 1 the total is not in general representable
+by the functional form of any single pass. `Scene.shifts` holds only the last
+increment's coefficients and is never written here.
+
+`sigma_shift` is the formal 1-sigma on that shift, propagated from the shift
+block's covariance with the fluxes marginalized out, evaluated at the scene
+centre and averaged over the two axes. It is what gives `dx`, `dy` a scale: a
+0.2 px shift means nothing until you know whether it was measured to 0.02 px or
+to 0.5 px. It is the *last pass's* number -- passes re-measure the same pixels,
+so at convergence the accumulated shift is determined about as well as any one
+pass determines it. Read it as the scale on the total, not as an error that
+shrinks with the number of passes.
+
+`chi2_dof` is the reduced chi-square over the scene's bounding box, against the
+residual with *every* scene's model subtracted, with one free parameter per
+template plus the shift coefficients. Sorting on it is the direct way to find
+the scenes worth looking at.
+
+`shift_rms` is the spread of those applied shifts about their mean. At the
+default order 0 every template receives the same offset, so a non-zero value
+means the field moved between passes — the scene walked rather than settled.
+At higher order it is the amplitude of the gradient the field actually
+carried, which is the direct way to see whether the extra terms did anything.
 
 Three columns record how the shift was reached: `astrom_niter` (solve/apply
 passes this scene used before it dropped out of the loop), `astrom_step`
 (its last shift increment in pixels) and `flag_astrom` (`0` converged, `1`
 still moving when the budget ran out, `-1` no verdict). Every source of the
 scene inherits `flag_astrom` as the fit table's `flag_astrom_<i>`.
+
+`astrom_floor` is what `FitConfig.astrom_robust` measured, NaN where the pass
+never ran or declined. It is the **systematic error floor on an anchor's
+position**: the extra per-axis scatter, in fit-grid pixels, that must be added
+in quadrature to the anchors' formal errors before their disagreement with the
+fitted shift field is statistically consistent. Formally it is the `s >= 0`
+solving
+
+    median over anchors and axes of  r_ia^2 / (v_i + s^2)  =  median(chi^2_1)
+
+with `r_ia` the anchor's implied shift minus the fitted field and `v_i = 1 /
+I_i` its formal variance. Median-based, so one wild anchor cannot set it, and
+zero when the anchors already agree within their errors.
+
+Read it against `astrom_shift_tol`: a floor several times the tolerance means
+the anchors do not agree at the level the loop is trying to converge to, and
+the shift is limited by template and PSF fidelity rather than by noise. It is
+also the ceiling on how much any one anchor can be trusted, which is what
+`astrom_leverage_cap` approximates with a quantile.
+
+The `SCENES` extension of the fit table carries the rest of the robust
+verdict: `astrom_robust` (`1` if the pass judged this scene), `astrom_nreject`
+(anchors rejected outright) and `astrom_neff` (anchors surviving rejection --
+`n_anchor` counts those that passed the cuts, before any rejection).
+Comparing these against a run with the flag off is the intended way to judge
+whether the weighting earned its place on a given field.
 
 With `scene_plots` enabled, each scene also gets a `<name>_scene_<id>.png`
 diagnostic figure, written to a `scenes/` subdirectory of `out_dir` (created

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -118,10 +118,11 @@ photometry with `photutils` is simpler and sufficient.
 - **API reference** — {doc}`api` is the autosummary listing of all public
   modules.
 
-## Minimal example
+## Quickstart
 
-The array-level entry point is {func}`mophongo.pipeline.run`, a thin wrapper
-that constructs a {class}`mophongo.pipeline.Pipeline` and calls
+{doc}`quickstart` walks through both entry points. The array-level one is
+{func}`mophongo.pipeline.run`, a thin wrapper that constructs a
+{class}`mophongo.pipeline.Pipeline` and calls
 {meth}`mophongo.pipeline.Pipeline.run`:
 
 ```python
@@ -150,80 +151,8 @@ experiments; runs on real mosaics use the JSON config path, which builds
 drizzled position-dependent PSFs, per-region kernels, and file outputs. The
 "Choosing an entry point" table in {doc}`quickstart` lists the differences.
 
-### Parameters of `pipeline.run` (and `Pipeline.__init__`)
-
-All arguments after `segmap` are keyword-only. Sequence arguments run
-parallel to `images` (index 0 = detection image).
-
-`images` (`Sequence[np.ndarray]`, required)
-: Science images. The first is the high-resolution detection image; each
-  subsequent image is fit.
-
-`segmap` (`np.ndarray`, required)
-: Segmentation map on the detection-image grid; pixel values are catalog ids.
-
-`catalog` (`Table | None`, default `None`)
-: Source catalog with `id`, `x`, `y` columns matching the segmentation ids.
-  The output table is a trimmed copy (`id`, `x`, `y`, plus any deblending and
-  saturation flag columns) with the flux columns added; the input table is
-  not modified. Required in practice: `run()` raises `NotImplementedError`
-  when no catalog is given.
-
-`psfs` (`Sequence[np.ndarray] | None`, default `None`)
-: Per-image PSFs, as arrays or {class}`mophongo.psf_map.PSFRegionMap`
-  instances; must match `images` in length when given. The detection-image
-  PSF (`psfs[0]`) supplies the wings for template extension, and every build
-  scheme except `"none"` requires it — with the default scheme a run without
-  it raises rather than substituting another band's PSF.
-
-`weights` (`Sequence[np.ndarray] | None`, default `None`)
-: Per-image inverse-variance maps. `wht_images` is an accepted alias. The
-  detection-image entry may be `None` — the build schemes that grade data
-  against a PSF model by signal-to-noise then use a single scalar noise
-  estimate for the whole detection image — but every fitted image needs a
-  map; omitting both arguments is not supported and fails inside
-  {meth}`mophongo.pipeline.Pipeline.run`.
-
-`wht_images` (`Sequence[np.ndarray] | None`, default `None`)
-: Alias for `weights`, kept for backward compatibility.
-
-`kernels` (`Sequence[np.ndarray | PSFRegionMap] | None`, default `None`)
-: Precomputed PSF-matching kernels per image (array or region map). A `None`
-  entry fits the templates without further convolution; config-driven runs
-  build kernels from the high- and low-resolution PSF maps automatically.
-
-`psf_throughputs` (`Sequence[float] | None`, default `None`)
-: Per-filter finite-stamp PSF sums used to convert fitted amplitudes into
-  `flux_<i>_total` (see conventions below); must match `images` in length.
-
-`wcs` (`Sequence[WCS] | None`, default `None`)
-: Per-image WCS. Required for multi-resolution fitting (bin factors are
-  derived from the WCS pixel scales) and for sky coordinates in outputs.
-
-`window` (default `None`)
-: Stored on the instance but not consumed by the fit as of this writing; the
-  annotated `Window` type is not defined in the package. Leave unset.
-
-`extend_mode` (`str | None`, default `None`)
-: Selector for the template build scheme: `"psf_wings"` (the wings scaled to
-  the segment data), `"psf_convolution"` and `"psf_model"` (post-extraction
-  filling of the zero pixels), `"wren"` and `"classic"` (the reference
-  implementations), or `"none"` to leave templates truncated at the segment
-  boundary. When given it overrides `FitConfig.extend_mode`; `None` — the
-  default — leaves the choice to that field, which itself defaults to
-  `"psf_wings"`, so both entry points extend templates unless told
-  otherwise. `extend_templates` is a deprecated alias for this argument, and
-  the spelling `"psf"` a deprecated alias for `"psf_convolution"`.
-  {doc}`pipeline` describes each scheme.
-
-`templates` (`Templates | Sequence[Template] | None`, default `None`)
-: Pre-built templates to reuse instead of extracting them from `segmap`.
-
-`config` (`FitConfig | None`, default `None`)
-: Fitting configuration; a default {class}`mophongo.fit.FitConfig` is used
-  when omitted. The fitting-related fields are documented in {doc}`fitting`,
-  the full reference on {doc}`pipeline`.
-
+The full argument list of `pipeline.run` and `Pipeline.__init__`, and the
+`RunConfig` fields of the config-driven path, are in {doc}`pipeline`.
 {func}`mophongo.pipeline.run` returns `(table, residuals, pipeline)`;
 {meth}`mophongo.pipeline.Pipeline.run` returns `(table, residuals)` and keeps
 the fitter, templates, and model images on the instance.

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -116,7 +116,7 @@ fit.
    - **Scene generation.** Templates are grouped into scenes of coupled
      sources ({func}`mophongo.scene.generate_scenes`), controlled by
      `FitConfig.scene_coupling_thresh`, `scene_max_size`,
-     `scene_minimum_bright`, and `scene_max_merge_radius`. See {doc}`fitting`.
+     `scene_minimum_anchors`, and `scene_max_merge_radius`. See {doc}`fitting`.
    - **Fitting.** Each scene is solved for template amplitudes, iterating up
      to `FitConfig.fit_astrometry_niter` passes with per-template astrometric
      shifts applied between passes, damped by `FitConfig.astrom_damping` and
@@ -310,25 +310,11 @@ Optional fields:
   high-resolution weight map costs as much memory as the mosaic. The
   detection background is measured alongside it but, unlike the low-resolution
   side, not subtracted.
-- `psf_dir` (*str*, default `"data/PSF"`) — directory of STDPSF grid files.
-- `pattern_hi`, `pattern_lo` (*str*, default `""`) — STDPSF filename regex
-  for each band, of the form
-  `{prefix}_{DET}_{FILT}[_MJD..]_GRID{N}_{OS4|DET}`.
 - `filter_lo` (*str*, default `""`) — lo-res filter name (e.g. `"f770w"`),
-  used for the default Gaussian-blur lookup.
-- `psf_size` (*float | None*, default `4.0`) — PSF stamp size in arcsec;
-  `None` keeps the full native ePSF stamp.
-- `psf_autobuild` (*bool*, default `True`) — generate missing PSF grids with
-  {class}`mophongo.psf_factory.PSFFactory` (see caching below).
-- `psf_fov_arcsec` (*float | None*, default `None`) — PSFFactory field of
-  view; `None` uses the backend default.
-- `psf_blur_fwhm` (*float | str | None*, default `"default"`) — extra
-  Gaussian broadening of the lo-res model PSF (FWHM, arcsec). `"default"`
-  looks up a per-filter value keyed by `filter_lo`; a number applies that
-  value; `None` applies no broadening.
-- `expect_frames` (*list[int] | None*, default `None`) — optional
-  `[n_frames_hi, n_frames_lo]` sanity check against the WCS csvs; a mismatch
-  raises.
+  used for the default Gaussian-blur lookup and for figure labels.
+- `psf` (*dict*, default `{}`) — the PSF block, loaded into a
+  {class}`mophongo.pipeline.PsfConfig` (see below). Like `fit`, it is a
+  nested object in the JSON rather than a row of top-level keys.
 - `bg_filter_sigma` (*float*, default `64.0`) — background filter scale
   passed to {func}`mophongo.catalog.get_bg_and_ivar`; the fitted image is the
   lo-res science image minus this background.
@@ -346,6 +332,51 @@ Optional fields:
 - `save_stamps` (*bool*, default `True`) — write the per-source stamps FITS
   (native-size hi/lo templates plus fit metadata; see
   {meth}`~mophongo.pipeline.Pipeline.write_stamps`).
+
+### The `psf` block
+
+{class}`mophongo.pipeline.PsfConfig` holds everything that decides which ePSF
+grids a run uses and what the delivered stamps look like. A JSON `"psf"`
+object is coerced to it on load; unknown keys raise, and omitted ones keep
+their defaults.
+
+```json
+"psf": {
+  "dir": "data/PSF",
+  "pattern_hi": "UDS_NRC.._F444W_MJD\\d+_GRID25_OS4",
+  "pattern_lo": "UDS_MIRI_F770W_MJD\\d+_GRID9_OS4",
+  "size": 4.0,
+  "date_mode": "all",
+  "provenance": "warn",
+  "blur_fwhm": "default"
+}
+```
+
+- `dir` (*str*, default `"data/PSF"`) — directory of STDPSF grid files;
+  generated grids are cached here too.
+- `pattern_hi`, `pattern_lo` (*str*, default `""`) — STDPSF filename regex
+  for each band, of the form
+  `{prefix}_{DET}_{FILT}[_MJD..]_GRID{N}_{OS4|DET}`.
+- `size` (*float | None*, default `4.0`) — PSF stamp size in arcsec; `None`
+  keeps the full native ePSF stamp.
+- `autobuild` (*bool*, default `True`) — generate missing PSF grids with
+  {class}`mophongo.psf_factory.PSFFactory` (see caching below).
+- `provenance` (*str*, default `"warn"`) — what to do when the exposure list
+  implies epochs no grid provides and `autobuild` is off: `"warn"` names them
+  and fits with the grids that exist, `"error"` refuses to run, `"off"` skips
+  the check.
+- `workers` (*int*, default `1`) — processes used when building ePSF grids;
+  it parallelises within one pattern only, since bands of a field share
+  `pattern_hi` and would race on the same filenames.
+- `fov_arcsec` (*float | None*, default `None`) — PSFFactory field of view;
+  `None` uses the backend default.
+- `date_mode` (*str | float*, default `"all"`) — which exposure dates get
+  their own grid when autobuilding (`"all"` = one per unique integer MJD; see
+  {func}`mophongo.psf_factory.dates_from_csv`).
+- `blur_fwhm` (*float | str | None*, default `"default"`) — extra Gaussian
+  broadening of the lo-res model PSF (FWHM, arcsec). `"default"` looks up a
+  per-filter value keyed by `filter_lo`; a number applies that value; `None`
+  applies no broadening.
 
 ### Per-frame WCS CSVs
 
@@ -517,19 +548,33 @@ Astrometry:
   extra pass. `1.0` is undamped.
 - `fit_astrometry_joint` (*bool*, default `True`) — solve shifts jointly
   with fluxes rather than as a separate step.
-- `reg_astrom` (*float*, default `1e-4`) — regularization of the astrometric
+- `astrom_reg` (*float*, default `1e-4`) — regularization of the astrometric
   shift solve.
-- `snr_thresh_astrom` (*float*, default `15.0`) — minimum SNR for a source
+- `astrom_minimum_snr` (*float*, default `15.0`) — minimum SNR for a source
   to constrain astrometry; `0` keeps all sources.
-- `astrom_isolation_thresh` (*float*, default `0.6`) — minimum flux
+- `astrom_isolation_thresh` (*float*, default `0.7`) — minimum flux
   dominance (0–1) for inclusion in the astrometric fit; `0.0` applies no
-  cut.
+  cut. In effect a separation cut: 0.6 admits blends down to ~1.2 PSF sigma,
+  0.7 to ~2. `astrom_robust` does not replace it — a blended anchor's implied
+  shift is shrunk toward zero *coherently*, so blended anchors agree with one
+  another and a robust estimator follows them instead of rejecting them.
+- `astrom_robust` (*bool*, default `True`) — weight each anchor by its
+  agreement with the shift field its neighbours define, and by how well its
+  own stamp fits once it is allowed to move. Catches the bright extended
+  source whose colour gradient reads as a displacement, which the flux²
+  weighting of the plain solve lets carry a scene on its own.
+  Gated on `scene_minimum_anchors` anchors, and where it is active it
+  supersedes `astrom_leverage_cap`: both bound how much one anchor can move
+  the field, but this one sets the ceiling from the anchors' measured scatter
+  rather than from a quantile.
 - `astrom_exclude_stars` (*bool*, default `False`) — exclude sources flagged
   `is_star` from the shift fit. Off by default: unsaturated stars are good
   astrometric anchors, and saturated ones are already isolated into their
   own scenes.
-- `astrom_model` (*str*, default `"gp"`) — spatial shift model,
-  `"poly"` or `"gp"`; any other value raises.
+- `astrom_model` (*str*, default `"poly"`) — spatial shift model,
+  `"poly"` or `"gp"`; any other value raises. Read only by the non-joint
+  astrometry step; the joint path (the default) always uses the polynomial
+  basis at `astrom_kwargs["poly"]["order"]`.
 - `astrom_centroid` (*str*, default `"centroid"`) — shift measurement,
   `"centroid"` or `"correlation"`.
 - `astrom_kwargs` (*dict*, default
@@ -617,9 +662,11 @@ Scenes:
   partner, and a merge that would leave the scene wider than this is refused.
   `np.inf` disables all three. The size cap above bounds a scene's template
   count and leaves its shape free; this bounds the shape.
-- `scene_minimum_bright` (*int | None*, default `5`) — minimum number of
-  bright sources per scene; when set to `None` it is derived from the
-  astrometric polynomial order as `(order + 1) * (order + 2) + 1`.
+- `scene_minimum_anchors` (*int | None*, default `None`) — minimum number of
+  bright anchors per scene, derived by default from the astrometric
+  polynomial order as `(order + 1) * (order + 2) + 1`, i.e. one more anchor
+  than the shift field has free parameters. Set an int to override. Also the
+  gate below which `astrom_robust` declines to judge a scene.
 - `generate_scene_catalog` (*bool*, default `False`) — write a scene catalog
   (`scene_catalog_<i>.ecsv`) and exit without fitting.
 
@@ -647,15 +694,16 @@ flux scale at the percent level, so a map built another way is rebuilt rather
 than silently reused. Passing `overwrite=True` to either step forces a
 rebuild.
 
-**PSF grid auto-build.** Loading the ePSF grids matches files under `psf_dir`
-against `pattern_hi`/`pattern_lo`. When no file matches and `psf_autobuild`
+**PSF grid auto-build.** Loading the ePSF grids matches files under `psf.dir`
+against `psf.pattern_hi`/`psf.pattern_lo`. When no file matches and
+`psf.autobuild`
 is `True` (the default), the pipeline derives the generator settings
 (prefix, grid size, oversampling, detector sampling, MJD tagging) from the
 pattern itself, runs {class}`mophongo.psf_factory.PSFFactory` over the band's
-exposure csv, writes the grids into `psf_dir`, and loads them; deriving the
+exposure csv, writes the grids into `psf.dir`, and loads them; deriving the
 settings from the search pattern guarantees the generated files are found
 again. This step is slow (it generates PSFs with stpsf). With
-`psf_autobuild=False` a missing grid raises `FileNotFoundError` instead of
+`psf.autobuild` false a missing grid raises `FileNotFoundError` instead of
 letting the run continue without a PSF. See {doc}`psf`.
 
 Other cached state: the stamps file (`<name>_stamps.fits`) records the grid

--- a/docs/preprocessing.md
+++ b/docs/preprocessing.md
@@ -225,7 +225,7 @@ accumulated in `Template.shifted`.
 {class}`mophongo.astrometry.AstroCorrect` is constructed from a
 {class}`~mophongo.fit.FitConfig`, which supplies all its options: the field
 model `astrom_model` (`"poly"` or `"gp"`), the measurement method
-`astrom_centroid`, the anchor cut `snr_thresh_astrom`, and the per-model
+`astrom_centroid`, the anchor cut `astrom_minimum_snr`, and the per-model
 keyword dicts in `astrom_kwargs` — all documented in {doc}`fitting`.
 {meth}`~mophongo.astrometry.AstroCorrect.fit` measures shifts from the
 current fit state (templates, residual image, fitted amplitudes), fits the

--- a/docs/psf.md
+++ b/docs/psf.md
@@ -91,6 +91,44 @@ matched = fftconvolve(psf_hi.array, kernel)
 print(f"{np.abs(matched - psf_lo.array).max():.1e}")  # 7.1e-07
 ```
 
+### `matching_kernel()` parameters
+
+{func}`mophongo.utils.matching_kernel` preserves the input sums: if
+`sum(psf_lo) / sum(psf_hi)` is not one, that ratio propagates into `sum(k)`,
+which is why pipeline-facing calls pass unit-sum shapes.
+
+`psf_hi_in`, `psf_lo_in` (`np.ndarray`, required)
+: High- and low-resolution PSF arrays.
+
+`window` (default `None`)
+: Fourier-domain window for `method="window"`; defaults to
+  `photutils.psf.matching.SplitCosineBellWindow(alpha=0.4, beta=0.1)`.
+
+`recenter` (`bool`, default `False`)
+: Shift the kernel to its measured centroid with bicubic interpolation.
+
+`pixel_ratio` (`float`, default `1.0`)
+: Pixel-scale ratio between the two PSF grids; a non-unity value resamples
+  one PSF onto the other's grid with flux-conserving cubic interpolation
+  before the kernel is computed.
+
+`method` (`str`, default `"window"`)
+: Kernel algorithm: `"window"`, `"tikhonov"`, `"wiener"`, or `"forward"`
+  (see below).
+
+`reg` (`float`, default `1e-3`)
+: Regularization strength for the `tikhonov`, `wiener`, and `forward`
+  methods.
+
+`wavelet` (`str`, default `"db4"`), `levels` (`int`, default `3`),
+`threshold_factor` (`float`, default `3.0`), `noise_sigma`
+(`float | None`, default `None`), `forward_wavelet_wiener` (`bool`,
+default `True`)
+: Wavelet-denoising controls for `method="forward"`.
+
+`signal_psd` (`np.ndarray | None`, default `None`)
+: Optional signal power spectrum for `method="wiener"`.
+
 ### Regularization methods
 
 **`"window"`**
@@ -324,15 +362,15 @@ grid = fac.build(telescope="JWST", instrument="NIRCAM",
 ### Automatic grid generation and per-band blur defaults
 
 The pipeline calls `PSFFactory.from_csv` itself when its ePSF loader finds
-no files matching the configured filename pattern and `psf_autobuild` is on
+no files matching the configured filename pattern and `psf.autobuild` is on
 (the default); see {doc}`pipeline`. The pipeline can also broaden the
 low-resolution model PSF by an extra Gaussian before kernel construction
-(`psf_blur_fwhm`): the `"default"` setting looks the FWHM up per filter in
+(`psf.blur_fwhm`): the `"default"` setting looks the FWHM up per filter in
 `mophongo.mock_mosaic.DEFAULT_PSF_GAUSSIAN_FWHM_ARCSEC`, which carries MIRI
 defaults (0.08 arcsec at F560W/F770W rising to 0.30 arcsec at F2100W, no
 broadening for unlisted filters), accounting for the broadening of real
 MIRI mosaics relative to the optical `stpsf` model. Production runs should
-keep this default blur on for MIRI bands; disable it (`psf_blur_fwhm=None`)
+keep this default blur on for MIRI bands; disable it (`psf.blur_fwhm` null)
 only when deliberately testing the unblurred optical model, for example
 when comparing drizzled model PSFs against real stars to measure the
 broadening itself.

--- a/docs/psf_maps.md
+++ b/docs/psf_maps.md
@@ -389,7 +389,7 @@ each band it forms the region map from the exposure footprints of the
 band's {class}`mophongo.psf.DrizzlePSF`, clips it to the drizzled mosaic
 outline with `overlay_with`, and drizzles a PSF at every region centroid.
 The low-resolution cube optionally receives a Gaussian broadening (the
-`psf_blur_fwhm` run setting). Stamps keep their native sums, so a stamp sum
+`psf.blur_fwhm` run setting). Stamps keep their native sums, so a stamp sum
 is a realized encircled energy: {meth}`mophongo.pipeline.Pipeline.run` divides
 each fitted amplitude (`flux_<i>`) by the encircled energy of the lo-res stamp
 at that source's position to get the total (`flux_<i>_total`), and falls back

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -11,17 +11,33 @@ mosaics — and passing in-memory arrays directly to
 
 ## Installation
 
-Install the dependencies with [Poetry](https://python-poetry.org/):
+Mophongo is not on PyPI; clone it from GitHub and install from the checkout.
+It needs Python >= 3.11, < 3.13.
 
 ```bash
-poetry install
+git clone https://github.com/ivolabbe/mophongo.git
+cd mophongo
+poetry install          # resolves and installs into .venv (recommended)
 ```
 
-or install in editable mode with pip:
+or, in an environment you manage yourself:
 
 ```bash
-pip install -e .
+pip install -e .        # editable install from the checkout
 ```
+
+Poetry keeps the environment in `.venv/` inside the checkout and does not put
+it on your `PATH`. Either prefix commands with `poetry run`, or activate it:
+
+```bash
+poetry run mophongo --help              # one-off
+eval $(poetry env activate)             # activate for the session (Poetry >= 2.0)
+source .venv/bin/activate               # same thing, by hand
+```
+
+The `mophongo` console script and `python -m mophongo.pipeline` both become
+available once the environment is active ({doc}`diagnostics` covers the
+subcommands).
 
 ## Choosing an entry point
 
@@ -107,19 +123,20 @@ A minimal config:
   "wht_hi": "wht_hi.fits",
   "csv_hi": "frames_hi.csv",
   "csv_lo": "frames_lo.csv",
-  "pattern_hi": "STDPSF_NRCA._F444W.*fits",
-  "pattern_lo": "STDPSF_MIRI_F770W.*fits",
-  "filter_lo": "f770w"
+  "filter_lo": "f770w",
+  "psf": {
+    "pattern_hi": "STDPSF_NRCA._F444W.*fits",
+    "pattern_lo": "STDPSF_MIRI_F770W.*fits"
+  }
 }
 ```
 
 Lines starting with `#` are treated as comments and stripped, so configs can
 be annotated. Unknown keys raise an error, so typos fail loudly.
 
-One input stays implicit above: every run needs a detection-band weight map,
-the source of the calibrated detection noise. `wht_hi` names it; left unset,
-the run looks for the standard `_sci.fits` -> `_wht.fits` sibling of `sci_hi`
-and raises when there is none.
+One input stays implicit above: every run needs a detection-band weight map.
+`wht_hi` names it; left unset, the run looks for the standard
+`_sci.fits` -> `_wht.fits` sibling of `sci_hi`.
 
 A realistic config for a JWST field — 40 mas F444W detection mosaic, 80 mas
 MIRI F770W band, MJD-tagged ePSF grids, a trial patch for testing before the
@@ -141,18 +158,19 @@ full-field run — looks like:
   "wht_lo": "data/mosaic-80mas-f770w_drz_wht.fits",
   "csv_lo": "data/mosaic-80mas-f770w_wcs.csv",
 
-  # MJD-tagged ePSF grids; psf_size in arcsec
-  "psf_dir": "data/PSF",
-  "pattern_hi": "NRC.._F444W_MJD\\d+_GRID25_OS4",
-  "pattern_lo": "MIRI_F770W_MJD\\d+_GRID9_OS4",
+  # MJD-tagged ePSF grids; psf.size in arcsec
   "filter_lo": "f770w",
-  "psf_size": 4.0,
-  "psf_blur_fwhm": "default",
+  "psf": {
+    "dir": "data/PSF",
+    "pattern_hi": "NRC.._F444W_MJD\\d+_GRID25_OS4",
+    "pattern_lo": "MIRI_F770W_MJD\\d+_GRID9_OS4",
+    "size": 4.0,
+    "blur_fwhm": "default"
+  },
 
-  # preprocessing: footprint cut + trial patch (r_trial 0 = full mosaic)
+  # preprocessing: footprint cut + trial patch ("trial": null = full mosaic)
   "footprint_filter": true,
-  "r_trial": 0.6,
-  "trial_center": [34.35, -5.27],
+  "trial": {"center": [34.35, -5.27], "radius": 0.6},
   "bg_filter_sigma": 64.0,
 
   # FitConfig overrides
@@ -160,108 +178,26 @@ full-field run — looks like:
 }
 ```
 
-Start with a small `r_trial` patch to validate PSFs, kernels, and residuals,
-then set `r_trial` to `0` for the full field: the cached PSF and kernel maps
+Start with a small `trial` patch to validate PSFs, kernels, and residuals,
+then set `trial` to `null` for the full field: the cached PSF and kernel maps
 in `out_dir` are reused.
 
-### `RunConfig` fields
+### The config fields
 
 {class}`mophongo.pipeline.RunConfig` describes one filter fit (one
-high-resolution plus one low-resolution band). Fields without a default are
-required.
+high-resolution plus one low-resolution band). The required fields are the
+ones in the minimal config above: the run `name` and `out_dir`, the
+high-resolution side (`sci_hi`, `segmap`, `catalog`, `csv_hi`), and the band
+to fit (`sci_lo`, `wht_lo`, `csv_lo`). Two nested blocks hold the settings
+that come in groups: `psf` selects the ePSF grids and the stamp size
+({class}`mophongo.pipeline.PsfConfig`), and `fit` forwards keywords to
+{class}`mophongo.fit.FitConfig`, including the template build scheme
+(`extend_mode`). The remaining top-level fields control preprocessing
+(`bg_filter_sigma`, `footprint_filter`, `trial`) and outputs (`scene_plots`,
+`save_stamps`).
 
-`name` (`str`)
-: Run label; prefixes every output file.
-
-`out_dir` (`str`)
-: Output directory for products and PSF/kernel caches (never inputs).
-
-`sci_hi` (`str`)
-: High-resolution template image (FITS).
-
-`segmap` (`str`)
-: Segmentation map on the high-resolution grid; labels equal catalog ids.
-
-`catalog` (`str`)
-: Source catalog with `id`, `x`, `y` (high-resolution pixels), `ra`, `dec`.
-
-`sci_lo` (`str`)
-: Low-resolution science mosaic to fit.
-
-`wht_lo` (`str`)
-: Low-resolution weight map (inverse variance).
-
-`csv_hi`, `csv_lo` (`str`)
-: Per-frame WCS CSV files of the high- and low-resolution mosaics, used to
-  drizzle position-dependent PSFs. The "Per-frame WCS CSVs" section of
-  {doc}`pipeline` describes what they contain and how to generate them with
-  {func}`mophongo.utils.reconstruct_wcs`.
-
-`wht_hi` (`str | None`, default `None`)
-: Detection-band weight map, the counterpart of `wht_lo`. `None` derives it
-  from `sci_hi` by the standard `_sci.fits` -> `_wht.fits` substitution; a
-  run with neither raises. Its pixels are read only by the build schemes
-  that weight data against a PSF model by signal-to-noise (`"psf_wings"`,
-  `"wren"`, `"classic"`), because a full-field high-resolution weight map
-  costs as much memory as the mosaic itself.
-
-`psf_dir` (`str`, default `"data/PSF"`)
-: Directory holding STDPSF grid files.
-
-`pattern_hi`, `pattern_lo` (`str`, default `""`)
-: STDPSF filename regexes selecting the PSF grids for each band.
-
-`filter_lo` (`str`, default `""`)
-: Low-resolution filter name (e.g. `"f770w"`), used for the blur lookup.
-
-`psf_size` (`float | None`, default `4.0`)
-: PSF stamp size in arcsec; `None` keeps the full native ePSF stamp.
-
-`psf_autobuild` (`bool`, default `True`)
-: Generate missing PSF grids with
-  {class}`mophongo.psf_factory.PSFFactory` (see {doc}`psf`).
-
-`psf_fov_arcsec` (`float | None`, default `None`)
-: PSFFactory field of view; `None` uses the backend default.
-
-`psf_blur_fwhm` (`float | str | None`, default `"default"`)
-: Extra Gaussian broadening of the low-resolution model PSF (FWHM,
-  arcsec). `"default"` looks up a per-filter value from
-  `mophongo.mock_mosaic.DEFAULT_PSF_GAUSSIAN_FWHM_ARCSEC`; a number uses
-  that value; `None` applies no broadening.
-
-`expect_frames` (`list[int] | None`, default `None`)
-: Optional `[n_frames_hi, n_frames_lo]` sanity assertion on the WCS CSVs.
-
-`bg_filter_sigma` (`float`, default `64.0`)
-: Background filter scale for the background/inverse-variance
-  preprocessing step (see {doc}`preprocessing`).
-
-`footprint_filter` (`bool`, default `True`)
-: Keep only sources where the low-resolution weight is positive.
-
-`r_trial` (`float`, default `0.0`)
-: Trial-patch radius in arcmin; `0` fits the full mosaic.
-
-`trial_center` (`list[float] | None`, default `None`)
-: `[ra, dec]` in degrees of the trial patch center.
-
-`fit` (`dict`, default `{}`)
-: Keyword arguments forwarded to {class}`mophongo.fit.FitConfig`
-  (see {doc}`fitting`). The template build scheme is selected here, with
-  `"extend_mode"`; there is no separate config field for it.
-
-`scene_plots` (`bool`, default `True`)
-: Write per-scene diagnostic PNGs during `write_outputs()`.
-
-`save_stamps` (`bool`, default `True`)
-: Write the per-source stamps FITS file (native-size high/low templates
-  plus each source's PSF region key; the PSF stamps themselves are not
-  duplicated here, they stay in the cached `<name>_psf_*.geojson` maps),
-  which later allows restoring a finished run with `Pipeline.load_fit()`.
-
-The full description of the config-driven flow, the step methods, and the
-caching behavior is in {doc}`pipeline`.
+Every field, its default, and the full description of the config-driven flow
+are in {doc}`pipeline`; the `FitConfig` fields are in {doc}`fitting`.
 
 ## An array-level run
 
@@ -331,151 +267,22 @@ Two conventions to keep in mind:
   fitted amplitude appears as `flux_<i>` and the throughput-corrected total
   as `flux_<i>_total`. See {doc}`psf` for the full convention.
 
-If a fitted band has a coarser pixel scale than the detection image, pass
-per-image WCS objects via `wcs`: the pipeline derives an integer bin factor
-from the WCS pair, block-replicates the low-resolution science pixels with
-flux conservation onto the reference grid, and copies the inverse variance
-to the subpixels multiplied by `factor**2` so the native chi-square is
-preserved.
+If a fitted band is coarser than the detection image, pass per-image WCS
+objects via `wcs`: the pipeline then derives the integer bin factor between
+the two grids and fits on the reference grid ({doc}`pipeline`).
 
-### `pipeline.run()` parameters
-
-{func}`mophongo.pipeline.run` is a thin wrapper that constructs a
-{class}`mophongo.pipeline.Pipeline` (same parameters) and calls
-{meth}`mophongo.pipeline.Pipeline.run`. All parameters after the first two
-are keyword-only.
-
-`images` (`Sequence[np.ndarray]`, required)
-: Science images. `images[0]` is the high-resolution detection image from
-  which templates are extracted; `images[1:]` are fitted. To also fit the
-  detection band, include it twice.
-
-`segmap` (`np.ndarray`, required)
-: Integer segmentation map on the `images[0]` grid. Labels correspond to
-  catalog `id` values; 0 is background.
-
-`catalog` (`astropy.table.Table | None`, default `None`)
-: Source catalog with columns `id`, `x`, `y`. Optional deblending columns
-  (`is_deblended`, `deblend_parent_label`, `deblend_nchildren`) are carried
-  through when present. As of this writing, passing `None` raises
-  `NotImplementedError` — catalog generation from the segmentation map is
-  not implemented, so build the catalog first (see {doc}`catalog`).
-
-`psfs` (`Sequence[np.ndarray] | None`, default `None`)
-: One PSF stamp per image. `psfs[0]` supplies the shape the template build
-  scheme extends with, and every scheme but `"none"` requires it, so with
-  the default scheme a run without it raises; the others provide per-band
-  PSF metadata and, when `psf_throughputs` is not given, the fallback
-  throughput from the stamp sum. Pass unit-sum shapes for fitting.
-
-`weights` (`Sequence[np.ndarray] | None`, default `None`)
-: Inverse-variance maps, one per image. `weights[0]` is the detection-band
-  map: the `"psf_wings"`, `"wren"` and `"classic"` build schemes measure
-  each segment's signal-to-noise from it, and fall back to one scalar noise
-  estimate for the whole detection image when it is `None`.
-
-`wht_images` (`Sequence[np.ndarray] | None`, default `None`)
-: Backward-compatible alias for `weights`; used only when `weights` is
-  `None`.
-
-`kernels` (`Sequence[np.ndarray | PSFRegionMap] | None`, default `None`)
-: One convolution kernel per image, mapping the detection-band PSF to that
-  band's PSF. Use `None` for entries needing no convolution (the detection
-  image itself). A {class}`mophongo.psf_map.PSFRegionMap` entry applies a
-  spatially varying kernel (see {doc}`psf_maps`).
-
-`psf_throughputs` (`Sequence[float] | None`, default `None`)
-: Finite-support PSF stamp sums, one per image. When given, these override
-  the sums of the `psfs` stamps as the filter-level throughput used for the
-  `flux_<i>_total` columns. Use `1.0` for a band fitted with a native-sum
-  PSF already summing to one.
-
-`wcs` (`Sequence[astropy.wcs.WCS] | None`, default `None`)
-: Per-image WCS. Enables the multi-resolution upsampling path (integer bin
-  factors derived from the WCS pair), RA/Dec in diagnostics, and aperture
-  radii specified in arcseconds.
-
-`window` (default `None`)
-: Accepted and stored on the pipeline for backward compatibility; as of
-  this writing it is not consumed by the fitting path.
-
-`extend_mode` (`str | None`, default `None`)
-: Constructor override for the template build scheme. When given it names a
-  scheme (`"none"`, `"psf_wings"`, `"psf_convolution"`, `"psf_model"`,
-  `"wren"`, `"classic"`) and overrides the config field; `None` leaves the
-  choice to `FitConfig.extend_mode`, which itself defaults to
-  `"psf_wings"`. `None` is therefore not "no extension" — that is
-  `"none"`, which leaves templates truncated at the segment boundary and
-  biases total fluxes low, badly so for faint sources. Prefer setting
-  `extend_mode` on the `FitConfig`; both entry points then read the same
-  field. `extend_templates` is a deprecated alias for this argument
-  (logs a warning), and `"psf"` a deprecated alias for
-  `"psf_convolution"`. The schemes are described in {doc}`pipeline` and
-  {doc}`templates`.
-
-`templates` (`Templates | Sequence[Template] | None`, default `None`)
-: Prebuilt {class}`mophongo.templates.Templates` to use instead of
-  extracting from `images[0]` and `segmap` (see {doc}`templates`).
-
-`config` ({class}`mophongo.fit.FitConfig` `| None`, default `None`)
-: Fitting configuration (regularization, astrometric iterations, scene
-  construction, aperture photometry). Defaults to `FitConfig()`; every
-  field is documented in {doc}`fitting`.
+Every argument of {func}`mophongo.pipeline.run` (the `Pipeline` constructor
+takes the same ones) is documented in {doc}`pipeline`, the kernel arguments in
+{doc}`psf`, and the `FitConfig` fields in {doc}`fitting`.
 
 ### Output columns
 
-For each fitted image `i` (counting from 1, in input order) the returned
-table gains `flux_i`, `err_i`, `err_pred_i` (raw fitted amplitude, solver
-error, and weight-map-predicted error), `throughput_i`, and the
-throughput-corrected totals `flux_i_total`, `err_i_total`,
-`err_pred_i_total`. When per-source encircled energies of the
-low-resolution PSF are available they are used in place of the filter-level
-throughput. A `scene_i` column records which scene each source was fitted
-in, `-1` for sources that had no template. Aperture and diagnostic columns
+For each fitted image `i` (counting from 1, in input order) the returned table
+gains `flux_i` (the fitted amplitude), `err_i` and `err_pred_i` (solver and
+weight-map errors), `throughput_i`, the total-flux versions `flux_i_total`,
+`err_i_total`, `err_pred_i_total`, and `scene_i`, the scene the source was
+fitted in (`-1` for sources with no template). Aperture and diagnostic columns
 are described in {doc}`outputs`.
-
-### `matching_kernel()` parameters
-
-{func}`mophongo.utils.matching_kernel` computes a kernel `k` such that
-`psf_hi * k ≈ psf_lo` under convolution. It preserves the input sums: if
-`sum(psf_lo) / sum(psf_hi)` is not one, that ratio propagates into
-`sum(k)`, which is why pipeline-facing calls should pass unit-sum shapes.
-PSFs of different shapes are zero-padded to a common grid.
-
-`psf_hi_in`, `psf_lo_in` (`np.ndarray`, required)
-: High- and low-resolution PSF arrays.
-
-`window` (default `None`)
-: Fourier-domain window for `method="window"`; defaults to
-  `photutils.psf.matching.SplitCosineBellWindow(alpha=0.4, beta=0.1)`.
-
-`recenter` (`bool`, default `False`)
-: Shift the kernel to its measured centroid with bicubic interpolation.
-
-`pixel_ratio` (`float`, default `1.0`)
-: Pixel-scale ratio between the two PSF grids; a non-unity value resamples
-  one PSF onto the other's grid with flux-conserving cubic interpolation
-  before the kernel is computed.
-
-`method` (`str`, default `"window"`)
-: Kernel algorithm: `"window"` (Fourier ratio with the window function),
-  `"tikhonov"`, `"wiener"`, or `"forward"` (ForWaRD: a regularized Fourier
-  inverse followed by wavelet denoising).
-
-`reg` (`float`, default `1e-3`)
-: Regularization strength for the `tikhonov`, `wiener`, and `forward`
-  methods.
-
-`wavelet` (`str`, default `"db4"`), `levels` (`int`, default `3`),
-`threshold_factor` (`float`, default `3.0`), `noise_sigma`
-(`float | None`, default `None`), `forward_wavelet_wiener` (`bool`,
-default `True`)
-: Wavelet-denoising controls for `method="forward"`.
-
-`signal_psd` (`np.ndarray | None`, default `None`)
-: Optional signal power spectrum for `method="wiener"`.
-
-See {doc}`psf` for kernel diagnostics and regularization scans.
 
 ## Where to go next
 

--- a/docs/repair.md
+++ b/docs/repair.md
@@ -216,18 +216,18 @@ segmentation map in memory, and proceeds — nothing on disk changes, and
 the repaired templates are what lands in the run's `*_stamps.fits`, so
 they can be inspected there as usual. Diagnostics (fit table, flag log,
 per-star PNGs) are written to `out_dir/repaired/`. The core fit reuses
-the pipeline's own `pattern_hi` ePSFs and the same epoch policy, so no
+the pipeline's own `psf.pattern_hi` ePSFs and the same epoch policy, so no
 extra PSF setup is needed; `repair_kwargs` forwards tuning options
 (`min_buffer_snr`, `flux_frac`, `min_snr`, `halo_nsigma`, `stamp_npix`).
 
 The *flag model* — the star model compared against each segment — is
-only defined where its ePSF is, and the MJD-matched `pattern_hi` grids
+only defined where its ePSF is, and the MJD-matched `psf.pattern_hi` grids
 typically span a few arcsec. The pipeline therefore uses a second,
 large-FOV halo grid set: 30" single-position grids named
 `{prefix}_{det}_{filt}_MJD{...}_FOV30_GRID1_OS4`. The pattern is derived
-from `pattern_hi` automatically, and missing grids are built once with
-stpsf (`psf_autobuild`; a few minutes per detector, cached in
-`psf_dir` — the run logs the one-off build). `repair_psf_pattern`
+from `psf.pattern_hi` automatically, and missing grids are built once with
+stpsf (`psf.autobuild`; a few minutes per detector, cached in
+`psf.dir` — the run logs the one-off build). `repair_psf_pattern`
 overrides the pattern when needed.
 
 The flag model itself is a **hybrid**: inside the small ePSF's support
@@ -236,7 +236,7 @@ PSF the core fit and fill use), and the halo grid continues the wings
 and diffraction spikes outside it, rescaled to match over the graft
 annulus ({func}`mophongo.repair.hybrid_psf_stamp`). The star's fitted
 centre — including the fitted sub-pixel shift — positions the whole
-model. The `RunConfig.psf_size` stamp trim does not apply to any of
+model. The `psf.size` stamp trim does not apply to any of
 this: the repair drizzles PSFs onto its own cutouts at full native ePSF
 support.
 
@@ -245,7 +245,7 @@ photometry run instead of a catalog release: flagged wing segments keep
 their labels (each catalog row still gets a template), and each
 saturated star's fragments — the rows sharing one `FLAG_SATURATED_TMPL`
 group id — are fit **together in their own scene**, one scene per star,
-exempt from the `scene_minimum_bright` merging criterion. Everything
+exempt from the `scene_minimum_anchors` merging criterion. Everything
 else is solved without them, so the star's poorly-constrained wings
 cannot contaminate neighbouring fluxes. In the per-scene diagnostic
 plots the saturated stars' segments are nulled when other scenes are

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -451,6 +451,33 @@ neighbors can both model it. `"wren"` never claims those pixels: its support is
 restricted to the territory the ownership map assigns to the source, so the
 partition prevents the double counting up front.
 
+The rule generalizes beyond `"psf_wings"`: whatever supplies a template's
+support outside its own segment, it should not be applied over a *neighboring*
+segment. Segmentation does not deblend — a neighbor's pixels hold light from
+both sources — and the neighbor's own template already models those pixels, so
+extending a second template across them gives two free amplitudes the same
+flux to fit. The post-extraction passes enforce it through
+`background_only=True`, their default; `"classic"` is the deliberate exception,
+kept as the IDL code behaves.
+
+#### Encircled energy of a template
+
+The fitted amplitude is converted to a total flux by dividing by `ee_psf_lo`,
+the encircled energy of the band PSF stamp ({doc}`outputs`). That is exact for
+a point source: its convolved template *is* the PSF, so the fraction of its
+light inside the finite support is the PSF's own,
+$EE_{\rm tmpl} = EE_{\rm psf}$.
+
+An extended source is broader than the PSF, so convolution pushes a larger
+fraction of its light past the same support and
+$EE_{\rm tmpl} < EE_{\rm psf}$; dividing by `ee_psf_lo` alone then still falls
+short of the total. The deficit is measurable rather than unknown: the
+encircled energy of the template before convolution over that of the convolved
+template on the same support, $EE_{\rm tmpl,hi} / EE_{\rm tmpl,lo}$, is the
+size of the correction. Measured at the photometry aperture radius it is the
+fit table's `psfcor_<i>` column ({doc}`outputs`); it is not folded into
+`flux_<i>_total`, which corrects for the PSF support only.
+
 #### Post-extraction passes
 
 The two remaining modes run after extraction as method calls on the container.

--- a/examples/canfar/MANUAL.md
+++ b/examples/canfar/MANUAL.md
@@ -153,7 +153,7 @@ mkdir -p $MPLCONFIGDIR
 ### 4.3 PSF grids — nothing to do
 
 The MJD-tagged ePSF grids are **built on the fly**. `data/PSF/*` is gitignored,
-so a fresh clone has none of them, but `psf_autobuild` defaults to on: when no
+so a fresh clone has none of them, but `psf.autobuild` defaults to on: when no
 file under `psf_dir` matches the config's pattern, `Pipeline._load_epsf` runs
 `PSFFactory` over the band's exposure list (the `_wcs.csv` already on arc, which
 is where the MJD tags come from), writes the grids to `psf_dir`, and carries on.

--- a/examples/canfar/README.md
+++ b/examples/canfar/README.md
@@ -7,7 +7,7 @@ on arc itself. Only the mophongo source and the job scripts have to be uploaded.
 
 `push` also ships the STPSF PSF grids (about 290 MB) as a convenience, since
 they already exist locally. That is an optimisation, not a requirement:
-`psf_autobuild` is on by default, so a run with an empty `psf_dir` generates the
+`psf.autobuild` is on by default, so a run with an empty `psf.dir` generates the
 grids from the exposure lists on arc and caches them there. Uploading just skips
 a slow first run.
 
@@ -142,10 +142,25 @@ It also repoints `psf_dir` at the uploaded grids, `out_dir` at
 `run<N>/<field>/<name>`, and `repair_cache_path` at a per-field cache one level
 above that.
 
+### Checking for a newer release
+
+```bash
+$P campaign.py --check-versions --dry-run      # as a pre-flight
+$P arcify.py ../minerva/*.json --check-versions
+```
+
+Lists the release directories on arc, reads back the version each config is
+pinned to from its own paths, and reports the pairs that are behind. It rewrites
+nothing, and on `campaign.py` it warns and carries on rather than refusing:
+moving onto a new release changes the photometry, so it belongs to a new run
+number with a note saying why — a deliberate act, not something a launch should
+do, or block on, because a directory appeared upstream. `../ozstar` takes the
+same flags and answers the same way.
+
 ## PSF grids: one per epoch
 
 `PSFFactory.date_mode` defaults to `"all"` — one grid per unique integer MJD in
-the exposure list — and the MINERVA configs state `psf_date_mode` explicitly
+the exposure list — and the MINERVA configs state `psf.date_mode` explicitly
 rather than relying on it. This matters because the grids are MJD-tagged and
 looked up by nearest date: the old default, `"modal"`, returned the centre of
 the densest five-day window, i.e. a *single* date. Bands whose exposures span up

--- a/examples/canfar/arcify.py
+++ b/examples/canfar/arcify.py
@@ -337,7 +337,7 @@ def arcify(cfg_path: Path, index: dict[str, str], out_dir: Path,
     # numbered run and grouped by field. `..` from out_dir is the field
     # directory, so the repair cache lands beside the bands that share it.
     field = str(name).split("_")[0]
-    cfg["psf_dir"] = f"{run}/PSF"
+    cfg.setdefault("psf", {})["dir"] = f"{run}/PSF"
     cfg["out_dir"] = f"{run}/run{run_number()}/{field}/{name}"
     cfg["repair_cache_path"] = f"../{_repair_cache_name(cfg)}"
 

--- a/examples/canfar/campaign.py
+++ b/examples/canfar/campaign.py
@@ -11,7 +11,12 @@ each stage by hand::
     python campaign.py --from stage          # inputs already pushed and built
     python campaign.py --from arcify --skip stage   # inputs already decompressed
     python campaign.py --skip psf repair     # grids and repair caches in place
+    python campaign.py --check-versions      # say what arc has moved on to
     python campaign.py --dry-run             # print the plan, do nothing
+
+The step names, the filters and the flags match ``examples/ozstar/campaign.py``,
+so one campaign reads the same way on either platform, and each accepts the
+other's spelling of the config-rewrite step (``--from ozify`` works here).
 
 To ship a code change into a campaign without rebuilding the venv, fast-forward
 the run's checkout first and start the campaign after it::
@@ -72,6 +77,20 @@ REPO = HERE.parent.parent
 PSF_DIR = REPO / "data" / "PSF"
 PYTHON = sys.executable
 STEPS = ["push", "setup", "arcify", "seed", "psf", "stage", "repair", "run"]
+
+#: Step names the other platform uses for the same work, so that a command
+#: written for one runs on the other. ``ozify`` is OzStar's name for the config
+#: rewrite, and ``prep`` was its older name for ``repair``.
+STEP_ALIASES = {"ozify": "arcify", "prep": "repair"}
+
+
+def step_name(value: str) -> str:
+    """Canonical step name, accepting the OzStar spellings."""
+    name = STEP_ALIASES.get(value, value)
+    if name not in STEPS:
+        raise argparse.ArgumentTypeError(
+            f"unknown step {value!r}; choose from {', '.join(STEPS)}")
+    return name
 
 
 #: Band a field's repair job runs. The repair depends on the detection band
@@ -160,16 +179,16 @@ def has_all_grids(cfg_path: Path, extra_names: list[str] | None = None) -> bool:
 
     A family counts as present when *anything* matches it. That is deliberately
     weak: it cannot tell a complete set of epochs from one grid, which is what
-    ``psf_provenance`` is for. It exists to skip a step that would otherwise
+    ``psf.provenance`` is for. It exists to skip a step that would otherwise
     queue three jobs to discover there is nothing to build.
     """
     cfg = json.loads(re.sub(r"(?m)^\s*#.*$", "", cfg_path.read_text()))
-    pattern = cfg.get("pattern_hi")
+    pattern = cfg.get("psf", {}).get("pattern_hi")
     if not pattern:
         return True
     patterns = [pattern]
-    if cfg.get("pattern_lo"):
-        patterns.append(cfg["pattern_lo"])
+    if cfg.get("psf", {}).get("pattern_lo"):
+        patterns.append(cfg["psf"]["pattern_lo"])
     if cfg.get("repair_saturated"):
         # same derivation as Pipeline._repair_halo_pattern
         patterns.append(cfg.get("repair_psf_pattern")
@@ -182,6 +201,30 @@ def has_all_grids(cfg_path: Path, extra_names: list[str] | None = None) -> bool:
                 for p in patterns]
     names = [p.name for p in PSF_DIR.glob("*.fits")] + list(extra_names or [])
     return all(any(re.search(pat, n) for n in names) for pat in patterns)
+
+
+def check_versions(cfgs: list[Path]) -> None:
+    """Warn when a config is pinned to an older release than arc now holds.
+
+    A pre-flight, not a gate. Moving a campaign onto a new release changes the
+    photometry, so it is a deliberate act belonging to a new run number with a
+    note saying why - not something a launch should do, or refuse to do,
+    because a directory appeared upstream. So this says what is behind and
+    carries on with the pinned versions.
+    """
+    from arcify import check_release_versions
+
+    behind = check_release_versions(cfgs)
+    if not behind:
+        log.info("release check: every config is pinned to the newest on arc")
+        return
+    log.warning("release check: %d config/version pair(s) are behind arc:",
+                len(behind))
+    for name, kind, pinned, newest in behind:
+        log.warning("  %-14s %-8s %s -> %s", name, kind, pinned, newest)
+    log.warning("Continuing with the pinned versions. To move onto a new "
+                "release, point the source configs at it, bump $CANFAR_RUNNUM, "
+                "and re-run with --note saying what changed.")
 
 
 def write_run_readme(names: list[str], cfgs: list[Path], note: str,
@@ -258,9 +301,10 @@ def main() -> None:
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--fields", nargs="+", help="restrict to these, e.g. uds cosmos")
     ap.add_argument("--bands", nargs="+", help="restrict to these, e.g. f770w")
-    ap.add_argument("--from", dest="start", choices=STEPS, default="push",
-                    help="skip everything before this step")
-    ap.add_argument("--skip", nargs="+", choices=STEPS, default=[],
+    ap.add_argument("--from", dest="start", type=step_name, default="push",
+                    metavar="STEP",
+                    help="skip everything before this step (%s)" % ", ".join(STEPS))
+    ap.add_argument("--skip", nargs="+", type=step_name, default=[], metavar="STEP",
                     help="drop these steps from the middle of the chain, e.g. "
                          "--skip stage when the inputs are already decompressed")
     # --mem is the OzStar spelling of the same knob, accepted so a campaign
@@ -279,6 +323,13 @@ def main() -> None:
     ap.add_argument("--note", default="",
                     help="one line for run<N>/README.md saying what this run "
                          "changes; the number alone records nothing")
+    ap.add_argument("--check-versions", action="store_true",
+                    help="report configs pinned to an older release than arc "
+                         "now holds, then carry on with the pinned versions")
+    ap.add_argument("--ref", default="main",
+                    help="git ref the source on arc must match (default: main)")
+    ap.add_argument("--force-stale", action="store_true",
+                    help="submit even though the source on arc is not that ref")
     ap.add_argument("--dry-run", action="store_true")
     args = ap.parse_args()
 
@@ -286,6 +337,12 @@ def main() -> None:
     cfgs = configs_for(args.fields, args.bands)
     names = [c.stem + args.suffix for c in cfgs]
     log.info("campaign over %d config(s): %s", len(names), ", ".join(names))
+    # Before the README, so that what is behind is said before the versions
+    # this run pins are written down. Run under --dry-run too: it reads arc,
+    # which is neither a session nor a change to anything, and a plan is the
+    # moment the answer is most useful.
+    if args.check_versions:
+        check_versions(cfgs)
     write_run_readme(names, cfgs, args.note, args.dry_run)
 
     if "push" in todo:
@@ -322,6 +379,12 @@ def main() -> None:
     common = [] if args.ram is None else ["--ram", str(args.ram)]
     if args.cores is not None:
         common += ["--cores", str(args.cores)]
+    # Every job of a campaign runs one version of the code, so the ref the
+    # checkout is verified against is the campaign's rather than each
+    # dispatch's default.
+    common += ["--ref", args.ref]
+    if args.force_stale:
+        common.append("--force-stale")
 
     # Group by field: everything below is per-field, because a field's bands
     # share its F444W grids, its halo grids and its saturation repair.

--- a/examples/canfar/jobs/build_psfs.py
+++ b/examples/canfar/jobs/build_psfs.py
@@ -103,18 +103,18 @@ def pattern_tasks(configs: list[Path]) -> list[tuple[str, str, str, float | None
     seen: set[tuple[str, str]] = set()
     for cfg_path in configs:
         cfg = RunConfig.from_json(str(cfg_path))
-        psf_dir = str(cfg.psf_dir)
+        psf_dir = str(cfg.psf.dir)
         Path(psf_dir).mkdir(parents=True, exist_ok=True)
-        pairs = [(cfg.pattern_hi, str(cfg.csv_hi)), (cfg.pattern_lo, str(cfg.csv_lo))]
+        pairs = [(cfg.psf.pattern_hi, str(cfg.csv_hi)), (cfg.psf.pattern_lo, str(cfg.csv_lo))]
         if getattr(cfg, "repair_saturated", False):
-            pat = cfg.repair_psf_pattern or halo_pattern(cfg.pattern_hi)
-            if pat and pat != cfg.pattern_hi:
+            pat = cfg.repair_psf_pattern or halo_pattern(cfg.psf.pattern_hi)
+            if pat and pat != cfg.psf.pattern_hi:
                 pairs.append((pat, str(cfg.csv_hi)))
         for pattern, csv in pairs:
             if not pattern or (pattern, csv) in seen:
                 continue
             seen.add((pattern, csv))
-            tasks.append((pattern, csv, psf_dir, cfg.psf_fov_arcsec))
+            tasks.append((pattern, csv, psf_dir, cfg.psf.fov_arcsec))
     return tasks
 
 

--- a/examples/canfar/jobs/scene_plots.py
+++ b/examples/canfar/jobs/scene_plots.py
@@ -10,10 +10,14 @@ are left exactly as the run left them.
 
 ``load_fit`` deliberately does not restore ``all_scenes``; scene objects are
 not persisted. Membership does survive, as ``id_scene`` on each template, so
-the scenes are regrouped from that here, and only the fields
-:meth:`Scene.plot` reads are populated - id, members, bounding box, the band's
-image and weights, and the solved fluxes that :func:`solution_from` carries
-over from the templates.
+the scenes are regrouped from that here and then refilled from two sides: the
+fluxes :func:`solution_from` carries over from the templates, and the solver
+state :meth:`Pipeline.restore_scene_fit` reads back from the ``SCENES``
+extension of the fit table. With both, everything a finished band writes can
+be written again -- the scene catalog and the shift field included.
+
+A run written before that extension existed restores no solver state, and the
+two products that need it are skipped rather than guessed at.
 
 Usage::
 
@@ -102,13 +106,50 @@ def main(argv: list[str]) -> None:
     with pipe.log_run():
         pipe.load_fit(ifilt=IFILT)
         scenes = rebuild_scenes(pipe)
+        # `Pipeline.scenes` is a read-only view of band 0, so the regrouped
+        # list has to go back on the pipeline for write_scene_catalog and
+        # plot_shift_field to see it
+        pipe.all_scenes = [scenes]
+
+        # Solver state the regrouped scenes never had: the shift coefficients
+        # and their basis, the astrometry counters, the convergence verdict.
+        # A run written before the SCENES extension existed restores nothing,
+        # and simply keeps missing the products that need it.
+        restored = pipe.restore_scene_fit(scenes)
+        logger.info("restored solver state for %d of %d scene(s)",
+                    restored, len(scenes))
+
+        name = pipe.run_config.name
+        stem = str(Path(pipe.out_dir) / name)
+
+        # Everything that does not depend on the per-scene loop goes first.
+        # That loop is the reason this script exists -- it is where the band
+        # died -- so nothing it could take down should be queued behind it.
+        if restored:
+            pipe.write_scene_catalog(f"{stem}_scene_catalog.csv")
+            out = pipe.plot_shift_field(save=f"{stem}_shift_field.png")
+            if out is not None:
+                plt.close(out[0])
+            logger.info("wrote %s_scene_catalog.csv and the shift field", name)
+        else:
+            logger.warning(
+                "no SCENES extension in the fit table: skipping the scene "
+                "catalog and the shift field, which need the solved shifts"
+            )
+
+        # The two full-field views of the partition that write_outputs draws,
+        # from the same helpers and under the same names, so a recovered band
+        # carries the same products as one that finished on its own.
+        save_scene_overview(pipe.images[0], pipe.segmap, scenes,
+                            f"{stem}_scene_map.png")
+        save_scene_blobs(scenes, pipe.images[0].shape, f"{stem}_scene_blobs.png")
+        logger.info("wrote %s_scene_map.png and %s_scene_blobs.png", name, name)
 
         # Saturated stars are kept out of every other scene's display scale and
         # nulled in their own residual panel, exactly as write_outputs does.
         sat_ids = [int(t.id) for s in scenes for t in s.templates
                    if getattr(t, "is_saturated", False)]
 
-        name = pipe.run_config.name
         scene_dir = Path(pipe.out_dir) / "scenes"
         scene_dir.mkdir(parents=True, exist_ok=True)
 
@@ -126,24 +167,6 @@ def main(argv: list[str]) -> None:
             drawn += 1
 
         logger.info("wrote %d of %d scene figures to %s", drawn, len(scenes), scene_dir)
-
-        # The two full-field views of the partition that write_outputs draws,
-        # from the same helpers and under the same names, so a recovered band
-        # carries the same products as one that finished on its own. Both need
-        # only the mosaic, the segmap and the regrouped scenes, all of which
-        # the load restores, so these are the real figures rather than
-        # approximations of them.
-        #
-        # The scene catalog and the shift field are deliberately not rebuilt.
-        # Both carry per-scene astrometry - dx, dy, astrom_niter, flag_astrom -
-        # recorded during the solve and not persisted, so anything written here
-        # would be a plausible-looking file with invented columns. A missing
-        # product is better than a wrong one.
-        stem = str(Path(pipe.out_dir) / name)
-        save_scene_overview(pipe.images[0], pipe.segmap, scenes,
-                            f"{stem}_scene_map.png")
-        save_scene_blobs(scenes, pipe.images[0].shape, f"{stem}_scene_blobs.png")
-        logger.info("wrote %s_scene_map.png and %s_scene_blobs.png", name, name)
 
 
 if __name__ == "__main__":

--- a/examples/cosmos_770_dr0.1.json
+++ b/examples/cosmos_770_dr0.1.json
@@ -26,16 +26,17 @@
   "sci_lo": "/Users/ivo/Astro/PROJECTS/MINERVA/data/COSMOS/m3.0/cosmos-sbkgsub-v3.0-80mas-f770w_drz_sci_extrabkg.fits",
   "wht_lo": "/Users/ivo/Astro/PROJECTS/MINERVA/data/COSMOS/m3.0/cosmos-sbkgsub-v3.0-80mas-f770w_drz_wht.fits",
   "csv_lo": "/Users/ivo/Astro/PROJECTS/MINERVA/data/COSMOS/m3.0/cosmos-v3.0_f770w_wcs.csv",
-  "expect_frames": [586, 518],
 
-  # MJD-tagged ePSF grids; psf_size in arcsec (null = full native stamp);
-  # psf_blur_fwhm "default" = shared DEFAULT_PSF_GAUSSIAN_FWHM_ARCSEC[filter_lo]
-  "psf_dir": "../data/PSF",
-  "pattern_hi": "COSMOS_NRC.._F444W_MJD\\d+_GRID25_OS4",
-  "pattern_lo": "COSMOS_MIRI_F770W_MJD\\d+_GRID9_OS4",
+  # MJD-tagged ePSF grids; psf.size in arcsec (null = full native stamp);
+  # psf.blur_fwhm "default" = shared DEFAULT_PSF_GAUSSIAN_FWHM_ARCSEC[filter_lo]
   "filter_lo": "f770w",
-  "psf_size": null,
-  "psf_blur_fwhm": "default",
+  "psf": {
+    "dir": "../data/PSF",
+    "pattern_hi": "COSMOS_NRC.._F444W_MJD\\d+_GRID25_OS4",
+    "pattern_lo": "COSMOS_MIRI_F770W_MJD\\d+_GRID9_OS4",
+    "size": null,
+    "blur_fwhm": "default"
+  },
 
   # preprocessing: footprint cut + trial patch (set "trial": null for a full
   # run). Only the patch plus its margin is read off disk.
@@ -47,6 +48,6 @@
   "bg_filter_sigma": 64.0,
 
   # FitConfig overrides
-  "fit": {"fit_astrometry_joint": true, "scene_minimum_bright": 10, "aperture_diam": 0.5},
+  "fit": {"fit_astrometry_joint": true, "scene_minimum_anchors": 10, "aperture_diam": 0.5},
   "scene_plots": true
 }

--- a/examples/make_minerva_configs.py
+++ b/examples/make_minerva_configs.py
@@ -4,8 +4,8 @@ MIRI band from whatever is staged under ``MINERVA/data``.
 The configs follow ``uds_770_dr0.json``: F444W template on the 40 mas NIRCam
 grid, the release segmap and SUPER catalog, and one 80 mas MIRI band as the
 low-resolution image to fit. Everything that can be read off the staged files
-is read off them -- frame counts from the WCS tables, the trial-patch centre
-from the weight map -- so the generator does not carry hand-copied numbers.
+is read off them -- the trial-patch centre from the weight map -- so the
+generator does not carry hand-copied numbers.
 
 Usage (from ``examples/``)::
 
@@ -118,12 +118,6 @@ def _find_release(root: Path, prefer: str, pattern: str, what: str,
     if exclude:
         hits = [h for h in hits if exclude not in str(h)]
     return _one([h for h in hits if prefer in str(h)] or hits, what)
-
-
-def n_frames(csv: Path) -> int:
-    """Number of exposures in a grizli/MINERVA ``_wcs.csv`` frame table."""
-    with open(csv) as fh:
-        return sum(1 for _ in fh) - 1
 
 
 # Coverage fractions accepted for the trial box, tried in order. The last two
@@ -284,28 +278,30 @@ def band_configs(rel: Release) -> list[dict]:
                 "sci_lo": str(sci_lo),
                 "wht_lo": str(wht_lo),
                 "csv_lo": str(csv_lo),
-                "expect_frames": [n_frames(csv_hi), n_frames(csv_lo)],
-                "psf_dir": str(PSF_DIR),
-                "pattern_hi": rf"{rel.local}_NRC.._F444W_MJD\d+_GRID25_OS4",
-                "pattern_lo": rf"{rel.local}_MIRI_{band.upper()}_MJD\d+_GRID9_OS4",
                 "filter_lo": band,
-                # 4.0 for every band: psf_size sets the hi-res support too,
-                # and the F444W grids are only 4.09 arcsec across, so a larger
-                # stamp would measure the grid edge (see TODO.md). The reddest
-                # MIRI bands want more, once the NIRCam grids are regenerated
-                # at a larger FOV.
-                "psf_size": 4.0,
-                # Stated explicitly rather than left to the default: these
-                # exposure lists span up to four years across a dozen or more
-                # epochs, the grids are MJD-tagged and looked up by nearest
-                # date, and any mode that collapses the list ("modal" returns
-                # a single date) throws that resolution away invisibly.
-                "psf_date_mode": "all",
-                # "warn" until the rebuild cost is affordable, then
-                # "rebuild" (TODO.md). Never leave it "off": a grid built
-                # another way is a silent photometric difference.
-                "psf_provenance": "warn",
-                "psf_blur_fwhm": "default",
+                "psf": {
+                    "dir": str(PSF_DIR),
+                    "pattern_hi": rf"{rel.local}_NRC.._F444W_MJD\d+_GRID25_OS4",
+                    "pattern_lo": rf"{rel.local}_MIRI_{band.upper()}_MJD\d+_GRID9_OS4",
+                    # 4.0 for every band: size sets the hi-res support too,
+                    # and the F444W grids are only 4.09 arcsec across, so a
+                    # larger stamp would measure the grid edge (see TODO.md).
+                    # The reddest MIRI bands want more, once the NIRCam grids
+                    # are regenerated at a larger FOV.
+                    "size": 4.0,
+                    # Stated explicitly rather than left to the default: these
+                    # exposure lists span up to four years across a dozen or
+                    # more epochs, the grids are MJD-tagged and looked up by
+                    # nearest date, and any mode that collapses the list
+                    # ("modal" returns a single date) throws that resolution
+                    # away invisibly.
+                    "date_mode": "all",
+                    # "warn" until the rebuild cost is affordable, then
+                    # "rebuild" (TODO.md). Never leave it "off": a grid built
+                    # another way is a silent photometric difference.
+                    "provenance": "warn",
+                    "blur_fwhm": "default",
+                },
                 "footprint_filter": True,
                 # In-memory saturation repair at load time: fill the wht=0
                 # cores in the F444W template image with the fitted PSF,
@@ -329,7 +325,7 @@ def band_configs(rel: Release) -> list[dict]:
                 "bg_filter_sigma": 64.0,
                 "fit": {
                     "fit_astrometry_joint": True,
-                    "scene_minimum_bright": 5,
+                    "scene_minimum_anchors": 5,
                     # larger scenes before the local threshold bisection kicks
                     # in, and no long-range gluing of underfilled scenes
                     # (radius in 40 mas reference pixels; 1000 px = 40").
@@ -355,9 +351,8 @@ HEADER = """\
 # F444W background-subtracted mosaic as the template image, the release segmap
 # and SUPER catalog, one 80 mas MIRI band fitted.
 #
-# expect_frames are the row counts of the two WCS tables; trial.center is the
-# deepest fully covered {r} arcmin patch of the MIRI weight map. Set
-# "trial" to null for a full-field run.
+# trial.center is the deepest fully covered {r} arcmin patch of the MIRI
+# weight map. Set "trial" to null for a full-field run.
 #
 # Run from examples/minerva/:  python -m mophongo.pipeline {name}.json
 """

--- a/examples/ozstar/MANUAL.md
+++ b/examples/ozstar/MANUAL.md
@@ -205,6 +205,7 @@ stamps:
 
 ```bash
 $P campaign.py --dry-run                        # the plan
+$P campaign.py --check-versions --dry-run       # ... and what arc moved on to
 $P campaign.py                                  # trial patches, every config
 $P campaign.py --fields uds --bands f770w       # one band of one field
 $P campaign.py --r-trial 0 --note "n3.0 UDS"    # the full-field release
@@ -214,7 +215,10 @@ $P campaign.py --r-trial 0 --note "n3.0 UDS"    # the full-field release
 One command rewrites all 17 configs, uploads them, builds the environment, and
 submits the work in the same three phases `../canfar/campaign.py` uses — `psf`,
 `repair`, `run` — with the same step names and flags, so a campaign reads the
-same way on either platform.
+same way on either platform. Each even accepts the other's name for the config
+rewrite, so `--from arcify` works here and `--from ozify` works there.
+`--check-versions` reports configs pinned to an older release than arc now
+holds, then carries on with the pinned ones.
 
 Only `psf` blocks. It cannot be a SLURM job: the build resolves each exposure's
 wavefront by querying MAST, and compute nodes have no route to it, so it is a

--- a/examples/ozstar/README.md
+++ b/examples/ozstar/README.md
@@ -73,6 +73,7 @@ OZSTAR_RUN=run3 ./release.sh --skip-stage   # the full-field release
 $P campaign.py --fields uds                 # one field
 $P campaign.py --bands f770w                # one band of every field
 $P campaign.py --skip psf repair            # grids and caches already in place
+$P campaign.py --check-versions             # say what arc has moved on to
 $P campaign.py --dry-run                    # print the plan, submit nothing
 ```
 
@@ -157,9 +158,29 @@ pipeline wants plain FITS, so `stage.sh` decompresses them; and MIRI frame
 tables ship as `*_f770_wcs.csv` while the filter parser expects `f770w`, so the
 staged copy carries the expected name.
 
+### Checking for a newer release
+
+```bash
+$P campaign.py --check-versions --dry-run     # as a pre-flight
+$P ozify.py ../minerva/*.json --check-versions
+```
+
+Lists the release directories on arc, reads back the version each config is
+pinned to from its own paths, and reports the pairs that are behind — the same
+flags `../canfar` takes, answered the same way. Note this runs on the laptop and
+needs only the CADC certificate: the datamover partition exists to *copy* inputs
+to `/fred`, not to see what is on arc.
+
+It rewrites nothing, and on `campaign.py` it warns and carries on rather than
+refusing. Moving onto a new release changes the photometry, so it belongs to a
+new run directory with a note saying why — a deliberate act, not something a
+launch should do, or block on, because a directory appeared upstream. On OzStar
+it also means re-staging: `/fred` holds a copy of each input, so a new release is
+new files rather than an in-place update.
+
 ## PSF grids must be built on the login node
 
-This is the one structural difference from CANFAR, where `psf_autobuild` just
+This is the one structural difference from CANFAR, where `psf.autobuild` just
 works inside a run. `PSFFactory` generates MJD-tagged grids, and for each
 exposure date `stpsf` resolves the wavefront OPD by querying MAST
 (`load_wss_opd_by_date` → `mast_wss_opds_around_date_query`). There is no
@@ -212,7 +233,7 @@ fails loudly per epoch and a re-run repairs it, but a first build against an
 empty `$STPSF_PATH` is safest done serially.
 
 The grids are one per epoch: `PSFFactory.date_mode` defaults to `"all"` (one
-per unique integer MJD) and the configs state `psf_date_mode` explicitly. The
+per unique integer MJD) and the configs state `psf.date_mode` explicitly. The
 old default, `"modal"`, gave a single date for an exposure list spanning years,
 which silently defeats the MJD-tagged lookup the grids exist for. See
 `../canfar/README.md` for the full account; it applies to both platforms.

--- a/examples/ozstar/campaign.py
+++ b/examples/ozstar/campaign.py
@@ -10,11 +10,13 @@ once::
     python campaign.py --bands f770w            # only that band
     python campaign.py --from stage             # source and configs already up
     python campaign.py --skip psf repair        # grids and caches in place
+    python campaign.py --check-versions         # say what arc has moved on to
     python campaign.py --dry-run                # print the plan, submit nothing
 
 The step names, the filters and the flags match ``examples/canfar/campaign.py``,
-so one campaign reads the same way on either platform. What differs is who
-enforces the order between the phases.
+so one campaign reads the same way on either platform, and each accepts the
+other's spelling of the config-rewrite step (``--from arcify`` works here). What
+differs is who enforces the order between the phases.
 
 The submission is three phases, the same split CANFAR uses:
 
@@ -76,9 +78,19 @@ PSF_DIR = REPO / "data" / "PSF"
 PYTHON = sys.executable
 STEPS = ["ozify", "push", "setup", "seed", "psf", "stage", "repair", "run"]
 
-#: ``prep`` was this campaign's name for what CANFAR calls ``repair``, and both
-#: ran the same pipeline step. Accepted so existing scripts keep working.
-STEP_ALIASES = {"prep": "repair"}
+#: Step names the other platform uses for the same work, so that a command
+#: written for one runs on the other. ``arcify`` is CANFAR's name for the
+#: config rewrite; ``prep`` was this campaign's own older name for ``repair``.
+STEP_ALIASES = {"prep": "repair", "arcify": "ozify"}
+
+# The arc index and the release-version parser are the same problem on both
+# platforms, so canfar/arcify.py is imported rather than copied - the same
+# trick, and the same reason, as ozify.py. Appended, not prepended: arcify
+# imports canfar's own `runroot`, and this directory's equivalent is
+# deliberately named `ozroot` so the two cannot shadow each other. The imports
+# themselves stay inside the functions that need them, to keep `vos` off the
+# path of a `--help`.
+sys.path.append(str(HERE.parent / "canfar"))
 
 #: A per-band run config is named ``<field>_f<band>w.json``. The directory also
 #: holds inputs that are not RunConfigs (``minerva_sed_fields.json``), which
@@ -159,12 +171,12 @@ def grid_patterns(cfg_path: Path, shared_only: bool) -> list[str]:
     the shared families, while the ``psf`` step asks about all of them.
     """
     cfg = json.loads(re.sub(r"(?m)^\s*#.*$", "", cfg_path.read_text()))
-    pattern = cfg.get("pattern_hi")
+    pattern = cfg.get("psf", {}).get("pattern_hi")
     if not pattern:
         return []
     patterns = [pattern]
-    if not shared_only and cfg.get("pattern_lo"):
-        patterns.append(cfg["pattern_lo"])
+    if not shared_only and cfg.get("psf", {}).get("pattern_lo"):
+        patterns.append(cfg["psf"]["pattern_lo"])
     if cfg.get("repair_saturated"):
         # same derivation as Pipeline._repair_halo_pattern; the 30" halo grids
         # are shared by a field's bands exactly as pattern_hi is
@@ -183,11 +195,39 @@ def has_grids(cfg_path: Path, names: list[str], shared_only: bool = False) -> bo
 
     A family counts as present when *anything* matches it. That is deliberately
     weak: it cannot tell a complete set of epochs from one grid, which is what
-    ``psf_provenance`` is for. It exists to skip a build that would otherwise
+    ``psf.provenance`` is for. It exists to skip a build that would otherwise
     spend an hour discovering there is nothing to do.
     """
     return all(any(re.search(pat, n) for n in names)
                for pat in grid_patterns(cfg_path, shared_only))
+
+
+def check_versions(cfgs: list[Path]) -> None:
+    """Warn when a config is pinned to an older release than arc now holds.
+
+    A pre-flight, not a gate. Moving a campaign onto a new release changes the
+    photometry, so it is a deliberate act belonging to a new run directory with
+    a note saying why - not something a launch should do, or refuse to do,
+    because a directory appeared upstream. So this says what is behind and
+    carries on with the pinned versions.
+
+    Reading arc is a laptop operation and needs only the CADC certificate: the
+    datamover partition exists to *copy* inputs to ``/fred``, not to see them.
+    """
+    from arcify import check_release_versions
+
+    behind = check_release_versions(cfgs)
+    if not behind:
+        log.info("release check: every config is pinned to the newest on arc")
+        return
+    log.warning("release check: %d config/version pair(s) are behind arc:",
+                len(behind))
+    for name, kind, pinned, newest in behind:
+        log.warning("  %-14s %-8s %s -> %s", name, kind, pinned, newest)
+    log.warning("Continuing with the pinned versions. To move onto a new "
+                "release, point the source configs at it, bump $OZSTAR_RUN, and "
+                "re-run with --note saying what changed - and re-stage, since "
+                "/fred holds a copy of each input rather than reading arc.")
 
 
 def previous_run(name: str) -> str | None:
@@ -213,10 +253,6 @@ def write_run_readme(names: list[str], cfgs: list[Path], note: str,
     what it was trying to do. The copy under ``scratch/ozstar`` is kept as well
     as uploaded, since reading it back needs an ssh.
     """
-    # The arc index and the version parser are the same problem on both
-    # platforms, so canfar/arcify.py is imported rather than copied - the same
-    # trick, and the same reason, as ozify.py.
-    sys.path.append(str(HERE.parent / "canfar"))
     from arcify import config_versions
 
     run = ozroot.run_name()
@@ -315,6 +351,9 @@ def main() -> None:
     ap.add_argument("--note", default="",
                     help="one line for <run>/README.md saying what this run "
                          "changes; the run directory alone records nothing")
+    ap.add_argument("--check-versions", action="store_true",
+                    help="report configs pinned to an older release than arc "
+                         "now holds, then carry on with the pinned versions")
     ap.add_argument("--dry-run", action="store_true")
     args = ap.parse_args()
 
@@ -323,6 +362,12 @@ def main() -> None:
     names = [c.stem + args.suffix for c in cfgs]
     log.info("campaign over %d config(s): %s", len(names), ", ".join(names))
     log.info("run tree %s on %s", ozroot.run_root(), ozroot.ssh_target())
+    # Before the README, so that what is behind is said before the versions
+    # this run pins are written down. Run under --dry-run too: it reads arc,
+    # which is neither the cluster nor a change to it, and a plan is the moment
+    # the answer is most useful.
+    if args.check_versions:
+        check_versions(cfgs)
     write_run_readme(names, cfgs, args.note, args.dry_run)
 
     if "ozify" in todo:

--- a/examples/ozstar/jobs/build_psfs.py
+++ b/examples/ozstar/jobs/build_psfs.py
@@ -103,18 +103,18 @@ def pattern_tasks(configs: list[Path]) -> list[tuple[str, str, str, float | None
     seen: set[tuple[str, str]] = set()
     for cfg_path in configs:
         cfg = RunConfig.from_json(str(cfg_path))
-        psf_dir = str(cfg.psf_dir)
+        psf_dir = str(cfg.psf.dir)
         Path(psf_dir).mkdir(parents=True, exist_ok=True)
-        pairs = [(cfg.pattern_hi, str(cfg.csv_hi)), (cfg.pattern_lo, str(cfg.csv_lo))]
+        pairs = [(cfg.psf.pattern_hi, str(cfg.csv_hi)), (cfg.psf.pattern_lo, str(cfg.csv_lo))]
         if getattr(cfg, "repair_saturated", False):
-            pat = cfg.repair_psf_pattern or halo_pattern(cfg.pattern_hi)
-            if pat and pat != cfg.pattern_hi:
+            pat = cfg.repair_psf_pattern or halo_pattern(cfg.psf.pattern_hi)
+            if pat and pat != cfg.psf.pattern_hi:
                 pairs.append((pat, str(cfg.csv_hi)))
         for pattern, csv in pairs:
             if not pattern or (pattern, csv) in seen:
                 continue
             seen.add((pattern, csv))
-            tasks.append((pattern, csv, psf_dir, cfg.psf_fov_arcsec))
+            tasks.append((pattern, csv, psf_dir, cfg.psf.fov_arcsec))
     return tasks
 
 

--- a/examples/ozstar/ozify.py
+++ b/examples/ozstar/ozify.py
@@ -25,6 +25,7 @@ Usage::
 
     python ozify.py ../minerva/uds_f770w.json [more configs ...]
     python ozify.py ../minerva/uds_f770w.json --r-trial 1.5 --suffix _trial
+    python ozify.py ../minerva/*.json --check-versions   # scan, rewrite nothing
 
 Needs a CADC proxy certificate locally (only to *list* arc; the copying itself
 happens on OzStar with the certificate pushed by ``submit.py cert``).
@@ -48,7 +49,8 @@ HERE = Path(__file__).resolve().parent
 sys.path.append(str(HERE.parent / "canfar"))
 
 from arcify import (  # noqa: E402
-    PATH_KEYS, _repair_cache_name, arc_index, resolve, roots_for,
+    PATH_KEYS, _repair_cache_name, arc_index, check_release_versions, resolve,
+    roots_for,
 )
 
 import ozroot  # noqa: E402
@@ -131,7 +133,7 @@ def ozify(cfg_path: Path, index: dict[str, str], out_dir: Path,
     # data/ and PSF/ live above the run directory: they are stable across
     # catalog versions, so a new run re-fits the same mosaics and reuses the
     # same grids rather than re-staging 64 GB and rebuilding 400 grids.
-    cfg["psf_dir"] = ozroot.psf_dir()
+    cfg.setdefault("psf", {})["dir"] = ozroot.psf_dir()
     cfg["out_dir"] = ozroot.out_dir(name)
     # Per-field saturation-repair cache, one level above out_dir. The repair
     # depends only on detection-side inputs, so a field's bands share it: band
@@ -161,7 +163,30 @@ def main() -> None:
                     help="override the trial-patch radius in arcmin (0 = full field)")
     ap.add_argument("--suffix", default="",
                     help="append to the run name, e.g. _trial, to keep outputs separate")
+    ap.add_argument("--check-versions", action="store_true",
+                    help="report configs pinned to an older release than arc "
+                         "now holds, and rewrite nothing")
     args = ap.parse_args()
+
+    # Reading arc is a laptop operation and needs only the certificate; the
+    # datamover partition exists to *copy* the files to /fred, not to see them.
+    # So this is the same check as `arcify.py --check-versions`, answered the
+    # same way, and it costs the cluster nothing.
+    if args.check_versions:
+        behind = check_release_versions(args.configs)
+        if not behind:
+            log.info("every config is pinned to the newest release on arc")
+            return
+        log.warning("%d config/version pair(s) are behind arc:", len(behind))
+        for name, kind, pinned, newest in behind:
+            log.warning("  %-14s %-8s %s -> %s", name, kind, pinned, newest)
+        log.warning("Nothing was rewritten. Moving to a new release changes the "
+                    "photometry, so it belongs in a new run: bump $OZSTAR_RUN, "
+                    "point the source configs at the new version, re-run ozify, "
+                    "and re-stage - /fred holds a copy of each input, so a new "
+                    "release is new files rather than an in-place update.")
+        return
+
     check_suffix(args.suffix)
 
     cert = Path.home() / ".ssl/cadcproxy.pem"

--- a/examples/run_1280.py
+++ b/examples/run_1280.py
@@ -145,7 +145,7 @@ if locals().get("r_trial", 0) > 0:
 
 # first fit, no shifts: first image is template, 2nd and on the fitting images
 config = FitConfig(
-    fit_astrometry_niter=2, fit_astrometry_joint=True, scene_minimum_bright=10, aperture_diam=0.5
+    fit_astrometry_niter=2, fit_astrometry_joint=True, scene_minimum_anchors=10, aperture_diam=0.5
 )
 
 pipe = Pipeline(

--- a/examples/run_1500.py
+++ b/examples/run_1500.py
@@ -149,7 +149,7 @@ if locals().get("r_trial", 0) > 0:
 
 # first fit, no shifts: first image is template, 2nd and on the fitting images
 config = FitConfig(
-    fit_astrometry_niter=2, fit_astrometry_joint=True, scene_minimum_bright=10, aperture_diam=0.5
+    fit_astrometry_niter=2, fit_astrometry_joint=True, scene_minimum_anchors=10, aperture_diam=0.5
 )
 
 pipe = Pipeline(

--- a/examples/run_1800.py
+++ b/examples/run_1800.py
@@ -149,7 +149,7 @@ if locals().get("r_trial", 0) > 0:
 
 # first fit, no shifts: first image is template, 2nd and on the fitting images
 config = FitConfig(
-    fit_astrometry_niter=2, fit_astrometry_joint=True, scene_minimum_bright=10, aperture_diam=0.5
+    fit_astrometry_niter=2, fit_astrometry_joint=True, scene_minimum_anchors=10, aperture_diam=0.5
 )
 
 pipe = Pipeline(

--- a/examples/run_mock.py
+++ b/examples/run_mock.py
@@ -114,10 +114,10 @@ bg_miri, ivar_miri = get_bg_and_ivar(sci_miri, wht_miri, bg_filter_sigma=64.0)
 # %%
 config = FitConfig(
     reg_flux=0.0,
-    reg_astrom=0.0,
+    astrom_reg=0.0,
     fit_astrometry_niter=2,
     fit_astrometry_joint=True,
-    scene_minimum_bright=10,
+    scene_minimum_anchors=10,
     aperture_diam=0.5,
     template_dilate_segmap=12,
 )

--- a/examples/run_mock_hisnr.py
+++ b/examples/run_mock_hisnr.py
@@ -119,7 +119,7 @@ bg_miri, ivar_miri = get_bg_and_ivar(sci_miri, wht_miri, bg_filter_sigma=64.0)
 config = FitConfig(
     fit_astrometry_niter=2,
     fit_astrometry_joint=True,
-    scene_minimum_bright=10,
+    scene_minimum_anchors=10,
     aperture_diam=0.5,
 )
 

--- a/examples/run_uds_770_wren.py
+++ b/examples/run_uds_770_wren.py
@@ -160,7 +160,7 @@ if locals().get("r_trial", 0) > 0:
 
 config = FitConfig(
     fit_astrometry_niter=2, 
-    scene_minimum_bright=5,
+    scene_minimum_anchors=5,
     scene_coupling_thresh=coupling_thresh,
     astrom_isolation_thresh=0.7,
     aperture_diam=aperture_diam,

--- a/examples/uds_770_dr0.1.json
+++ b/examples/uds_770_dr0.1.json
@@ -35,16 +35,17 @@
   "sci_lo": "/Users/ivo/Astro/PROJECTS/MINERVA/data/UDS/m3.0/uds-sbkgsub-v3.0-80mas-f770w_drz_sci_extrabkg.fits",
   "wht_lo": "/Users/ivo/Astro/PROJECTS/MINERVA/data/UDS/m3.0/uds-sbkgsub-v3.0-80mas-f770w_drz_wht.fits",
   "csv_lo": "/Users/ivo/Astro/PROJECTS/MINERVA/data/UDS/m3.0/uds-v3.0_f770w_wcs.csv",
-  "expect_frames": [297, 229],
 
-  # MJD-tagged ePSF grids; psf_size in arcsec (null = full native stamp);
-  # psf_blur_fwhm "default" = shared DEFAULT_PSF_GAUSSIAN_FWHM_ARCSEC[filter_lo]
-  "psf_dir": "../data/PSF",
-  "pattern_hi": "UDS_NRC.._F444W_MJD\\d+_GRID25_OS4",
-  "pattern_lo": "UDS_MIRI_F770W_MJD\\d+_GRID9_OS4",
+  # MJD-tagged ePSF grids; psf.size in arcsec (null = full native stamp);
+  # psf.blur_fwhm "default" = shared DEFAULT_PSF_GAUSSIAN_FWHM_ARCSEC[filter_lo]
   "filter_lo": "f770w",
-  "psf_size": 4.0,
-  "psf_blur_fwhm": "default",
+  "psf": {
+    "dir": "../data/PSF",
+    "pattern_hi": "UDS_NRC.._F444W_MJD\\d+_GRID25_OS4",
+    "pattern_lo": "UDS_MIRI_F770W_MJD\\d+_GRID9_OS4",
+    "size": 4.0,
+    "blur_fwhm": "default"
+  },
 
   # preprocessing: footprint cut + trial patch (set r_trial 0 for full run).
   # trial_center = deepest fully F770W-covered 0.5' patch of the v3.0 mosaic
@@ -55,6 +56,6 @@
   "bg_filter_sigma": 64.0,
 
   # FitConfig overrides
-  "fit": {"fit_astrometry_joint": true, "scene_minimum_bright": 5, "aperture_diam": 0.5},
+  "fit": {"fit_astrometry_joint": true, "scene_minimum_anchors": 5, "aperture_diam": 0.5},
   "scene_plots": true
 }

--- a/examples/uds_770_dr0.1_head.json
+++ b/examples/uds_770_dr0.1_head.json
@@ -34,16 +34,17 @@
   "sci_lo": "/Users/ivo/Astro/PROJECTS/MINERVA/data/UDS/m3.0/uds-sbkgsub-v3.0-80mas-f770w_drz_sci_extrabkg.fits",
   "wht_lo": "/Users/ivo/Astro/PROJECTS/MINERVA/data/UDS/m3.0/uds-sbkgsub-v3.0-80mas-f770w_drz_wht.fits",
   "csv_lo": "/Users/ivo/Astro/PROJECTS/MINERVA/data/UDS/m3.0/uds-v3.0_f770w_wcs.csv",
-  "expect_frames": [297, 229],
 
-  # MJD-tagged ePSF grids; psf_size in arcsec (null = full native stamp);
-  # psf_blur_fwhm "default" = shared DEFAULT_PSF_GAUSSIAN_FWHM_ARCSEC[filter_lo]
-  "psf_dir": "../data/PSF",
-  "pattern_hi": "UDS_NRC.._F444W_MJD\\d+_GRID25_OS4",
-  "pattern_lo": "UDS_MIRI_F770W_MJD\\d+_GRID9_OS4",
+  # MJD-tagged ePSF grids; psf.size in arcsec (null = full native stamp);
+  # psf.blur_fwhm "default" = shared DEFAULT_PSF_GAUSSIAN_FWHM_ARCSEC[filter_lo]
   "filter_lo": "f770w",
-  "psf_size": 4.0,
-  "psf_blur_fwhm": "default",
+  "psf": {
+    "dir": "../data/PSF",
+    "pattern_hi": "UDS_NRC.._F444W_MJD\\d+_GRID25_OS4",
+    "pattern_lo": "UDS_MIRI_F770W_MJD\\d+_GRID9_OS4",
+    "size": 4.0,
+    "blur_fwhm": "default"
+  },
 
   # preprocessing: footprint cut + trial patch (set r_trial 0 for full run).
   # trial_center = deepest fully F770W-covered 0.5' patch of the v3.0 mosaic
@@ -54,6 +55,6 @@
   "bg_filter_sigma": 64.0,
 
   # FitConfig overrides
-  "fit": {"fit_astrometry_joint": true, "scene_minimum_bright": 5, "aperture_diam": 0.5},
+  "fit": {"fit_astrometry_joint": true, "scene_minimum_anchors": 5, "aperture_diam": 0.5},
   "scene_plots": true
 }

--- a/examples/uds_770_dr0.1_ps3.json
+++ b/examples/uds_770_dr0.1_ps3.json
@@ -37,16 +37,17 @@
   "sci_lo": "/Users/ivo/Astro/PROJECTS/MINERVA/data/UDS/m3.0/uds-sbkgsub-v3.0-80mas-f770w_drz_sci_extrabkg.fits",
   "wht_lo": "/Users/ivo/Astro/PROJECTS/MINERVA/data/UDS/m3.0/uds-sbkgsub-v3.0-80mas-f770w_drz_wht.fits",
   "csv_lo": "/Users/ivo/Astro/PROJECTS/MINERVA/data/UDS/m3.0/uds-v3.0_f770w_wcs.csv",
-  "expect_frames": [297, 229],
 
-  # MJD-tagged ePSF grids; psf_size in arcsec (null = full native stamp);
-  # psf_blur_fwhm "default" = shared DEFAULT_PSF_GAUSSIAN_FWHM_ARCSEC[filter_lo]
-  "psf_dir": "../data/PSF",
-  "pattern_hi": "UDS_NRC.._F444W_MJD\\d+_GRID25_OS4",
-  "pattern_lo": "UDS_MIRI_F770W_MJD\\d+_GRID9_OS4",
+  # MJD-tagged ePSF grids; psf.size in arcsec (null = full native stamp);
+  # psf.blur_fwhm "default" = shared DEFAULT_PSF_GAUSSIAN_FWHM_ARCSEC[filter_lo]
   "filter_lo": "f770w",
-  "psf_size": 3.0,
-  "psf_blur_fwhm": "default",
+  "psf": {
+    "dir": "../data/PSF",
+    "pattern_hi": "UDS_NRC.._F444W_MJD\\d+_GRID25_OS4",
+    "pattern_lo": "UDS_MIRI_F770W_MJD\\d+_GRID9_OS4",
+    "size": 3.0,
+    "blur_fwhm": "default"
+  },
 
   # preprocessing: footprint cut + trial patch (set r_trial 0 for full run).
   # trial_center = deepest fully F770W-covered 0.5' patch of the v3.0 mosaic
@@ -57,6 +58,6 @@
   "bg_filter_sigma": 64.0,
 
   # FitConfig overrides
-  "fit": {"fit_astrometry_joint": true, "scene_minimum_bright": 5, "aperture_diam": 0.5},
+  "fit": {"fit_astrometry_joint": true, "scene_minimum_anchors": 5, "aperture_diam": 0.5},
   "scene_plots": true
 }

--- a/examples/uds_770_dr0.json
+++ b/examples/uds_770_dr0.json
@@ -16,16 +16,17 @@
   "sci_lo": "/Users/ivo/Astro/PROJECTS/MINERVA/data/UDS/DR0/uds-sbkgsub-v2.4-80mas-f770w_drz_sci_extrabkg.fits",
   "wht_lo": "/Users/ivo/Astro/PROJECTS/MINERVA/data/UDS/DR0/uds-sbkgsub-v2.4-80mas-f770w_drz_wht.fits",
   "csv_lo": "/Users/ivo/Astro/PROJECTS/MINERVA/data/UDS/DR0/uds-v2.4_f770w_wcs.csv",
-  "expect_frames": [297, 228],
 
-  # MJD-tagged ePSF grids; psf_size in arcsec (null = full native stamp);
-  # psf_blur_fwhm "default" = shared DEFAULT_PSF_GAUSSIAN_FWHM_ARCSEC[filter_lo]
-  "psf_dir": "../data/PSF",
-  "pattern_hi": "UDS_NRC.._F444W_MJD\\d+_GRID25_OS4",
-  "pattern_lo": "UDS_MIRI_F770W_MJD\\d+_GRID9_OS4",
+  # MJD-tagged ePSF grids; psf.size in arcsec (null = full native stamp);
+  # psf.blur_fwhm "default" = shared DEFAULT_PSF_GAUSSIAN_FWHM_ARCSEC[filter_lo]
   "filter_lo": "f770w",
-  "psf_size": null,
-  "psf_blur_fwhm": "default",
+  "psf": {
+    "dir": "../data/PSF",
+    "pattern_hi": "UDS_NRC.._F444W_MJD\\d+_GRID25_OS4",
+    "pattern_lo": "UDS_MIRI_F770W_MJD\\d+_GRID9_OS4",
+    "size": null,
+    "blur_fwhm": "default"
+  },
 
   # preprocessing: footprint cut + trial patch (set "trial": null for a full
   # run). Only the patch plus its margin is read off disk.
@@ -34,6 +35,6 @@
   "bg_filter_sigma": 64.0,
 
   # FitConfig overrides
-  "fit": {"fit_astrometry_joint": true, "scene_minimum_bright": 10, "aperture_diam": 0.5},
+  "fit": {"fit_astrometry_joint": true, "scene_minimum_anchors": 10, "aperture_diam": 0.5},
   "scene_plots": true
 }

--- a/src/mophongo/astrom_robust.py
+++ b/src/mophongo/astrom_robust.py
@@ -1,0 +1,437 @@
+"""Robust weighting of a scene's astrometric anchors.
+
+The scene shift field is fitted by least squares, so each anchor's pull scales
+as its Fisher information ``I_i = alpha_i^2 <grad T_i, w, grad T_i>`` -- as the
+*square* of its flux. One bright extended source with an asymmetric colour
+gradient therefore carries a scene on its own: its residual is a dipole aligned
+with the template gradient, formally indistinguishable from a displacement.
+``FitConfig.astrom_leverage_cap`` bounds that pull by clipping the top quantile
+of ``I``, which is blind (it clips the brightest, which are usually the *best*
+anchors) and arbitrary (a quantile, not a physical scale).
+
+This module replaces the quantile with a measurement. Given a table of
+per-anchor implied shifts and their information -- what
+:func:`mophongo.scene.measure_anchor_shifts` produces -- it fits the shift
+field robustly and returns a per-anchor weight built from two terms:
+
+**Systematic floor.** Anchors scatter about the fitted field by more than their
+formal errors whenever template morphology, PSF matching or colour gradients
+limit the centroid. Estimating that excess as a common floor ``s`` and using
+``v_i + s^2`` in place of ``v_i`` makes an anchor's weight saturate at
+``1/s^2`` however bright it is. That is what ``astrom_leverage_cap`` was
+approximating, with the cap now set by the data rather than by a quantile.
+
+**Outlier rejection.** A source whose residual dipole comes from morphology
+rather than displacement disagrees with its neighbours: a real offset is smooth
+in position (the premise of the field model), while morphology-driven
+pseudo-shifts are random per source. Tukey's biweight on the standardized
+residual about the robustly fitted field rejects those, and rejects them
+*hard* -- see :func:`robust_anchor_weights` for why a hard cutoff is preferable
+to a Huber tail here.
+
+Both terms need several anchors to mean anything, so the whole pass is gated on
+anchor count and reports itself as inactive below it (see ``min_anchors``). In
+particular nothing here can help a scene whose only bright member is the
+offender: with one anchor the weight is a global scale, and a global scale
+cannot change where the field lands.
+
+The module is a leaf: plain arrays in, plain arrays out, no imports from
+``scene``, ``fit``, ``templates`` or ``pipeline``. That keeps it usable by the
+non-joint path in :mod:`mophongo.astrometry`, whose ``fit_polynomial_field``
+weights anchors by SNR^2 and rejects nothing, i.e. fails the same way.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["AnchorWeights", "robust_anchor_weights"]
+
+#: Tukey biweight tuning constant, in units of the robust scale. 4.685 gives
+#: 95% efficiency against a Gaussian and rejects outright beyond 4.685 sigma.
+TUKEY_C = 4.685
+
+#: Smallest scene-median reduced chi-square at which the per-anchor misfit
+#: inflation is believed. A scene fitting a hundred times inside its own noise
+#: has nothing to say about which of its anchors is misfit, and the ratios
+#: between such numbers are floating-point noise.
+CHI2_FLOOR = 1e-2
+
+#: Median of a chi^2 with one degree of freedom. The systematic floor is set by
+#: matching the median standardized square residual to this value, which is the
+#: robust analogue of "reduced chi^2 equals one".
+CHI2_1_MEDIAN = 0.4549364231195728
+
+
+@dataclass
+class AnchorWeights:
+    """Outcome of a robust pass over one scene's anchor table.
+
+    Attributes
+    ----------
+    weight
+        ``(m,)`` multiplier for each anchor's leverage, in ``[0, 1]``. This is
+        ``omega_i / I_i``: the ratio of the weight the robust fit gave the
+        anchor to the information it carries on its own, which is exactly the
+        factor :func:`mophongo.scene.assemble_scene_system_AB` needs to scale
+        that anchor's contribution to the shift blocks. All ones when the pass
+        is gated off.
+    coeff
+        ``(2, p)`` Chebyshev coefficients of the robustly fitted field, x then
+        y. Diagnostic only -- the joint solve refits the field with these
+        weights, it does not adopt these coefficients.
+    field
+        ``(m, 2)`` fitted field evaluated at the anchors.
+    resid
+        ``(m, 2)`` ``eps - field``, the disagreement each anchor was judged on.
+    sys_floor
+        Estimated systematic floor ``s``, in pixels. Zero when the anchors
+        scatter no more than their formal errors allow.
+    n_rejected
+        Anchors given zero weight.
+    n_eff
+        Effective number of anchors surviving rejection,
+        ``(sum w)^2 / sum w^2`` over the robustness weights. Deliberately not
+        taken over the information-scaled weights, which would confuse a wide
+        flux range with a heavy rejection.
+    applied
+        False when the pass was gated off or backed out, leaving ``weight``
+        all ones.
+    reason
+        Why, when ``applied`` is False. Empty otherwise.
+    """
+
+    weight: np.ndarray
+    coeff: np.ndarray
+    field: np.ndarray
+    resid: np.ndarray
+    sys_floor: float
+    n_rejected: int
+    n_eff: float
+    applied: bool
+    reason: str = ""
+
+
+def _wls(basis: np.ndarray, values: np.ndarray, omega: np.ndarray) -> np.ndarray:
+    """Weighted least squares of ``values`` on ``basis``, one column per axis.
+
+    Parameters
+    ----------
+    basis
+        ``(m, p)`` design matrix.
+    values
+        ``(m, k)`` observations, fitted independently per column.
+    omega
+        ``(m,)`` non-negative weights.
+
+    Returns
+    -------
+    ndarray
+        ``(k, p)`` coefficients. Rank-deficient systems fall back to the
+        least-norm solution rather than raising, which is what
+        ``np.linalg.lstsq`` gives.
+    """
+    root = np.sqrt(np.maximum(omega, 0.0))[:, None]
+    coeff, *_ = np.linalg.lstsq(basis * root, values * root, rcond=None)
+    return coeff.T
+
+
+def _robust_start(
+    basis: np.ndarray,
+    values: np.ndarray,
+    usable: np.ndarray,
+    *,
+    n_iter: int = 5,
+    tukey_c: float = TUKEY_C,
+) -> np.ndarray:
+    """Leverage-blind robust fit: one anchor, one vote.
+
+    The starting point decides everything about what follows. Beginning from
+    the information-weighted least-squares fit does not work here, because that
+    fit is the very thing under suspicion: an anchor with a hundred times the
+    leverage of its neighbours *is* the least-squares answer, so every honest
+    anchor looks like the outlier and the reweighting locks onto them. Huber
+    does not rescue it either -- the leverage sits in the weights, not in the
+    design, so the anchor that ought to be doubted has the smallest
+    standardized residual of all.
+
+    Ignoring the information entirely breaks that. With equal votes a lone
+    liar is outnumbered whatever its flux, the fit lands near the majority, and
+    the liar acquires the large residual it deserves. The price is statistical
+    efficiency, which is why this is only the *start*: the information-weighted
+    pass in :func:`robust_anchor_weights` recomputes the weights from scratch
+    about this fit, so a bright anchor that was right is readmitted.
+
+    Parameters
+    ----------
+    basis
+        ``(m, p)`` design matrix.
+    values
+        ``(m, k)`` observations.
+    usable
+        ``(m,)`` mask of anchors that may vote.
+    n_iter
+        Reweighting steps.
+    tukey_c
+        Tukey tuning constant, in units of the residual MAD.
+
+    Returns
+    -------
+    ndarray
+        ``(k, p)`` starting coefficients.
+    """
+    w = usable.astype(float)
+    coeff = _wls(basis, values, w)
+    for _ in range(n_iter):
+        r = values - basis @ coeff.T
+        peak = np.max(np.abs(r), axis=1)
+        scale = 1.4826 * float(np.median(np.abs(r[usable])))
+        if scale > 0:
+            u = peak / (tukey_c * scale)
+        else:
+            # An exact fit to the majority: anything off it is an outlier, and
+            # anything on it is perfect. Guards against 0/0 as well.
+            u = np.where(peak > 0, np.inf, 0.0)
+        w = np.where(u < 1.0, (1.0 - u**2) ** 2, 0.0) * usable
+        if not np.any(w > 0):
+            break
+        coeff = _wls(basis, values, w)
+    return coeff
+
+
+def _systematic_floor(resid: np.ndarray, var: np.ndarray) -> float:
+    """Excess scatter of ``resid`` beyond the formal variances ``var``.
+
+    Solves ``median_i,a[ resid_ia^2 / (var_i + s^2) ] = median(chi^2_1)`` for
+    ``s^2 >= 0`` by bisection. The left side decreases monotonically in
+    ``s^2``, so the root is unique when it exists; if the anchors already
+    scatter *less* than their formal errors the answer is zero.
+
+    Using the median rather than the mean is what keeps a single wild anchor
+    from inflating the floor for everybody -- which would defeat the purpose,
+    since a floor large enough to accommodate the outlier also flattens the
+    weights of the anchors that were right.
+
+    Parameters
+    ----------
+    resid
+        ``(m, k)`` residuals about the fitted field.
+    var
+        ``(m,)`` formal variances, broadcast across the ``k`` axes.
+
+    Returns
+    -------
+    float
+        ``s`` in the units of ``resid`` (pixels).
+    """
+    r2 = np.asarray(resid, float) ** 2
+    v = np.asarray(var, float)[:, None]
+
+    def excess(s2: float) -> float:
+        return float(np.median(r2 / (v + s2))) - CHI2_1_MEDIAN
+
+    if excess(0.0) <= 0.0:
+        return 0.0
+    # The median of r^2/(v + s^2) falls below the target once s^2 exceeds the
+    # median of r^2, so that is a guaranteed bracket.
+    hi = float(np.median(r2)) / CHI2_1_MEDIAN + np.median(v)
+    lo = 0.0
+    for _ in range(60):
+        mid = 0.5 * (lo + hi)
+        if excess(mid) > 0.0:
+            lo = mid
+        else:
+            hi = mid
+    return float(np.sqrt(0.5 * (lo + hi)))
+
+
+def robust_anchor_weights(
+    eps: np.ndarray,
+    info: np.ndarray,
+    basis: np.ndarray,
+    *,
+    chi2_red: np.ndarray | None = None,
+    min_anchors: int = 5,
+    tukey_c: float = TUKEY_C,
+    n_iter: int = 8,
+) -> AnchorWeights:
+    """Weight a scene's anchors by agreement with the fitted shift field.
+
+    Fits the field to the per-anchor implied shifts by iteratively reweighted
+    least squares, estimating a common systematic floor as it goes, and returns
+    the ratio of each anchor's final weight to its own information. Works at
+    any polynomial order: the order enters only through the width of ``basis``.
+
+    The estimator is of MM type: a high-breakdown starting fit that ignores
+    the anchors' information entirely (:func:`_robust_start`), followed by
+    redescending Tukey steps that put the information back. Both halves are
+    needed. Without the leverage-blind start the reweighting *masks*: the
+    dominant anchor is the least-squares answer, so the honest anchors carry
+    the large residuals and get cut instead. A Huber warm-up does not
+    substitute for it either -- its weights decay only as ``1/u``, so against
+    an anchor with 400x the leverage of its neighbours a tenfold downweight
+    still leaves it holding most of the vote, and the fit walks back onto it.
+
+    Rejection is hard (Tukey), not a decaying tail (Huber), for a reason
+    specific to how the weight is consumed. The weight enters
+    :func:`mophongo.scene.assemble_scene_system_AB` through ``lev_w``, whose
+    two-power split is exact for the shift-only block but leaves the
+    flux-marginalization term ``AB^T A^-1 AB`` scaled as ``c_i c_j`` where the
+    information it corrects scales as ``sqrt(c_i c_j)``. That mismatch is worst
+    at intermediate weights and vanishes identically at ``c_i = 0``, where the
+    anchor becomes exactly equivalent to one that was never bright.
+
+    Parameters
+    ----------
+    eps
+        ``(m, 2)`` implied shift of each anchor, in pixels, measured against
+        the flux-only residual.
+    info
+        ``(m,)`` Fisher information of each implied shift, ``1 / var(eps)``,
+        averaged over the two axes. Non-positive entries are treated as
+        uninformative and get zero weight.
+    basis
+        ``(m, p)`` shift-field basis evaluated at the anchors, i.e. the rows
+        :func:`mophongo.scene.make_scene_basis` produced for these anchors.
+    chi2_red
+        ``(m,)`` reduced chi-square of each anchor's own residual after its
+        private shift and flux are projected out. Used *relative to the scene
+        median* to inflate that anchor's variance: a source whose stamp does
+        not fit even after being allowed to move is not a source whose position
+        should be trusted. Relative because the absolute value is not
+        trustworthy -- drizzled pixels are correlated, so the nominal degrees
+        of freedom are too generous. ``None`` skips the inflation, as do
+        scenes with fewer than three usable values, where the median it would
+        be measured against means nothing.
+    min_anchors
+        Floor on the anchor count. The effective gate is
+        ``max(min_anchors, 2 * p)``: a robust scatter about a ``p``-term fit
+        per axis needs comfortably more points than parameters.
+    tukey_c
+        Tukey tuning constant in units of the robust scale.
+    n_iter
+        Reweighting steps after the high-breakdown start.
+
+    Returns
+    -------
+    AnchorWeights
+        With ``applied`` False and unit weights whenever the scene is too
+        small to judge, the field cannot be fitted, or rejection would leave
+        too few anchors standing.
+    """
+    eps = np.atleast_2d(np.asarray(eps, dtype=float))
+    info = np.asarray(info, dtype=float).ravel()
+    basis = np.atleast_2d(np.asarray(basis, dtype=float))
+    m, p = basis.shape
+
+    def _inactive(reason: str) -> AnchorWeights:
+        return AnchorWeights(
+            weight=np.ones(m, dtype=float),
+            coeff=np.zeros((eps.shape[1] if eps.size else 2, p)),
+            field=np.zeros_like(eps) if eps.size else np.zeros((m, 2)),
+            resid=np.zeros_like(eps) if eps.size else np.zeros((m, 2)),
+            sys_floor=0.0,
+            n_rejected=0,
+            n_eff=float(m),
+            applied=False,
+            reason=reason,
+        )
+
+    if eps.shape[0] != m or info.size != m:
+        raise ValueError(
+            f"eps {eps.shape}, info {info.shape} and basis {basis.shape} "
+            "must agree on the anchor count"
+        )
+
+    usable = np.isfinite(info) & (info > 0) & np.all(np.isfinite(eps), axis=1)
+    # Unusable rows carry zero weight throughout, but a NaN would still poison
+    # the weighted design matrix (0 * nan = nan), so blank them here.
+    eps = np.where(usable[:, None], eps, 0.0)
+    gate = max(int(min_anchors), 2 * p)
+    if int(usable.sum()) < gate:
+        return _inactive(
+            f"{int(usable.sum())} usable anchor(s) < {gate} required for "
+            f"order with {p} term(s)"
+        )
+
+    # Per-anchor variance of the implied shift, inflated where the anchor's own
+    # stamp does not fit even after its private shift is removed.
+    var = np.where(usable, 1.0 / np.where(usable, info, 1.0), np.inf)
+    if chi2_red is not None:
+        c = np.asarray(chi2_red, dtype=float).ravel()
+        good = usable & np.isfinite(c) & (c > 0)
+        # The inflation is a ratio, so it needs a scene whose misfits mean
+        # something. Below CHI2_FLOOR every anchor already fits orders of
+        # magnitude inside its own noise, and the ratios between such numbers
+        # are roundoff rather than evidence.
+        if good.sum() >= 3 and np.median(c[good]) >= CHI2_FLOOR:
+            var = var * np.where(good, np.maximum(1.0, c / np.median(c[good])), 1.0)
+
+    # Start from a fit no single anchor can buy, then let the information back
+    # in. Weights are recomputed from scratch about the current fit on every
+    # pass, so nothing the start rejected is permanently barred.
+    coeff = _robust_start(basis, eps, usable, tukey_c=tukey_c)
+    if not np.all(np.isfinite(coeff)):
+        return _inactive("shift-field fit did not produce finite coefficients")
+
+    w = usable.astype(float)
+    s = 0.0
+    resid = eps - basis @ coeff.T
+    for _ in range(n_iter):
+        resid = eps - basis @ coeff.T
+        s = _systematic_floor(resid[usable], var[usable])
+
+        sigma = np.sqrt(var + s**2)
+        # One weight per anchor, not one per axis: an anchor whose residual
+        # dipole comes from its morphology is untrustworthy in both.
+        u = np.max(np.abs(resid), axis=1) / np.maximum(sigma, 1e-30)
+        t = u / tukey_c
+        w = np.where((t < 1.0) & usable, (1.0 - t**2) ** 2, 0.0)
+
+        omega = np.where(usable, w / (var + s**2), 0.0)
+        if not np.any(omega > 0):
+            return _inactive("every anchor lost its weight during the fit")
+        coeff = _wls(basis, eps, omega)
+        if not np.all(np.isfinite(coeff)):
+            return _inactive("shift-field fit did not produce finite coefficients")
+
+    resid = eps - basis @ coeff.T
+    omega = np.where(usable, w / (var + s**2), 0.0)
+
+    # Count survivors, not influence. The effective count is taken on the
+    # robustness weights alone: computing it on `omega` would fold in the
+    # anchors' natural flux range, so a scene of six honest anchors spanning
+    # 4x in flux would report ~3.9 "effective" anchors and be refused for a
+    # concentration that is not rejection at all.
+    n_eff = float(w.sum() ** 2 / np.sum(w**2)) if np.any(w > 0) else 0.0
+    if n_eff < gate:
+        return _inactive(
+            f"rejection left {n_eff:.1f} effective anchor(s) < {gate} required"
+        )
+
+    # lev_w scales the information the blocks carry for this anchor from I_i to
+    # the weight the robust fit actually gave it.
+    weight = np.where(usable, omega / np.where(usable, info, 1.0), 0.0)
+    weight = np.clip(weight, 0.0, 1.0)
+
+    n_rej = int(np.sum(usable & (w <= 0.0)))
+    logger.debug(
+        "[astrom] robust anchors: m=%d p=%d floor=%.4f px rejected=%d "
+        "n_eff=%.1f weight %.3g-%.3g",
+        m, p, s, n_rej, n_eff, float(weight.min()), float(weight.max()),
+    )
+    return AnchorWeights(
+        weight=weight,
+        coeff=coeff,
+        field=basis @ coeff.T,
+        resid=resid,
+        sys_floor=float(s),
+        n_rejected=n_rej,
+        n_eff=n_eff,
+        applied=True,
+    )

--- a/src/mophongo/astrometry.py
+++ b/src/mophongo/astrometry.py
@@ -214,7 +214,7 @@ class AstroCorrect:
     constructor field ``cfg`` (:class:`~mophongo.fit.FitConfig`) supplies
     the astrometry options: ``astrom_model`` (``"poly"`` or ``"gp"``),
     ``astrom_centroid`` (``"centroid"`` or ``"correlation"``),
-    ``snr_thresh_astrom``, and ``astrom_kwargs`` (per-model keyword dicts,
+    ``astrom_minimum_snr``, and ``astrom_kwargs`` (per-model keyword dicts,
     e.g. ``{"poly": {"order": 2}, "gp": {"length_scale": 400}}``).
     """
 
@@ -296,7 +296,7 @@ class AstroCorrect:
         ``templates`` is a sequence of
         :class:`~mophongo.templates.Template`, ``residual`` the current
         residual image, and ``coeffs`` the fitted amplitudes. Shifts are
-        measured at templates with ``flux/err >= cfg.snr_thresh_astrom``
+        measured at templates with ``flux/err >= cfg.astrom_minimum_snr``
         (see :func:`measure_template_shifts`) and fit with the configured
         field model. For the polynomial model the basis order comes from
         ``astrom_kwargs["poly"]["order"]`` (fallback 0); for the Gaussian
@@ -318,7 +318,7 @@ class AstroCorrect:
             coeffs,
             residual,
             box_size=astrom_kw.pop("box_size", 7),
-            snr_threshold=self.cfg.snr_thresh_astrom,
+            snr_threshold=self.cfg.astrom_minimum_snr,
             method=self.cfg.astrom_centroid.lower(),
         )
 

--- a/src/mophongo/fit.py
+++ b/src/mophongo/fit.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from typing import Any, Dict, List, Tuple, Optional
 
 import numpy as np
@@ -27,6 +27,37 @@ logger = logging.getLogger(__name__)
 # Correlated templates (overlapping) require full covariance accounting; your current implementation approximates this by assuming per-template independence.
 # If template noise is negligible, simplify to: weights = wht2 (as in your current default).
 # Flux-dependent variance (via A^2) introduces mild nonlinearity; it's safe to fix A from initial fit for a single iteration.
+
+
+@dataclass
+class PhotConfig:
+    """Aperture photometry settings (the ``phot`` block of ``fit``).
+
+    Everything about *measuring* fluxes in apertures and about the detection
+    catalog's own aperture columns. None of it enters the linear solve, which
+    is why it sits apart from the rest of :class:`FitConfig` rather than
+    beside the solver and astrometry knobs.
+    """
+
+    # Image measurement aperture, as a diameter:
+    # - float/int: fixed size, in `units`
+    # - str: column name in the input catalog for per-source sizes
+    # - None: fall back to 1.5 * FWHM (in pixels) measured from the template
+    aperture_diam: float | np.ndarray | str | None = None
+    # Catalog aperture: a diameter, or the name of a table column holding one
+    aperture_catalog: float | str | None = None
+    units: str = "arcsec"  # "arcsec" or "pix", for both apertures above
+
+    # Catalog-side aperture-to-total, totcor_cat = (f_kron/f_aper) / EE_H(k*R_kron)
+    # (the flux-estimator report's "tcorH", renamed). Computed when the three
+    # column names below exist in the input catalog; radius column in arcsec.
+    # These name columns of the *input* catalog rather than configuring a
+    # measurement, so they read as `phot.kron_flux_col` and keep no `cat_`
+    # prefix -- the block already says where they come from.
+    kron_flux_col: str | None = None  # detection-catalog Kron (AUTO) flux
+    aper_flux_col: str | None = None  # detection-catalog flux in the R_phi aperture
+    kron_radius_col: str | None = None  # circularized Kron radius [arcsec]
+    kron_k: float = 2.5  # Kron scaling: EE_H evaluated at k * R_kron
 
 
 @dataclass
@@ -126,20 +157,9 @@ class FitConfig:
     # instead of leaving a hand-set number behind. Set an int to override.
     scene_minimum_anchors: int | None = None
 
-    # Photometry aperture control:
-    # - float/int: fixed aperture diameter size (in arcsec or pixels per `aperture_units`)
-    # - str: column name in the input catalog for per-source aperture sizes
-    # - None: fallback to 1.5 * FWHM (in pixels) measured from template
-    aperture_diam: float | np.ndarray | None = None  # image measurement aperture (diameter)
-    aperture_catalog: float | str | None = None  # catalog aperture (diameter or table column name)
-    aperture_units: str = "arcsec"  # "arcsec" or "pix"
-    # Catalog-side aperture-to-total, totcor_cat = (f_kron/f_aper) / EE_H(k*R_kron)
-    # (the flux-estimator report's "tcorH", renamed). Computed when the three
-    # column names below exist in the input catalog; radius column in arcsec.
-    cat_kron_flux_col: str | None = None  # detection-catalog Kron (AUTO) flux
-    cat_aper_flux_col: str | None = None  # detection-catalog flux in the R_phi aperture
-    cat_kron_radius_col: str | None = None  # circularized Kron radius [arcsec]
-    cat_kron_k: float = 2.5  # Kron scaling: EE_H evaluated at k * R_kron
+    # Aperture photometry and the catalog columns it compares against, as one
+    # block (see PhotConfig). Nothing in the linear solve reads these.
+    phot: "PhotConfig" = field(default_factory=lambda: PhotConfig())
 
     # Template extraction: dilate each segment by this many pixels (disk radius)
     # to capture more of the point-source PSF wings. Off by default (0): the
@@ -230,6 +250,19 @@ class FitConfig:
             # default to 2x # of Chebyshev terms + 1
             n_poly = (poly_order + 1) * (poly_order + 2)
             self.scene_minimum_anchors = n_poly + 1
+
+        # Coerce a JSON `phot` object into a PhotConfig, as RunConfig does for
+        # `psf`. Unknown keys raise rather than being ignored: a misspelled
+        # aperture setting that silently does nothing is worse than a stop.
+        if isinstance(self.phot, dict):
+            known = {f.name for f in fields(PhotConfig)}
+            unknown = set(self.phot) - known
+            if unknown:
+                raise ValueError(
+                    f"unknown phot config key(s): {sorted(unknown)}; "
+                    f"known keys are {sorted(known)}"
+                )
+            self.phot = PhotConfig(**self.phot)
 
 
 

--- a/src/mophongo/fit.py
+++ b/src/mophongo/fit.py
@@ -50,8 +50,8 @@ class FitConfig:
     # only captures part of a large offset per pass, so set
     # fit_astrometry_niter to the maximum passes allowed and let this tol stop.
     # 0.1 sits just above the statistical floor of the weakest scene the
-    # anchor cuts admit -- 5 bright members (scene_minimum_bright) at
-    # snr_thresh_astrom = 15 give a scene centroid good to ~0.08 fit pixels --
+    # anchor cuts admit -- 5 bright members (scene_minimum_anchors) at
+    # astrom_minimum_snr = 15 give a scene centroid good to ~0.08 fit pixels --
     # and well below PSF-matching centroid systematics, which are a bias no
     # tolerance can iterate away. The increment tested is the applied (damped)
     # one, so the last sub-tolerance step is on the templates, not discarded.
@@ -65,9 +65,16 @@ class FitConfig:
     astrom_damping: float = 0.8
     fit_astrometry_joint: bool = True  # Use joint astrometry fitting, or separate step
     # --- astrometry options -------------------------------------------------
-    reg_astrom: float = 1e-4
-    snr_thresh_astrom: float = 15.0  # 0 → keep all sources
-    astrom_isolation_thresh: float = 0.6  # min flux dominance to include in astrometry (0–1); 0.0 = no cut
+    astrom_reg: float = 1e-4
+    astrom_minimum_snr: float = 15.0  # 0 → keep all sources
+    # Minimum flux dominance within its own footprint for a template to anchor
+    # astrometry (0–1); 0.0 disables the cut. 0.7 admits blends no tighter
+    # than about 2 sigma. This is not made redundant by `astrom_robust`: a
+    # blended anchor's implied shift is *shrunk* toward zero, coherently, so
+    # blended anchors agree with each other and a robust estimator -- which is
+    # majority rule -- follows them rather than rejecting them. See
+    # mophongo.astrom_robust and TODO.md.
+    astrom_isolation_thresh: float = 0.7
     # Exclude sources flagged is_star from the astrometric shift fit. Off by
     # default: unsaturated stars are the best astrometric anchors, and
     # saturated ones are already isolated into their own scenes.
@@ -78,12 +85,31 @@ class FitConfig:
     # -- and if it is extended with an asymmetric colour gradient, its
     # residual dipole is indistinguishable from a shift and drags the field.
     # The cap bounds influence without changing the shift that anchor
-    # measures. See assemble_scene_system_AB and TODO.md (cross-anchor IRLS
-    # is the complementary fix this cannot provide).
+    # measures. See assemble_scene_system_AB.
     # 0.9 clips only the top tail: the handful of anchors carrying more
     # information than nine-tenths of their scene.
+    # `astrom_robust` supersedes this wherever it is active: it sets the same
+    # ceiling from the anchors' measured scatter instead of from a quantile,
+    # so the cap only applies in scenes the robust pass declines to judge.
     astrom_leverage_cap: float | None = 0.9
-    astrom_model: str = "gp"  # 'poly' or 'gp'
+    # Weight each astrometric anchor by how well it agrees with the shift field
+    # its neighbours define, and by how well its own stamp fits once it is
+    # allowed to move. On by default: a redescending estimator costs a few
+    # percent of efficiency on clean anchors, which is the cheaper error than
+    # letting one source with a colour gradient carry a scene. Gated on
+    # `scene_minimum_anchors` anchors (see below), which is also the floor scene
+    # merging works to, so a scene built to support the shift model is by
+    # construction big enough to be judged; below it the pass declines and
+    # `astrom_leverage_cap` is the only protection left. Set False to recover
+    # the unweighted fit.
+    astrom_robust: bool = True
+    # 'poly' or 'gp'. Only read by the non-joint `AstroCorrect` path
+    # (`astrometry.py:329`); the joint path takes its basis order straight from
+    # `astrom_kwargs["poly"]["order"]` (`scene.py:1475`) and never branches on
+    # this. Defaulted to 'poly' so the two paths agree on which model is in
+    # force under the default `fit_astrometry_joint=True`. A global GP is a
+    # possible joint model but needs the cross-scene solve in TODO.md.
+    astrom_model: str = "poly"
     astrom_centroid: str = "centroid"  # "centroid" (=old) | "correlation"
     astrom_kwargs: dict[str, dict] = field(
         default_factory=lambda: {"poly": {"order": 0}, "gp": {"length_scale": 400}}
@@ -92,9 +118,13 @@ class FitConfig:
     #    multi_resolution_method: str = "upsample"  # 'upsample' or 'downsample'
     multi_resolution_method: str = "upsample"  # 'upsample' or 'downsample'
     normal: str = "tree"  # 'loop' or 'tree'
-    # None → derive from astrometric model order in __post_init__
-    # Minimum bright sources per scene. If None reverts to (n_poly+1)*(n_poly+2)
-    scene_minimum_bright: int = 5
+    # Minimum bright anchors per scene: the floor `merge_small_scenes` merges
+    # toward, and the gate below which `astrom_robust` declines to judge a
+    # scene. None (the default) derives it from the astrometric model order in
+    # __post_init__ as (order+1)(order+2) + 1 -- one more anchor than the field
+    # has free parameters -- so raising the order raises the floor with it
+    # instead of leaving a hand-set number behind. Set an int to override.
+    scene_minimum_anchors: int | None = None
 
     # Photometry aperture control:
     # - float/int: fixed aperture diameter size (in arcsec or pixels per `aperture_units`)
@@ -190,8 +220,8 @@ class FitConfig:
     generate_scene_catalog: bool = False  # If True, generate scene catalog and exit
 
     def __post_init__(self):
-        # Derive scene_minimum_bright from astrometric polynomial order if not provided
-        if self.scene_minimum_bright is None:
+        # Derive scene_minimum_anchors from astrometric polynomial order if not provided
+        if self.scene_minimum_anchors is None:
             try:
                 # fallback matches the astrom_kwargs default above: order 0
                 poly_order = int(self.astrom_kwargs.get("poly", {}).get("order", 0))
@@ -199,7 +229,7 @@ class FitConfig:
                 poly_order = 0
             # default to 2x # of Chebyshev terms + 1
             n_poly = (poly_order + 1) * (poly_order + 2)
-            self.scene_minimum_bright = n_poly + 1
+            self.scene_minimum_anchors = n_poly + 1
 
 
 

--- a/src/mophongo/pipeline.py
+++ b/src/mophongo/pipeline.py
@@ -4265,14 +4265,14 @@ class Pipeline:
         # array leaves it None, which only disables the flux_beyond_aper
         # crowding bookkeeping).
         r_ap = None
-        scalar_ap = np.isscalar(config.aperture_diam) and not isinstance(config.aperture_diam, str)
+        scalar_ap = np.isscalar(config.phot.aperture_diam) and not isinstance(config.phot.aperture_diam, str)
         if scalar_ap:
-            if config.aperture_units == "arcsec":
+            if config.phot.units == "arcsec":
                 pscale = self._pixel_scale_arcsec(self.wcs[0] if self.wcs is not None else None)
                 if pscale:
-                    r_ap = 0.5 * float(config.aperture_diam) / pscale
+                    r_ap = 0.5 * float(config.phot.aperture_diam) / pscale
             else:
-                r_ap = 0.5 * float(config.aperture_diam)
+                r_ap = 0.5 * float(config.phot.aperture_diam)
 
         # Largest matching-kernel effective half-width over the fitted bands
         # (95% encircled radius of |K|, not the zero-padded array size).
@@ -4356,21 +4356,21 @@ class Pipeline:
 
     def _resolve_image_ap_radius_pix(self, idx: int, cfg: _FitConfig) -> float:
         """
-        Diameter source: cfg.aperture_diam
+        Diameter source: cfg.phot.aperture_diam
         - float/int => same for all images
         - np.ndarray(len(images)-1) => per image (idx>=1), pick [idx-1]
         - None => 1.5 × FWHM of PSF[idx] (in *pixels* of image idx),
                     fallback 3.0 pixels if PSF is missing.
-        Units: cfg.aperture_units ("arcsec" or "pix")
+        Units: cfg.phot.units ("arcsec" or "pix")
         """
         diam = None
-        if isinstance(cfg.aperture_diam, (int, float)):
-            diam = float(cfg.aperture_diam)
-        elif isinstance(cfg.aperture_diam, np.ndarray):
+        if isinstance(cfg.phot.aperture_diam, (int, float)):
+            diam = float(cfg.phot.aperture_diam)
+        elif isinstance(cfg.phot.aperture_diam, np.ndarray):
             # array corresponds to images[1:], so use [idx-1]
-            if cfg.aperture_diam.size != (len(self.images) - 1):
+            if cfg.phot.aperture_diam.size != (len(self.images) - 1):
                 raise ValueError("aperture_diam array must have len(images)-1 elements")
-            diam = float(cfg.aperture_diam[idx - 1])  # idx>=1 by construction here
+            diam = float(cfg.phot.aperture_diam[idx - 1])  # idx>=1 by construction here
 
         if diam is None:
             # default: 1.5×FWHM of this image PSF (pixels)
@@ -4392,7 +4392,7 @@ class Pipeline:
             return float(rad_pix)
 
         # convert diameter to pixels if needed
-        if cfg.aperture_units.lower().startswith("arc"):
+        if cfg.phot.units.lower().startswith("arc"):
             pscale = self._pixel_scale_arcsec(self.wcs[idx] if self.wcs is not None else None)
             if not pscale or pscale <= 0:
                 raise ValueError("aperture_diam in arcsec requires valid WCS for each image")
@@ -4411,7 +4411,7 @@ class Pipeline:
         - float/int => fixed *diameter* for all sources
         - None => default 1.5 × FWHM of PSF[0] in pixels (fallback 3.0)
 
-        Units: cfg.aperture_units ("arcsec" or "pix")
+        Units: cfg.phot.units ("arcsec" or "pix")
         """
         # get reference pixel scale
         pscale_ref = self._pixel_scale_arcsec(self.wcs[0] if self.wcs is not None else None)
@@ -4419,15 +4419,15 @@ class Pipeline:
         out: dict[int, float] = {}
 
         # if no catalog, default to r_default for all (if given)
-        if cfg.aperture_catalog is None:
+        if cfg.phot.aperture_catalog is None:
             for i, _ in enumerate(cat["id"]):
                 out[int(cat["id"][i])] = r_default
             return out
 
         # get from catalog
-        if isinstance(cfg.aperture_catalog, (int, float)):
-            diam = float(cfg.aperture_catalog)
-            if cfg.aperture_units.lower().startswith("arc"):
+        if isinstance(cfg.phot.aperture_catalog, (int, float)):
+            diam = float(cfg.phot.aperture_catalog)
+            if cfg.phot.units.lower().startswith("arc"):
                 if not pscale_ref or pscale_ref <= 0:
                     raise ValueError("aperture_catalog in arcsec requires valid ref WCS")
                 rad = diam / (2.0 * pscale_ref)
@@ -4438,10 +4438,10 @@ class Pipeline:
             return out
 
         # string column name
-        col = str(cfg.aperture_catalog)
+        col = str(cfg.phot.aperture_catalog)
         if col not in cat.colnames:
             raise ValueError(f"aperture_catalog column '{col}' not found in table")
-        if cfg.aperture_units.lower().startswith("arc"):
+        if cfg.phot.units.lower().startswith("arc"):
             if not pscale_ref or pscale_ref <= 0:
                 raise ValueError("aperture_catalog in arcsec requires valid ref WCS")
             for i, _ in enumerate(cat["id"]):
@@ -4478,13 +4478,13 @@ class Pipeline:
         This is the flux-estimator report's ``tcorH``, renamed: the
         detection catalog's Kron-to-aperture flux ratio times the inverse
         encircled energy of the high-resolution PSF at the scaled circularized
-        Kron radius.  Computed only when the three ``cat_*_col`` FitConfig
+        Kron radius.  Computed only when the three ``phot`` column
         knobs name existing catalog columns; otherwise empty.  The Kron radius
-        column is in arcsec; ``cat_kron_k`` scales it (SExtractor AUTO: 2.5).
+        column is in arcsec; ``phot.kron_k`` scales it (SExtractor AUTO: 2.5).
         Written once to the band-independent ``totcor_cat`` catalog column.
         """
         cfg = self.config
-        cols = (cfg.cat_kron_flux_col, cfg.cat_aper_flux_col, cfg.cat_kron_radius_col)
+        cols = (cfg.phot.kron_flux_col, cfg.phot.aper_flux_col, cfg.phot.kron_radius_col)
         source_cat = self.catalog
         if source_cat is None or any(c is None for c in cols):
             return {}
@@ -4513,9 +4513,9 @@ class Pipeline:
             ci = id_to_row.get(sid)
             if ci is None:
                 continue
-            f_kron = float(row[cfg.cat_kron_flux_col])
-            f_aper = float(row[cfg.cat_aper_flux_col])
-            r_kron = float(row[cfg.cat_kron_radius_col])  # arcsec
+            f_kron = float(row[cfg.phot.kron_flux_col])
+            f_aper = float(row[cfg.phot.aper_flux_col])
+            r_kron = float(row[cfg.phot.kron_radius_col])  # arcsec
             if not (np.isfinite(f_kron) and np.isfinite(f_aper) and f_aper > 0
                     and np.isfinite(r_kron) and r_kron > 0):
                 n_bad += 1
@@ -4528,7 +4528,7 @@ class Pipeline:
             if stamp is None:
                 n_bad += 1
                 continue
-            r_pix = float(cfg.cat_kron_k) * r_kron / pscale
+            r_pix = float(cfg.phot.kron_k) * r_kron / pscale
             cy, cx = (stamp.shape[0] - 1) / 2.0, (stamp.shape[1] - 1) / 2.0
             aper = CircularAperture((cx, cy), r=max(r_pix, 0.5))
             ee_h = float(aperture_photometry(stamp, aper, method="exact")["aperture_sum"][0])
@@ -4704,8 +4704,8 @@ class Pipeline:
         sat_cols = [c for c in catalog.colnames if c.startswith("FLAG_SATURATED_")]
         keep_cols.extend(sat_cols)
         cat = cat[keep_cols]
-        if config.aperture_catalog is not None:
-            cat[config.aperture_catalog] = catalog[config.aperture_catalog]
+        if config.phot.aperture_catalog is not None:
+            cat[config.phot.aperture_catalog] = catalog[config.phot.aperture_catalog]
         return cat
 
     def _prepare_hi_templates(self, cat: Table, config: _FitConfig) -> list[Template]:
@@ -5212,7 +5212,7 @@ class Pipeline:
             )
 
 
-            if config.aperture_diam is not None:
+            if config.phot.aperture_diam is not None:
                 pscale = self._pixel_scale_arcsec(
                     self.wcs[ifilt] if self.wcs is not None else None
                 )

--- a/src/mophongo/pipeline.py
+++ b/src/mophongo/pipeline.py
@@ -121,6 +121,76 @@ def _quiet_hierarch_warnings():
 # the outermost samples stay inside the scene rather than sitting on its edge
 _SHIFT_SAMPLE_SPREAD = 0.7
 
+#: Host serving the FITSMap viewers, prefixed to a config that gives a bare
+#: ``<field>/<release>`` path rather than a full URL. Not tied to any one
+#: survey: point ``RunConfig.minerva_viewer`` at another host and it is used
+#: as given.
+FITSMAP_URL = "https://minerva.colorado.edu"
+
+
+def _cheb_order_from_coeffs(shifts: Sequence[float] | None) -> int | None:
+    """Chebyshev order behind a flat ``[bx | by]`` coefficient vector.
+
+    Inverts ``n_terms(order) = (order+1)(order+2)/2`` on half the vector, and
+    returns None when the length matches no order -- which is the signal that
+    the coefficients cannot be interpreted, not that the scene has none.
+    """
+    from .astrometry import n_terms
+
+    if shifts is None or len(shifts) < 2:
+        return None
+    p = len(shifts) // 2
+    order = int(round((np.sqrt(8.0 * p + 1.0) - 3.0) / 2.0))
+    return order if order >= 0 and n_terms(order) == p else None
+
+
+@dataclass
+class PsfConfig:
+    """PSF grid selection and stamp settings of a run (the ``psf`` config block).
+
+    Everything that decides *which* ePSF grids a run uses and what the
+    delivered stamps look like. Loaded from the ``"psf"`` object of the run
+    JSON; unknown keys raise.
+    """
+
+    # directory of STDPSF grid files (generated grids are cached here too)
+    dir: str = "data/PSF"
+    pattern_hi: str = ""  # STDPSF filename regex for the hi-res band
+    pattern_lo: str = ""  # STDPSF filename regex for the lo-res band
+    # PSF stamp size in arcsec; None = full native ePSF stamp as generated
+    size: float | None = 4.0
+    autobuild: bool = True  # generate missing PSF grids with PSFFactory
+    # What to do when the exposure list implies epochs that no grid provides
+    # and `autobuild` is off (see Pipeline._missing_psf_dates). With autobuild
+    # on -- the default -- the missing epochs are simply built and this never
+    # applies.
+    #   "warn"  - name the missing epochs and fit with the ones that exist
+    #   "error" - refuse to run
+    #   "off"   - do not look; load whatever matches the pattern
+    # Grids themselves carry no provenance: a grid is its detector, filter,
+    # epoch and field of view, all of them in its filename, and none of them
+    # a function of the rest of the exposure list. Adding a frame to that list
+    # leaves every existing grid correct and asks for at most one more.
+    provenance: str = "warn"
+    # Processes used when building ePSF grids. One (detector, date) grid is an
+    # independent job of tens to low hundreds of MB, so this scales with cores
+    # rather than with memory. It parallelises within one pattern only: bands
+    # of a field share pattern_hi, so two bands building at once still race on
+    # the same F444W filenames -- which is why a campaign builds one band of a
+    # field first and fans out afterwards (see docs/campaigns.md).
+    workers: int = 1
+    fov_arcsec: float | None = None  # PSFFactory field of view; None = backend default
+    # Which exposure dates get their own grid when autobuilding. "all" (one
+    # per unique integer MJD) is the default because the grids are MJD-tagged
+    # and looked up by nearest date: collapsing an exposure list that spans
+    # years onto one date ("modal") or a few ("cluster") silently discards
+    # that. See psf_factory.dates_from_csv for the full set of modes.
+    date_mode: str | float = "all"
+    # extra Gaussian broadening of the lo-res model PSF (FWHM arcsec);
+    # "default" = mock_mosaic.DEFAULT_PSF_GAUSSIAN_FWHM_ARCSEC[filter_lo],
+    # a number = that value, None = no broadening
+    blur_fwhm: float | str | None = "default"
+
 
 @dataclass
 class RunConfig:
@@ -152,45 +222,10 @@ class RunConfig:
     # '_sci' -> '_wht' naming" (see :meth:`Pipeline.resolve_wht_hi`).
     wht_hi: str | None = None
     # --- PSFs -------------------------------------------------------------
-    psf_dir: str = "data/PSF"
-    pattern_hi: str = ""  # STDPSF filename regex for the hi-res band
-    pattern_lo: str = ""  # STDPSF filename regex for the lo-res band
-    filter_lo: str = ""  # lo-res filter name, e.g. "f770w" (blur lookup)
-    # PSF stamp size in arcsec; None = full native ePSF stamp as generated
-    psf_size: float | None = 4.0
-    psf_autobuild: bool = True  # generate missing PSF grids with PSFFactory
-    # What to do when the exposure list implies epochs that no grid provides
-    # and `psf_autobuild` is off (see Pipeline._missing_psf_dates). With
-    # autobuild on -- the default -- the missing epochs are simply built and
-    # this never applies.
-    #   "warn"  - name the missing epochs and fit with the ones that exist
-    #   "error" - refuse to run
-    #   "off"   - do not look; load whatever matches the pattern
-    # Grids themselves carry no provenance: a grid is its detector, filter,
-    # epoch and field of view, all of them in its filename, and none of them
-    # a function of the rest of the exposure list. Adding a frame to that list
-    # leaves every existing grid correct and asks for at most one more.
-    psf_provenance: str = "warn"
-    # Processes used when building ePSF grids. One (detector, date) grid is an
-    # independent job of tens to low hundreds of MB, so this scales with cores
-    # rather than with memory. It parallelises within one pattern only: bands
-    # of a field share pattern_hi, so two bands building at once still race on
-    # the same F444W filenames -- which is why a campaign builds one band of a
-    # field first and fans out afterwards (see docs/campaigns.md).
-    psf_workers: int = 1
-    psf_fov_arcsec: float | None = None  # PSFFactory field of view; None = backend default
-    # Which exposure dates get their own grid when autobuilding. "all" (one
-    # per unique integer MJD) is the default because the grids are MJD-tagged
-    # and looked up by nearest date: collapsing an exposure list that spans
-    # years onto one date ("modal") or a few ("cluster") silently discards
-    # that. See psf_factory.dates_from_csv for the full set of modes.
-    psf_date_mode: str | float = "all"
-    # extra Gaussian broadening of the lo-res model PSF (FWHM arcsec);
-    # "default" = mock_mosaic.DEFAULT_PSF_GAUSSIAN_FWHM_ARCSEC[filter_lo],
-    # a number = that value, None = no broadening
-    psf_blur_fwhm: float | str | None = "default"
-    # optional [n_frames_hi, n_frames_lo] sanity assert on the WCS csvs
-    expect_frames: list[int] | None = None
+    filter_lo: str = ""  # lo-res filter name, e.g. "f770w" (blur lookup, labels)
+    # Grid selection and stamp settings; a plain dict in the JSON is coerced
+    # to a PsfConfig by __post_init__.
+    psf: PsfConfig = field(default_factory=PsfConfig)
     # --- templates --------------------------------------------------------
     # The template build scheme is selected by ``fit["extend_mode"]``
     # (FitConfig.extend_mode): 'default' -> 'psf_wings'. Without an extension
@@ -207,9 +242,9 @@ class RunConfig:
     # Large-FOV STDPSF pattern for the repair's halo model (full halo +
     # diffraction spikes, so segments far from the core can be flagged).
     # Empty (default) derives '{prefix}_{det}_{filt}_MJD\d+_FOV30_GRID1_OS4'
-    # from pattern_hi and, with psf_autobuild, generates the grids once
-    # (~minutes; cached in psf_dir). The core fit always keeps the
-    # MJD-matched pattern_hi ePSFs; the halo model is grafted outside
+    # from psf.pattern_hi and, with psf.autobuild, generates the grids once
+    # (~minutes; cached in psf.dir). The core fit always keeps the
+    # MJD-matched psf.pattern_hi ePSFs; the halo model is grafted outside
     # their support.
     repair_psf_pattern: str = ""
     # Reuse a previous run's repair from the cache file when its recorded
@@ -233,7 +268,7 @@ class RunConfig:
     # pixel coordinates, slices and WCS are unchanged.
     #
     # The margin covers what reaches outside the patch: PSF support (half of
-    # ``psf_size`` — 4" for production and canfar runs, 8" for the verification
+    # ``psf.size`` — 4" for production and canfar runs, 8" for the verification
     # runs), template stamps and convolution wings. The 60" default clears
     # both by a wide margin and still reads a few per cent of a mosaic.
     #
@@ -242,9 +277,12 @@ class RunConfig:
     # the flux errors differ from a full-field run. Use it to iterate, not to
     # produce release numbers.
     trial: dict[str, Any] | None = None
-    # Viewer path for the scene-catalog `minerva_link` column, as
-    # `<field>/<release>`. None derives the field from the leading token of
-    # `name` and pairs it with `minerva_release`; "" drops the column.
+    # FITSMap root for the scene-catalog `minerva_link` column, as a full URL:
+    # "https://minerva.colorado.edu/cosmos" or ".../uds/DR0". Fields do not
+    # agree on whether a release is part of the path, so the config states the
+    # root rather than the code assembling one from the field name. A bare
+    # `<field>/<release>` is accepted and gets FITSMAP_URL in front. None or ""
+    # drops the column, because a guessed link is worse than no link.
     minerva_viewer: str | None = None
     minerva_release: str = "DR0"
     # --- fitting ----------------------------------------------------------
@@ -253,6 +291,15 @@ class RunConfig:
     # per-source stamps FITS: tmpl_hi/tmpl_lo at native sizes + per-source PSF
     # region keys (PSF stamps stay in the cached <name>_psf_*.geojson maps)
     save_stamps: bool = True
+
+    def __post_init__(self) -> None:
+        """Coerce a JSON ``psf`` object into a :class:`PsfConfig`."""
+        if isinstance(self.psf, dict):
+            known = {f.name for f in fields(PsfConfig)}
+            unknown = set(self.psf) - known
+            if unknown:
+                raise ValueError(f"unknown psf config keys: {sorted(unknown)}")
+            self.psf = PsfConfig(**self.psf)
 
     @classmethod
     def from_json(cls, path: str | Path) -> "RunConfig":
@@ -268,6 +315,28 @@ class RunConfig:
             raise ValueError(
                 f"{sorted(legacy)} were replaced by a single `trial` field: "
                 'trial={"center": [ra, dec], "radius": <arcmin>}. '
+                "Regenerate the config (examples/make_minerva_configs.py) or "
+                "edit it by hand."
+            )
+        # The flat psf_* keys moved into a `psf` block, mirroring `fit`, and
+        # expect_frames was dropped: it asserted the row counts of the very
+        # csvs the run reads, so it only ever fired when the exposure list
+        # changed, which is when a run wants the new frames rather than a
+        # raise.
+        moved = {
+            "psf_dir": "dir", "pattern_hi": "pattern_hi",
+            "pattern_lo": "pattern_lo", "psf_size": "size",
+            "psf_autobuild": "autobuild", "psf_provenance": "provenance",
+            "psf_workers": "workers", "psf_fov_arcsec": "fov_arcsec",
+            "psf_date_mode": "date_mode", "psf_blur_fwhm": "blur_fwhm",
+        }
+        flat = set(moved) & set(data)
+        if flat or "expect_frames" in data:
+            nested = ", ".join(f'"{moved[k]}"' for k in sorted(flat)) or "..."
+            raise ValueError(
+                f"{sorted(flat | ({'expect_frames'} & set(data)))} are no "
+                'longer top-level config keys: the psf settings live in a '
+                f'"psf" block ({{{nested}}}) and expect_frames was removed. '
                 "Regenerate the config (examples/make_minerva_configs.py) or "
                 "edit it by hand."
             )
@@ -1272,9 +1341,89 @@ class Pipeline:
                           variant=var_scene, baseline=base_scene, pipeline=self,
                           ifilt=ifilt)
 
+    def _refine_scene_astrometry(self, scene, config: "_FitConfig") -> bool | None:
+        """Drive one scene through the astrometric refinement to convergence.
+
+        Up to ``config.fit_astrometry_niter`` solve/apply passes, each damped
+        by ``astrom_damping``, stopping once the largest per-template increment
+        drops below ``astrom_shift_tol``; then one flux-only solve on the final
+        templates.
+
+        That closing solve is not optional bookkeeping. Every pass fits fluxes
+        on the templates as they stood *before* that pass's shift was applied,
+        so without it the stored fluxes, errors and model belong to a basis
+        that no longer exists and the last shift is never accounted for.
+
+        Records ``astrom_step``, ``astrom_niter`` and ``astrom_converged`` on
+        the scene. ``astrom_converged`` stays ``None`` where no shift was ever
+        fitted -- a flux-only run, or a scene with too few anchors to carry a
+        shift block -- because calling that "converged" would claim an
+        astrometric solution that was never solved for.
+
+        Both :meth:`run` and :meth:`_solve_frozen_scene` go through here, so a
+        refit is refined exactly as the run refined it. A refit that took a
+        single pass would not be comparable with anything the run wrote: the
+        scene catalog and the scene figures report the accumulated shift after
+        this loop.
+
+        Args:
+            scene: a :class:`~mophongo.scene.Scene` with its band already set.
+            config: the fit configuration to refine under.
+
+        Returns:
+            ``scene.astrom_converged``.
+        """
+        from dataclasses import replace
+
+        niter = max(int(config.fit_astrometry_niter), 1)
+        shift_tol = float(getattr(config, "astrom_shift_tol", 0.02))
+        final_cfg = (
+            replace(config, fit_astrometry_niter=0)
+            if config.fit_astrometry_niter > 0
+            else None
+        )
+
+        with self._phase("astrometry passes"):
+            for j in range(niter):
+                prev = np.array([t.shifted[:2] for t in scene.templates], dtype=float)
+                scene.solve(config=config, apply_shifts=True)
+                cur = np.array([t.shifted[:2] for t in scene.templates], dtype=float)
+                step = (
+                    float(np.max(np.abs(cur - prev)))
+                    if prev.size and cur.shape == prev.shape
+                    else 0.0
+                )
+                scene.astrom_step, scene.astrom_niter = step, j + 1
+                if scene.shifts is not None and len(scene.shifts) > 0:
+                    scene.astrom_converged = step < shift_tol
+                if scene.astrom_converged is not False:
+                    break
+
+        if final_cfg is not None:
+            with self._phase("final flux solve"):
+                scene.solve(config=final_cfg)
+
+        logger.debug(
+            "[Scenes] scene %s: %d pass(es), last increment %.4f pix, %s",
+            scene.id, scene.astrom_niter, scene.astrom_step or 0.0,
+            "converged" if scene.astrom_converged
+            else ("no shift fitted" if scene.astrom_converged is None
+                  else "still moving"),
+        )
+        return scene.astrom_converged
+
     def _solve_frozen_scene(self, id_scene: int, ids: np.ndarray,
                             config: "_FitConfig", ifilt: int):
         """Extract, convolve and solve one frozen source set. Restores state.
+
+        The scene is driven through the same astrometric refinement
+        :meth:`run` uses -- up to ``fit_astrometry_niter`` solve/apply passes,
+        damped by ``astrom_damping``, stopping at ``astrom_shift_tol``, then a
+        closing flux-only solve on the final templates. A single pass would not
+        be comparable with anything the run wrote: the run's scene catalog and
+        scene figures report the *accumulated* shift after that loop, so a
+        one-pass refit would be measured against a converged result and read as
+        a large disagreement when it is only an unfinished one.
 
         ``_convolved_templates`` is not idempotent: on the upsample path it
         rebinds ``images[ifilt]`` and ``wcs[ifilt]`` to their reference-grid
@@ -1296,13 +1445,49 @@ class Pipeline:
             "extend_mode": getattr(self, "extend_mode", None),
         }
         try:
-            cat = self.catalog[np.isin(np.asarray(self.catalog["id"], int), ids)]
+            cat_ids = np.asarray(self.catalog["id"], int)
+            cat = self.catalog[np.isin(cat_ids, ids)]
+            # Extraction is positions-driven, so a frozen id that is not a row
+            # of self.catalog contributes nothing: the scene came back short --
+            # or, when nothing matched, empty, and the failure surfaced far
+            # downstream as "No templates to convolve".
+            #
+            # A shortfall does not invalidate the comparison, so it is a
+            # warning: both sides of a refit are built from this same subset,
+            # so the A/B stays internally consistent. It does mean the refit is
+            # not the run's own scene, which matters when reading either side
+            # against what the run wrote. The usual cause is version skew --
+            # the catalog is re-derived by today's `load_data` while the fit on
+            # disk was written by an earlier one (the detection-coverage cut in
+            # ff3b8d4 drops 569 COSMOS F770W sources an older run kept) -- or a
+            # config whose footprint or trial cut differs from the run's.
+            if len(cat) != len(ids):
+                missing = np.setdiff1d(ids, cat_ids)
+                if not len(cat):
+                    raise RuntimeError(
+                        f"scene {id_scene}: none of its {len(ids)} frozen "
+                        f"source id(s) are rows of the pipeline catalog, so "
+                        f"there is nothing to rebuild. The membership table "
+                        f"and the catalog describe different source sets. "
+                        f"Catalog holds {len(cat_ids)} source(s) "
+                        f"(ids {cat_ids[:3].tolist()} ...); wanted "
+                        f"{ids[:3].tolist()} ..."
+                    )
+                logger.warning(
+                    "scene %d: %d of %d frozen source id(s) are missing from "
+                    "the pipeline catalog and cannot be rebuilt; refitting the "
+                    "remaining %d. Both sides use this same subset, so the "
+                    "comparison holds, but neither is the run's own scene. "
+                    "Missing %s%s",
+                    id_scene, len(missing), len(ids), len(cat),
+                    missing[:5].tolist(), " ..." if missing.size > 5 else "",
+                )
             self._prepare_hi_templates(cat, config)
             templates, weights_i = self._convolved_templates(ifilt, config)
             scene = Scene(id=int(id_scene), templates=templates,
                           fitter=SceneFitter(), bbox=_bbox_union(templates))
             scene.set_band(self.images[ifilt], weights_i, config=config)
-            scene.solve(config=config)
+            self._refine_scene_astrometry(scene, config)
             # the band arrays the scene keeps are the ones it was solved
             # against, which on the upsample path are NOT the restored ones
             return scene
@@ -1320,7 +1505,7 @@ class Pipeline:
 
     # -- shared helpers ----------------------------------------------------
     def _blur_fwhm(self) -> float | None:
-        blur = self.run_config.psf_blur_fwhm
+        blur = self.run_config.psf.blur_fwhm
         if blur == "default":
             from .mock_mosaic import DEFAULT_PSF_GAUSSIAN_FWHM_ARCSEC
 
@@ -1328,8 +1513,8 @@ class Pipeline:
         return float(blur) if blur else None
 
     def _size_kw(self) -> dict:
-        if self.run_config.psf_size is not None:
-            return dict(size=self.run_config.psf_size)
+        if self.run_config.psf.size is not None:
+            return dict(size=self.run_config.psf.size)
         return dict(size=None, ee_fraction=None)
 
     def _ensure_dpsfs(self, load_epsf: bool = False) -> None:
@@ -1344,18 +1529,13 @@ class Pipeline:
             self.dpsf_lo = DrizzlePSF(
                 driz_image=str(cfg.sci_lo), csv_file=str(cfg.csv_lo)
             )
-            if cfg.expect_frames:
-                n_hi, n_lo = cfg.expect_frames
-                got_hi = len(self.dpsf_hi.footprint)
-                got_lo = len(self.dpsf_lo.footprint)
-                if got_hi != n_hi or got_lo != n_lo:
-                    raise ValueError(
-                        f"frame-count mismatch: hi {got_hi} (expect {n_hi}), "
-                        f"lo {got_lo} (expect {n_lo})"
-                    )
+            logger.info(
+                "exposures behind the mosaics: hi %d, lo %d",
+                len(self.dpsf_hi.footprint), len(self.dpsf_lo.footprint),
+            )
         if load_epsf and not self._epsf_loaded:
-            self._load_epsf(self.dpsf_hi, cfg.pattern_hi, cfg.csv_hi, "hi")
-            self._load_epsf(self.dpsf_lo, cfg.pattern_lo, cfg.csv_lo, "lo")
+            self._load_epsf(self.dpsf_hi, cfg.psf.pattern_hi, cfg.csv_hi, "hi")
+            self._load_epsf(self.dpsf_lo, cfg.psf.pattern_lo, cfg.csv_lo, "lo")
             self._epsf_loaded = True
 
     def _missing_psf_dates(self, pattern: str, csv: str) -> list[float]:
@@ -1365,7 +1545,7 @@ class Pipeline:
         and every one of those is in its own filename. Whether the *set* is
         complete is a different question, and not one any single file can
         answer: it is the dates the exposure list implies under
-        ``psf_date_mode``, minus the dates already on disk. Asking it this way
+        ``psf.date_mode``, minus the dates already on disk. Asking it this way
         is what makes adding a frame to the exposure list cost one grid instead
         of all of them -- the existing epochs are still exactly right.
 
@@ -1380,10 +1560,10 @@ class Pipeline:
         from .psf_factory import dates_from_csv
 
         cfg = self.run_config
-        if str(getattr(cfg, "psf_provenance", "warn")).lower() == "off":
+        if str(cfg.psf.provenance).lower() == "off":
             return []
-        want = dates_from_csv(csv, cfg.psf_date_mode)
-        psf_dir = Path(cfg.psf_dir)
+        want = dates_from_csv(csv, cfg.psf.date_mode)
+        psf_dir = Path(cfg.psf.dir)
         rx = re.compile(fov_agnostic_pattern(pattern))
         have: set[int] = set()
         if psf_dir.is_dir():
@@ -1398,18 +1578,18 @@ class Pipeline:
     def _existing_grid_fov(self, pattern: str) -> float | None:
         """Largest field of view already on disk for ``pattern``, if any.
 
-        Neither the pattern nor ``psf_fov_arcsec`` is required to name a
+        Neither the pattern nor ``psf.fov_arcsec`` is required to name a
         field of view. When one isn't given, a missing epoch should still
         match whatever this band's grids already use rather than falling
         back to the backend default -- otherwise one config can quietly
         produce a mixed FOV4/FOV6 set. First-ever build for a pattern has
         nothing to match, so this returns ``None`` and the backend default
         applies; :meth:`_check_psf_size_fits_grids` warns afterwards if the
-        result is too small for ``psf_size``.
+        result is too small for ``psf.size``.
         """
         from .jwst_psf import fov_agnostic_pattern
 
-        psf_dir = Path(self.run_config.psf_dir)
+        psf_dir = Path(self.run_config.psf.dir)
         if not psf_dir.is_dir():
             return None
         rx = re.compile(fov_agnostic_pattern(pattern))
@@ -1426,7 +1606,7 @@ class Pipeline:
         """Load the ePSF grids for one band, building the epochs that are absent.
 
         Completeness is a question about dates, not about files: the exposure
-        list under ``psf_date_mode`` says which epochs this band needs, and
+        list under ``psf.date_mode`` says which epochs this band needs, and
         :meth:`_missing_psf_dates` says which of them no file provides. Only
         those are built, one call per epoch, so a band already holding 99 of
         100 epochs costs one grid rather than a hundred.
@@ -1438,52 +1618,52 @@ class Pipeline:
         """
         cfg = self.run_config
         kw = _psf_factory_kwargs(pattern)
-        fov = kw.get("fov_arcsec", cfg.psf_fov_arcsec)
+        fov = kw.get("fov_arcsec", cfg.psf.fov_arcsec)
         if fov is None:
             fov = self._existing_grid_fov(pattern)
         missing = self._missing_psf_dates(pattern, csv)
-        mode = str(getattr(cfg, "psf_provenance", "warn")).lower()
+        mode = str(cfg.psf.provenance).lower()
 
-        if missing and not cfg.psf_autobuild:
+        if missing and not cfg.psf.autobuild:
             summary = (
                 f"{band}-res band: {len(missing)} of "
                 f"{len(missing) + len(set(dpsf.epsf_obj.epsf))} epoch(s) that "
                 f"{Path(csv).name} implies under date_mode="
-                f"{cfg.psf_date_mode!r} have no grid under {cfg.psf_dir} "
-                f"(first MJD{int(round(missing[0]))}), and psf_autobuild is off"
+                f"{cfg.psf.date_mode!r} have no grid under {cfg.psf.dir} "
+                f"(first MJD{int(round(missing[0]))}), and psf.autobuild is off"
             )
             if mode == "error":
                 raise FileNotFoundError(summary)
             logger.warning("%s; fitting with the epochs that are there", summary)
 
-        if missing and cfg.psf_autobuild:
+        if missing and cfg.psf.autobuild:
             from .psf_factory import PSFFactory
 
             logger.warning(
                 "%s-res band: building %d missing epoch(s) for %r from %s "
                 "(minutes each, cached in %s)",
-                band, len(missing), pattern, Path(csv).name, cfg.psf_dir,
+                band, len(missing), pattern, Path(csv).name, cfg.psf.dir,
             )
-            Path(cfg.psf_dir).mkdir(parents=True, exist_ok=True)
+            Path(cfg.psf.dir).mkdir(parents=True, exist_ok=True)
             # An _FOV token in the pattern carries its own field of view;
-            # otherwise psf_fov_arcsec applies, then the FOV already on disk
+            # otherwise psf.fov_arcsec applies, then the FOV already on disk
             # (`fov`, resolved above), then the backend default.
             kw.pop("fov_arcsec", None)
             # One call per epoch: a literal MJD as date_mode selects exactly
             # that date (psf_factory.dates_from_csv), so nothing already on
             # disk is touched and no other epoch is recomputed.
             for mjd in missing:
-                PSFFactory(outdir=str(cfg.psf_dir), fov_arcsec=fov,
+                PSFFactory(outdir=str(cfg.psf.dir), fov_arcsec=fov,
                            date_mode=float(mjd),
-                           workers=int(getattr(cfg, "psf_workers", 1) or 1),
+                           workers=int(cfg.psf.workers or 1),
                            **kw).from_csv(str(csv), save=True)
 
-        dpsf.epsf_obj.load_jwst_stdpsf(local_dir=str(cfg.psf_dir), filter_pattern=pattern)
+        dpsf.epsf_obj.load_jwst_stdpsf(local_dir=str(cfg.psf.dir), filter_pattern=pattern)
         if not dpsf.epsf_obj.epsf:
             raise FileNotFoundError(
-                f"no PSF grids under {cfg.psf_dir} match {pattern!r} for the "
+                f"no PSF grids under {cfg.psf.dir} match {pattern!r} for the "
                 f"{band}-res band"
-                + ("" if cfg.psf_autobuild else " and psf_autobuild is off")
+                + ("" if cfg.psf.autobuild else " and psf.autobuild is off")
             )
         logger.info(
             "%s-res band: loaded %d ePSF grid(s) matching %r",
@@ -1494,14 +1674,14 @@ class Pipeline:
     def _check_psf_size_fits_grids(self, dpsf, band: str) -> None:
         """Warn when the requested stamp is wider than the grids that feed it.
 
-        ``psf_size`` is the drizzled stamp side in arcsec; a grid's ``FOV``
+        ``psf.size`` is the drizzled stamp side in arcsec; a grid's ``FOV``
         header is its own side in arcsec. Asking for more than the grid holds
         does not fail: ``eval_ePSF`` returns zero outside the grid's support,
         so the stamp is simply padded with zeros and the missing wings are
         quietly absent from the kernel and from every template. That is worth
         a line in the log rather than a silent truncation of the PSF.
         """
-        size = self.run_config.psf_size
+        size = self.run_config.psf.size
         if not size:
             return
         meta_by_key = getattr(dpsf.epsf_obj, "epsf_meta", None) or {}
@@ -1512,10 +1692,10 @@ class Pipeline:
             return
         worst = min(short, key=lambda k: short[k])
         logger.warning(
-            "%s-res band: psf_size=%.3g\" exceeds the field of view of %d of "
+            "%s-res band: psf.size=%.3g\" exceeds the field of view of %d of "
             "%d ePSF grid(s); the stamp is zero-padded beyond the grid and the "
             "PSF wings outside it are lost. Smallest: %s at FOV=%.3g\". Rebuild "
-            "those grids at a larger fov_arcsec, or lower psf_size.",
+            "those grids at a larger fov_arcsec, or lower psf.size.",
             band, float(size), len(short), len(fovs), worst, short[worst],
         )
 
@@ -1549,9 +1729,9 @@ class Pipeline:
         """Build (or reload) per-band PSF maps with PSFs at their own centroids."""
         self._ensure_dpsfs()
         cfg = self.run_config
-        want_hi = {"pattern": cfg.pattern_hi, "psf_size": float(cfg.psf_size or 0.0),
+        want_hi = {"pattern": cfg.psf.pattern_hi, "psf_size": float(cfg.psf.size or 0.0),
                    "blur_fwhm": 0.0}
-        want_lo = {"pattern": cfg.pattern_lo, "psf_size": float(cfg.psf_size or 0.0),
+        want_lo = {"pattern": cfg.psf.pattern_lo, "psf_size": float(cfg.psf.size or 0.0),
                    "blur_fwhm": float(self._blur_fwhm() or 0.0)}
         if self.f_psf_hi.exists() and self.f_psf_lo.exists() and not overwrite:
             cached_hi = PSFRegionMap.from_geojson(str(self.f_psf_hi))
@@ -1695,7 +1875,7 @@ class Pipeline:
             prm_kern,
             kernel_method=method,
             kernel_reg=float("nan") if reg is None else float(reg),
-            psf_size=float(self.run_config.psf_size or 0.0),
+            psf_size=float(self.run_config.psf.size or 0.0),
         )
         logger.info(
             "kernel map: method=%s reg=%s, DC before renormalization "
@@ -1785,7 +1965,7 @@ class Pipeline:
         prov: dict[str, str] = {
             "sci_hi": str(cfg.sci_hi),
             "wht_hi": str(self.resolve_wht_hi()),
-            "pattern": cfg.pattern_hi,
+            "pattern": cfg.psf.pattern_hi,
             "halo": pattern_halo or "",
             "kwargs": json.dumps(cfg.repair_kwargs or {}, sort_keys=True),
             # A trial run only repairs its own patch, so its cache must not
@@ -1935,21 +2115,21 @@ class Pipeline:
         return sci, wht, cat, seg
 
     def _repair_halo_pattern(self) -> str:
-        """Canonical large-FOV halo-grid pattern derived from ``pattern_hi``.
+        """Canonical large-FOV halo-grid pattern derived from ``psf.pattern_hi``.
 
         Keeps the prefix/detector/filter of the photometry grids and swaps
         the sampling tail for the 30" single-position halo layout:
         ``{prefix}_{det}_{filt}_MJD\\d+_FOV30_GRID1_OS4``. Building these
         is a one-off of a few minutes per detector (stpsf at 30" FOV),
-        cached in ``psf_dir``; :meth:`_load_epsf` handles the build when
-        ``psf_autobuild`` is on.
+        cached in ``psf.dir``; :meth:`_load_epsf` handles the build when
+        ``psf.autobuild`` is on.
         """
-        m = _PSF_PATTERN_RE.match(self.run_config.pattern_hi.strip())
+        m = _PSF_PATTERN_RE.match(self.run_config.psf.pattern_hi.strip())
         if m is None:
             logger.warning(
-                "cannot derive a halo-grid pattern from pattern_hi=%r; "
+                "cannot derive a halo-grid pattern from psf.pattern_hi=%r; "
                 "set repair_psf_pattern explicitly",
-                self.run_config.pattern_hi,
+                self.run_config.psf.pattern_hi,
             )
             return ""
         return (
@@ -2061,12 +2241,12 @@ class Pipeline:
 
             self._ensure_dpsfs(load_epsf=True)
             # Large-FOV grids for the halo model (halo + spikes); the core
-            # fit keeps the MJD-matched pattern_hi ePSFs and the halo is
+            # fit keeps the MJD-matched psf.pattern_hi ePSFs and the halo is
             # grafted outside their support. Same two-PSF split as the
             # original standalone repair flow.
             pattern_halo = cfg.repair_psf_pattern or self._repair_halo_pattern()
             stamp_dpsf = None
-            if pattern_halo and pattern_halo != cfg.pattern_hi:
+            if pattern_halo and pattern_halo != cfg.psf.pattern_hi:
                 from .psf import DrizzlePSF
 
                 stamp_dpsf = DrizzlePSF(
@@ -2079,11 +2259,11 @@ class Pipeline:
                 except (FileNotFoundError, ValueError) as exc:
                     # Missing grids with autobuild off, or a pattern the
                     # autobuild grammar cannot parse (e.g. a legacy-order
-                    # spelling): degrade to the pattern_hi reach instead of
+                    # spelling): degrade to the psf.pattern_hi reach instead of
                     # failing the run — the repair itself is unaffected.
                     logger.warning(
                         "halo PSF grids unavailable for %r (%s); flag reach "
-                        "limited to the pattern_hi field of view",
+                        "limited to the psf.pattern_hi field of view",
                         pattern_halo, exc,
                     )
                     stamp_dpsf, pattern_halo = None, ""
@@ -2113,7 +2293,7 @@ class Pipeline:
                 seg0 = segmap.copy()
                 rep = repair_in_memory(
                     tmpl_hi, wht0,
-                    dpsf=self.dpsf_hi, wcs=wcs_hi, psf_pattern=cfg.pattern_hi,
+                    dpsf=self.dpsf_hi, wcs=wcs_hi, psf_pattern=cfg.psf.pattern_hi,
                     catalog=cat, segmap=segmap,
                     stamp_dpsf=stamp_dpsf,
                     stamp_pattern=pattern_halo or None,
@@ -2288,9 +2468,18 @@ class Pipeline:
 
         if getattr(self, "run_config", None) is None:
             raise RuntimeError("load_outputs requires a config-driven Pipeline")
+        self.scene_fit = None
         if self.f_fit_table.exists():
-            self.table = Table.read(self.f_fit_table)
+            # hdu=1 explicitly: the file carries a SCENES extension too, and a
+            # bare read warns about the ambiguity before picking this one
+            self.table = Table.read(self.f_fit_table, hdu=1)
             logger.info("loaded %s (%d rows)", self.f_fit_table.name, len(self.table))
+            with fits.open(self.f_fit_table) as hdul:
+                has_scenes = "SCENES" in [h.name for h in hdul]
+            if has_scenes:
+                self.scene_fit = Table.read(self.f_fit_table, hdu="SCENES")
+                logger.info("loaded %s[SCENES] (%d scenes)",
+                            self.f_fit_table.name, len(self.scene_fit))
         else:
             logger.warning("no fit table %s", self.f_fit_table)
         if self.f_residual.exists():
@@ -2426,6 +2615,204 @@ class Pipeline:
             rows=rows,
             names=["id", "id_parent", "x", "y", "dx", "dy", "flux", "err", "id_scene"],
         )
+
+    def write_scene_catalog(self, path: str | Path) -> Table:
+        """Write the human-readable per-scene summary and return it.
+
+        Deliberately short: this file is for reading. Everything the solver
+        recorded per scene -- iteration counts, step sizes, the robust-pass
+        verdict, and the shift coefficients -- is in the ``SCENES`` extension
+        of the fit table, which is what a machine should read.
+
+        ``dx``, ``dy`` are the *applied* shift field sampled at the scene
+        centre, so they stay a summary of what the sources actually moved
+        rather than the last pass's coefficients, which is a different and
+        smaller thing.
+
+        Public because a run that died drawing figures re-emits this from a
+        reloaded fit, and it has to be the same file either way.
+        """
+        cfg = self.run_config
+        # chi2 is judged against the residual with *every* scene's model
+        # subtracted; Scene.residual() keeps the neighbours' light and would
+        # charge it to this scene.
+        residuals = getattr(self, "residuals", None)
+        global_residual = residuals[0] if residuals else None
+        rows = []
+        for s in self.scenes:
+            xy = np.mean([t.position_original for t in s.templates], axis=0)
+            ra, dec = self.wcs[0].wcs_pix2world([xy], 0)[0]
+            # The scene's total shift at the centroid of its own templates,
+            # taken as the plain mean of what was actually applied. See
+            # Scene.mean_shift for why this is not a field evaluation.
+            dx, dy = s.mean_shift()
+            anchors = getattr(s, "is_bright", None)
+            rep = getattr(s, "anchor_report", None)
+            applied = bool(rep is not None and rep.applied)
+            rows.append(
+                (s.id, len(s.templates),
+                 0 if anchors is None else int(np.sum(anchors)), ra, dec,
+                 float(dx), float(dy), s.shift_error(), s.shift_scatter(),
+                 float(rep.sys_floor) if applied else np.nan,
+                 s.chi2_dof(global_residual),
+                 -1 if s.astrom_converged is None else int(not s.astrom_converged))
+            )
+        table = Table(
+            rows=rows,
+            names=["id", "n_templates", "n_anchor", "ra", "dec", "dx", "dy",
+                   "sigma_shift", "shift_rms", "astrom_floor", "chi2_dof",
+                   "flag_astrom"],
+        )
+        # No viewer, no column: a guessed URL is worse than none, since the
+        # fields do not agree on whether the release is part of the path.
+        viewer = (cfg.minerva_viewer or "") if cfg is not None else ""
+        if viewer and "://" not in viewer:
+            viewer = f"{FITSMAP_URL}/{viewer.strip('/')}"  # bare <field>/<release>
+        if viewer:
+            table["minerva_link"] = [
+                f"{viewer.rstrip('/')}/?ra={ra:.7f}&dec={dec:.7f}&zoom=7"
+                for ra, dec in zip(table["ra"], table["dec"])
+            ]
+        table.write(str(path), format="ascii.csv", overwrite=True)
+        return table
+
+    def restore_scene_fit(self, scenes: Sequence[Any]) -> int:
+        """Put the ``SCENES`` extension back onto regrouped scene objects.
+
+        ``load_fit`` does not rebuild scenes -- membership survives as
+        ``id_scene`` and the caller regroups from it -- so the solver state
+        those scenes never had is reattached here, matched by scene id.
+        Restores the shift coefficients and their basis, the astrometry
+        counters and the robust-pass verdict, which is everything
+        :meth:`write_scene_catalog` and :meth:`plot_shift_field` read.
+
+        Returns the number of scenes matched, and does nothing when the fit
+        table has no such extension -- runs written before it existed reload
+        exactly as they did.
+        """
+        table = getattr(self, "scene_fit", None)
+        if table is None:
+            return 0
+        by_id = {int(r["id"]): r for r in table}
+        matched = 0
+        for s in scenes:
+            row = by_id.get(int(s.id))
+            if row is None:
+                continue
+            order = int(row["shift_order"])
+            if order >= 0 and int(row["n_coeff"]) > 0:
+                s.shifts = np.asarray(row["shift_coeff"][: int(row["n_coeff"])], float)
+                # `basis` is the per-template design, rebuilt on demand by the
+                # evaluators; only the normalisation has to survive the trip
+                s.shift_basis = [None,
+                                 (float(row["shift_x0"]), float(row["shift_y0"])),
+                                 (float(row["shift_sx"]), float(row["shift_sy"]))]
+            s.astrom_niter = int(row["astrom_niter"])
+            conv = int(row["astrom_converged"])
+            s.astrom_converged = None if conv < 0 else bool(conv)
+            step = float(row["astrom_step"])
+            s.astrom_step = None if np.isnan(step) else step
+            matched += 1
+        return matched
+
+    def _band_label(self, ifilt: int) -> str:
+        """Name one of ``self.images`` for a log line.
+
+        ``image 1`` says nothing in a run log that is read weeks later beside
+        sixteen other bands, so name the file. A run config describes one
+        reference and one lo-res band; a pipeline driven directly can hold
+        more, and those keep the index rather than borrowing a name.
+        """
+        cfg = getattr(self, "run_config", None)
+        path = None if cfg is None else (cfg.sci_hi, cfg.sci_lo)[ifilt] if ifilt < 2 else None
+        if not path:
+            return f"image {ifilt}"
+        name = Path(path).name
+        filt = (cfg.filter_lo or "") if ifilt else ""
+        return f"{filt} ({name})" if filt else name
+
+    def _scene_fit_table(self) -> Table:
+        """Per-scene fit state: the shift field the anchors solved.
+
+        The per-template table records the shift each source *received*; this
+        records where that came from. ``shift_coeff`` with ``shift_order`` and
+        the ``(x0, y0, sx, sy)`` normalisation are exactly the arguments of
+        :meth:`AstroCorrect.build_poly_predictor`, so the field can be
+        evaluated anywhere rather than only at the sources that sampled it.
+
+        Two things it is not, both of which matter when reading it back:
+
+        * **The last pass, not the sum of them.** ``Scene.solve`` overwrites
+          ``shifts`` on every astrometric pass, so a scene with
+          ``astrom_niter`` above 1 kept only the final pass's coefficients.
+          The total offset a source ended up with is the per-template ``dx``,
+          ``dy`` of ``<name>_templates.fits``, and refitting those is what
+          :meth:`_scene_shift_samples` does.
+        * **Undamped.** The applied shift is ``astrom_damping`` times this
+          field, so the factor is stored beside it rather than left to the
+          config that happened to be in force.
+
+        ``shift_coeff`` is padded with NaN to the widest order in the run and
+        cut back with ``n_coeff``; ``shift_order`` is -1 for a scene that
+        solved no shifts, which includes every scene when astrometry is off.
+        Order is per scene, not per run -- a saturated scene is forced to 0 so
+        its fragments move rigidly.
+        """
+        damping = float(getattr(self.config, "astrom_damping", 1.0))
+        widths = [len(s.shifts) for s in self.scenes
+                  if getattr(s, "shifts", None) is not None]
+        nmax = max(widths) if widths else 1
+        coeff = np.full((len(self.scenes), nmax), np.nan)
+        residuals = getattr(self, "residuals", None)
+        sc_residual = residuals[0] if residuals else None
+
+        rows = []
+        for i, s in enumerate(self.scenes):
+            xy = np.mean([t.position_original for t in s.templates], axis=0)
+            ra, dec = self.wcs[0].wcs_pix2world([xy], 0)[0]
+
+            shifts = getattr(s, "shifts", None)
+            basis = getattr(s, "shift_basis", None)
+            order = _cheb_order_from_coeffs(shifts)
+            if order is None or basis is None:
+                order, ncoef = -1, 0
+                x0 = y0 = sx = sy = np.nan
+            else:
+                ncoef = len(shifts)
+                coeff[i, :ncoef] = np.asarray(shifts, dtype=float)
+                _, (x0, y0), (sx, sy) = basis
+
+            rep = getattr(s, "anchor_report", None)
+            applied = bool(rep is not None and rep.applied)
+            anchors = getattr(s, "is_bright", None)
+            rows.append(
+                (int(s.id), len(s.templates),
+                 0 if anchors is None else int(anchors.sum()),
+                 float(xy[0]), float(xy[1]), float(ra), float(dec),
+                 int(order), int(ncoef),
+                 float(x0), float(y0), float(sx), float(sy),
+                 damping if order >= 0 else np.nan,
+                 int(s.astrom_niter),
+                 -1 if s.astrom_converged is None else int(s.astrom_converged),
+                 float(s.astrom_step if s.astrom_step is not None else np.nan),
+                 int(applied),
+                 int(rep.n_rejected) if applied else -1,
+                 float(rep.sys_floor) if applied else np.nan,
+                 float(rep.n_eff) if applied else np.nan,
+                 s.shift_scatter(), s.shift_error(), s.chi2_dof(sc_residual))
+            )
+        table = Table(
+            rows=rows,
+            names=["id", "n_templates", "n_anchor", "x", "y", "ra", "dec",
+                   "shift_order", "n_coeff",
+                   "shift_x0", "shift_y0", "shift_sx", "shift_sy",
+                   "astrom_damping",
+                   "astrom_niter", "astrom_converged", "astrom_step",
+                   "astrom_robust", "astrom_nreject", "astrom_floor",
+                   "astrom_neff", "shift_rms", "sigma_shift", "chi2_dof"],
+        )
+        table["shift_coeff"] = coeff
+        return table
 
     # -- inspection --------------------------------------------------------
     def __repr__(self) -> str:
@@ -2628,17 +3015,15 @@ class Pipeline:
             ``(xy, dxy)`` in reference-image pixels, both ``(n, 2)``, or None
             when the scene has no usable shift solution.
         """
-        from .astrometry import cheb_basis, n_terms
+        from .astrometry import cheb_basis
 
         shifts = getattr(scene, "shifts", None)
         basis = getattr(scene, "shift_basis", None)
         if shifts is None or basis is None or len(shifts) < 2 or not scene.templates:
             return None
         _, (x0, y0), (Sx, Sy) = basis
-        # invert n_terms(order) = (order+1)(order+2)/2 on the dx half of shifts
-        p = len(shifts) // 2
-        order = int(round((np.sqrt(8.0 * p + 1.0) - 3.0) / 2.0))
-        if order < 0 or n_terms(order) != p:
+        order = _cheb_order_from_coeffs(shifts)
+        if order is None:
             logger.warning(
                 "scene %s: %d shift coefficients match no Chebyshev order; skipped",
                 getattr(scene, "id", -1), len(shifts),
@@ -2815,6 +3200,19 @@ class Pipeline:
             if getattr(self, "all_templates", None):
                 self._template_fit_table().write(self.f_templates, overwrite=True)
 
+            # Per-scene fit state, as a SCENES extension of the fit table.
+            # Written here rather than beside the scene catalog further down,
+            # because everything below this point draws figures, and the
+            # figure loop is where a band dies: three of the seventeen in the
+            # 2026-08-16 campaign stopped inside it, and the solution they had
+            # already found went with them. Read it back with
+            # ``Table.read(f_fit_table, hdu="SCENES")``.
+            if self.scenes:
+                scene_hdu = fits.BinTableHDU(
+                    self._scene_fit_table().as_array(), name="SCENES"
+                )
+                fits.append(self.f_fit_table, scene_hdu.data, scene_hdu.header)
+
         scene_dir = self.out_dir / "scenes"
         if cfg.scene_plots and self.scenes:
             scene_dir.mkdir(parents=True, exist_ok=True)
@@ -2828,46 +3226,18 @@ class Pipeline:
             for t in s.templates
             if getattr(t, "is_saturated", False)
         ]
-        rows = []
-        for s in self.scenes:
-            xy = np.mean([t.position_original for t in s.templates], axis=0)
-            ra, dec = self.wcs[0].wcs_pix2world([xy], 0)[0]
-            # total applied shift at the scene center, NaN where none was fitted
-            sampled = self._scene_shift_samples(s, at=xy)
-            dx, dy = sampled[1][0] if sampled is not None else (np.nan, np.nan)
-            rows.append(
-                (s.id, len(s.templates), int(s.is_bright.sum()), ra, dec,
-                 float(dx), float(dy),
-                 int(s.astrom_niter),
-                 -1 if s.astrom_converged is None else int(not s.astrom_converged),
-                 float(s.astrom_step if s.astrom_step is not None else np.nan))
-            )
-            if cfg.scene_plots:
-                import matplotlib.pyplot as plt
+        self.write_scene_catalog(f"{stem}_scene_catalog.csv")
 
+        if cfg.scene_plots:
+            import matplotlib.pyplot as plt
+
+            for s in self.scenes:
                 fig, _ = s.plot(
                     self.images[0], self.segmap, display_sig=5,
                     null_segments=sat_ids,
                 )
                 fig.savefig(scene_dir / f"{cfg.name}_scene_{s.id}.png", dpi=300)
                 plt.close(fig)
-        scene_table = Table(
-            rows=rows,
-            names=["id", "n_templates", "is_bright", "ra", "dec", "dx", "dy",
-                   "astrom_niter", "flag_astrom", "astrom_step"],
-        )
-        viewer = cfg.minerva_viewer
-        if viewer is None:
-            viewer = f"{str(cfg.name).split('_')[0].lower()}/{cfg.minerva_release}"
-        if viewer:
-            scene_table["minerva_link"] = [
-                f"https://minerva.colorado.edu/{viewer.strip('/')}/"
-                f"?ra={ra:.7f}&dec={dec:.7f}&zoom=7"
-                for ra, dec in zip(scene_table["ra"], scene_table["dec"])
-            ]
-        scene_table.write(
-            f"{stem}_scene_catalog.csv", format="ascii.csv", overwrite=True
-        )
 
         # Two full-field views of the partition, answering different
         # questions, side by side in one figure and sharing one colour per
@@ -3085,6 +3455,11 @@ class Pipeline:
             rows["ee_psf_lo"].append(float(getattr(t_lo, "ee_psf_lo", np.nan)))
             rows["ee_tmpl"].append(float(getattr(t_lo, "ee_tmpl", np.nan)))
             rows["err_pred"].append(float(getattr(t_lo, "err_pred", np.nan)))
+            # Weight this source carried as an astrometric anchor. 1.0 unless
+            # FitConfig.astrom_robust downweighted it, 0.0 if it was rejected;
+            # 1.0 for every non-anchor. Written so an A/B pair of runs can be
+            # compared source by source, not just scene by scene.
+            rows["astrom_weight"].append(float(getattr(t_lo, "astrom_weight", 1.0)))
             shift = np.asarray(getattr(t_lo, "shifted", (0.0, 0.0)), dtype=float)
             rows["shift_x"].append(float(shift[0]))
             rows["shift_y"].append(float(shift[1]))
@@ -3220,10 +3595,17 @@ class Pipeline:
         k = bin_factor_from_wcs(self.wcs[0], self.wcs[ifilt]) if self.wcs is not None else 1
         self.fit_bin_factors.append(int(k))
         if k > 1 and config.multi_resolution_method == "upsample":
-            logger.info("upsampling image %d by factor %d", ifilt, k)
-            self.images[ifilt], _ = _upsample_boxed(
-                self.images[ifilt], None, k, self.trial_box_lo
+            logger.info("upsampling %s by factor %d", self._band_label(ifilt), k)
+            # The weight goes with the image, or the restored instance carries
+            # a native-grid weight beside a reference-grid image while
+            # `wcs[ifilt] = wcs[0]` hides the discrepancy from the next caller
+            # (see _convolved_templates).
+            w_i = self.weights[ifilt] if self.weights is not None else None
+            self.images[ifilt], w_i = _upsample_boxed(
+                self.images[ifilt], w_i, k, self.trial_box_lo
             )
+            if self.weights is not None:
+                self.weights[ifilt] = w_i
             self.wcs[ifilt] = self.wcs[0]
 
         shape_hi = self.images[0].shape
@@ -3288,6 +3670,9 @@ class Pipeline:
                 t_lo.id_scene = int(row["id_scene"])
                 t_lo.ee_psf_lo = float(row["ee_psf_lo"])
                 t_lo.ee_tmpl = float(row["ee_tmpl"])
+                # absent from stamp files written before astrom_robust existed
+                if "astrom_weight" in row:
+                    t_lo.astrom_weight = float(row["astrom_weight"])
                 t_lo.shifted = np.array(
                     [float(row["shift_x"]), float(row["shift_y"])], dtype=float
                 )
@@ -3592,7 +3977,7 @@ class Pipeline:
 
         A campaign submits a field's bands together, and each would otherwise
         re-run the same repair: it depends on the detection image, its weight,
-        ``pattern_hi``, the halo pattern, ``repair_kwargs`` and the trial box
+        ``psf.pattern_hi``, the halo pattern, ``repair_kwargs`` and the trial box
         (:meth:`_repair_provenance`), and on nothing that varies between bands.
         Running it once per field turns that duplicated work into a cache hit,
         and removes the concurrent writes to a shared cache file that come with
@@ -3706,6 +4091,11 @@ class Pipeline:
         # int16, not int8: astropy writes an int8 column as a FITS logical,
         # and -1 comes back as True.
         cat[f"flag_astrom_{idx}"] = np.full(len(cat), -1, dtype=np.int16)
+        # Anchor weight from FitConfig.astrom_robust: 1.0 when the pass is off,
+        # declined, or found nothing to downweight; 0.0 for a rejected anchor.
+        # Always written, so an A/B pair of runs differs in the column values
+        # rather than in the schema.
+        cat[f"astrom_weight_{idx}"] = np.ones(len(cat), dtype=np.float32)
 
         if not np.isfinite(throughput) or throughput <= 0.0:
             logger.warning(
@@ -3732,6 +4122,11 @@ class Pipeline:
         # first template wins for a parent: deblend children of one source share
         # a scene, so any of them names it
         scene_of_parent: dict[int, int] = {}
+        # Weakest anchor weight among a parent's templates: a source whose only
+        # fragment was rejected reads 0, one never downweighted reads 1. The
+        # minimum rather than a mean, because the question the column answers
+        # is whether any part of this source was thrown out of the shift fit.
+        astrom_w_of_parent: dict[int, float] = {}
         for k, (tmpl, pid, fl, er, ep) in enumerate(
             zip(templates, parent_ids, fluxes, errs, err_pred)
         ):
@@ -3739,6 +4134,8 @@ class Pipeline:
                 continue
             if scene_ids is not None and k < len(scene_ids):
                 scene_of_parent.setdefault(pid, int(scene_ids[k]))
+            aw = float(getattr(tmpl, "astrom_weight", 1.0))
+            astrom_w_of_parent[pid] = min(astrom_w_of_parent.get(pid, 1.0), aw)
             ee = getattr(tmpl, "ee_psf_lo", np.nan)
             if not np.isfinite(ee) or ee <= 0.0:
                 ee = throughput
@@ -3785,6 +4182,7 @@ class Pipeline:
             cat[f"err_{idx}_total"][ci] = err_total_sum[pid]
             cat[f"err_pred_{idx}_total"][ci] = err_pred_total_sum[pid]
             cat[f"throughput_{idx}"][ci] = throughput
+            cat[f"astrom_weight_{idx}"][ci] = astrom_w_of_parent.get(pid, 1.0)
             sid = scene_of_parent.get(pid, -1)
             cat[f"scene_{idx}"][ci] = sid
             if scene_flags:
@@ -4472,7 +4870,7 @@ class Pipeline:
 
         if k > 1:
             if config.multi_resolution_method == "upsample":
-                logger.info("upsampling image %d by factor %d", ifilt, k)
+                logger.info("upsampling %s by factor %d", self._band_label(ifilt), k)
                 images[ifilt], weights_i = _upsample_boxed(
                     images[ifilt],
                     weights_i,
@@ -4480,6 +4878,20 @@ class Pipeline:
                     self.trial_box_lo,
                 )
                 wcs[ifilt] = wcs[0]
+                # Keep the instance's own weight on the same grid as its own
+                # image. The upsampled weight used to live only in this local,
+                # so afterwards images[ifilt] was on the reference grid while
+                # weights[ifilt] was still native -- and `wcs[ifilt] = wcs[0]`
+                # above erases the evidence, because the next call computes
+                # k = 1 and upsamples neither. A second pass over the same band
+                # (`_solve_frozen_scene`, or any refit) then indexed a native
+                # weight map with reference-grid slices. Numpy clips
+                # out-of-range slices rather than raising, so that read
+                # silently returned the wrong region: templates in genuinely
+                # covered sky were pruned as uncovered, and the scene residual
+                # was masked over valid pixels.
+                if weights is not None:
+                    weights[ifilt] = weights_i
             else:
                 logger.info("downsampling templates and kernels by factor %d", k)
                 tmpls_lo = Templates()
@@ -4508,6 +4920,17 @@ class Pipeline:
             tmpls_lo._templates = list(self.tmpls._templates)
 
         if weights_i is not None:
+            # Slicing a too-small weight map with reference-grid slices is not
+            # an error in numpy -- it clips and returns the wrong region -- so
+            # the pairing has to be checked rather than trusted.
+            if weights_i.shape != images[ifilt].shape:
+                raise RuntimeError(
+                    f"band {ifilt}: weight map {weights_i.shape} is not on the "
+                    f"same grid as the image {images[ifilt].shape}. Slicing it "
+                    f"with fit-grid coordinates would silently read the wrong "
+                    f"pixels: templates over covered sky would be pruned as "
+                    f"uncovered and residuals masked over valid data."
+                )
             tmpls_lo.prune_outside_weight(weights_i)
 
         templates = tmpls_lo.convolve_templates(
@@ -4634,9 +5057,9 @@ class Pipeline:
                 weights_i,
                 coupling_thresh=float(config.scene_coupling_thresh),
                 max_size=config.scene_max_size,
-                snr_thresh_astrom=float(config.snr_thresh_astrom),
+                astrom_minimum_snr=float(config.astrom_minimum_snr),
                 isolation_thresh=float(config.astrom_isolation_thresh),
-                minimum_bright=int(config.scene_minimum_bright),
+                minimum_bright=int(config.scene_minimum_anchors),
                 max_merge_radius=float(getattr(config, "scene_max_merge_radius", np.inf)),
                 exclude_stars=bool(config.astrom_exclude_stars),
             )
@@ -4694,63 +5117,18 @@ class Pipeline:
             # pass. The results are identical either way; what goes is the
             # barrier, which is what stops a scene from being handed to a
             # worker process (see docs/SCALING_FIXED_MEMORY.md).
+            # That unit of work is `_refine_scene_astrometry`, shared with
+            # `_solve_frozen_scene` so a refit is refined exactly as the run
+            # refined it.
             logger.info(
                 "[Scenes] solving %d scene(s), up to %d astrometric pass(es) "
                 "each (tol %s)", len(scenes), niter_scene, tol_txt,
             )
-            # A flux-only run (fit_astrometry_niter = 0) takes one pass through
-            # the loop below -- solve() dispatches to the flux-only path on the
-            # same flag -- and skips the closing re-solve.
-            final_cfg = (
-                replace(config, fit_astrometry_niter=0)
-                if config.fit_astrometry_niter > 0
-                else None
-            )
             unconverged: list[Scene] = []
             for scn in scenes:
                 scn.set_band(images[ifilt], weights_i, config=config)
-                with self._phase("astrometry passes"):
-                  for j in range(niter_scene):
-                    prev = np.array([t.shifted[:2] for t in scn.templates], dtype=float)
-                    scn.solve(config=config, apply_shifts=True)
-                    cur = np.array([t.shifted[:2] for t in scn.templates], dtype=float)
-                    step = (
-                        float(np.max(np.abs(cur - prev)))
-                        if prev.size and cur.shape == prev.shape
-                        else 0.0
-                    )
-                    scn.astrom_step, scn.astrom_niter = step, j + 1
-                    # a verdict only means something where shifts were fitted:
-                    # a flux-only run, or a scene with too few bright anchors
-                    # to carry a shift block, never moves, and reporting that
-                    # as "converged" would claim an astrometric solution that
-                    # was never solved for. Those keep astrom_converged None
-                    # and flag -1 -- and stop here, since nothing will move
-                    # them on a later pass either.
-                    if scn.shifts is not None and len(scn.shifts) > 0:
-                        scn.astrom_converged = step < shift_tol
-                    if scn.astrom_converged is not False:
-                        break
-                if scn.astrom_converged is False:
+                if self._refine_scene_astrometry(scn, config) is False:
                     unconverged.append(scn)
-                # Each pass solved fluxes on the templates as they stood
-                # *before* that pass's shift was applied, so the stored fluxes,
-                # errors and model belong to a basis that no longer exists --
-                # the last shift applied is never accounted for. Re-solve
-                # fluxes once on the final templates, regardless of the
-                # convergence verdict, so what is written is stationary for the
-                # basis actually used to build the model, residual and stamps.
-                # Shifts are left untouched: this is a flux-only pass.
-                if final_cfg is not None:
-                    with self._phase("final flux solve"):
-                        scn.solve(config=final_cfg)
-                logger.debug(
-                    "[Scenes] scene %s: %d pass(es), last increment %.4f pix, %s",
-                    scn.id, scn.astrom_niter, scn.astrom_step or 0.0,
-                    "converged" if scn.astrom_converged
-                    else ("no shift fitted" if scn.astrom_converged is None
-                          else "still moving"),
-                )
 
             niters = [s.astrom_niter for s in scenes]
             logger.info(
@@ -4760,7 +5138,7 @@ class Pipeline:
                 tol_txt,
                 int(np.median(niters)) if niters else 0, max(niters, default=0),
                 "; fluxes re-solved on the final templates"
-                if final_cfg is not None else "",
+                if config.fit_astrometry_niter > 0 else "",
             )
 
             # Scenes still moving when the budget ran out: their shifts are the

--- a/src/mophongo/scene.py
+++ b/src/mophongo/scene.py
@@ -9,7 +9,7 @@ import scipy.sparse as sp
 from .templates import Template, Templates
 from .fit import FitConfig
 from .scene_fitter import SceneFitter
-from .astrometry import cheb_basis, AstroCorrect
+from .astrometry import cheb_basis, n_terms, AstroCorrect
 from scipy.sparse.csgraph import connected_components
 from .templates import _slices_from_bbox
 
@@ -550,6 +550,264 @@ from .templates import Template
 from .astrometry import cheb_basis
 
 
+def _scene_residual(
+    templates: Sequence[Template],
+    image: np.ndarray,
+    flux: np.ndarray,
+) -> tuple[np.ndarray, int, int]:
+    """Residual of ``image`` after ``flux``-scaled templates, over their union.
+
+    Parameters
+    ----------
+    templates
+        Scene members, in scene-local order.
+    image
+        Full-frame band image.
+    flux
+        Per-template amplitudes aligned to ``templates``.
+
+    Returns
+    -------
+    tuple
+        ``(resid, y0, x0)``: the residual on the union footprint of the
+        templates, and the origin of that footprint in image coordinates. The
+        union is taken over ``slices_original``, the same convention
+        :func:`assemble_scene_system_AB` uses for its derivative buffers.
+    """
+    y0 = min(t.slices_original[0].start for t in templates)
+    y1 = max(t.slices_original[0].stop for t in templates)
+    x0 = min(t.slices_original[1].start for t in templates)
+    x1 = max(t.slices_original[1].stop for t in templates)
+
+    resid = np.array(image[y0:y1, x0:x1], dtype=float, copy=True)
+    for t, f in zip(templates, flux):
+        so = t.slices_original
+        sl = (
+            slice(so[0].start - y0, so[0].stop - y0),
+            slice(so[1].start - x0, so[1].stop - x0),
+        )
+        resid[sl] -= float(f) * t.data[t.slices_cutout]
+    return resid, y0, x0
+
+
+def measure_anchor_shifts(
+    templates: Sequence[Template],
+    resid: np.ndarray,
+    weights: np.ndarray,
+    origin: tuple[int, int],
+    bright_idx: Sequence[int],
+    alpha: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Per-anchor implied shift, information and misfit, from one residual.
+
+    Each anchor is given a private displacement and flux correction and fitted
+    on its own footprint against ``resid``, by least squares on the three
+    columns :math:`(T_i, -\\partial_x T_i, -\\partial_y T_i)`. That is a
+    3x3 normal system per anchor, and it yields everything the robust
+    weighting needs:
+
+    * ``eps`` -- the displacement that anchor's residual implies,
+    * ``info`` -- its Fisher information, marginalized over the anchor's own
+      flux (the 2x2 Schur complement of the flux row), so a source whose
+      template is nearly degenerate with its own gradient is correctly
+      reported as uninformative,
+    * ``chi2_red`` -- what is *left* of the residual once that displacement and
+      flux correction are removed. This is the discriminator between a source
+      that has moved and one whose template is simply wrong: a pure
+      displacement lives entirely in the span of the two gradient columns, so
+      projecting them out leaves noise, while a colour gradient leaves
+      structure behind.
+
+    The residual to pass is the **flux-only** one. The shift block's effective
+    right-hand side after eliminating the fluxes is exactly
+    :math:`B^\\top W (d - A\\hat\\alpha_0)`, so measuring against that residual
+    is what the joint solve itself responds to, not an approximation of it.
+
+    The local system is **conditional on the anchor's neighbourhood**, which
+    is what makes the estimate usable in a blend. It holds a flux column for
+    every template overlapping the anchor, and a free displacement for every
+    overlapping template that is itself an anchor, fitted over their union
+    footprint so each of those parameters is constrained by all of its own
+    pixels. Neither addition is a refinement; each is the difference between a
+    right and a wrong answer, and both were measured:
+
+    * **A neighbour's free flux.** The residual arrives with the fluxes already
+      fitted, and a neighbour to one side absorbs part of a dipole by adjusting
+      its brightness. Projecting out only the anchor's own flux left that
+      absorption in place: a bright anchor with a faint blended neighbour read
+      0.095 px against a true 0.20 -- half its shift, in the blend direction,
+      with no misfit to show for it -- while its isolated twin read 0.20
+      exactly.
+    * **A neighbouring anchor's free shift.** Two overlapping sources that have
+      both moved leave overlapping dipoles. Holding the neighbour's shift at
+      zero split them badly: a pair at 6 px read 0.089 and 0.039 px against a
+      true 0.20, both low, both agreeing with each other, and both carrying
+      more information than the honest anchors they disagreed with. With the
+      neighbour's displacement free, 0.171 and 0.151.
+
+    The numerator ``<G_i, w, r0>`` is right in every version; it is the
+    information divided by that has to be marginalized over everything local
+    and free.
+
+    Two approximations remain, both bounded by construction. Neighbours of
+    neighbours are not included, and the union footprint stands in for the
+    global flux constraint. What survives of them is smaller than the anchor's
+    own reported uncertainty, which is the property that matters -- a residual
+    bias inside the error bar cannot make a blend look like a liar. A
+    non-anchor that has itself moved is not modelled anywhere, by design, so
+    its dipole lands in ``chi2_red``: the anchor's stamp genuinely no longer
+    explains its own footprint.
+
+    Parameters
+    ----------
+    templates
+        Scene members, in scene-local order.
+    resid
+        Flux-only residual on the union footprint, from :func:`_scene_residual`.
+    weights
+        Full-frame inverse-variance weights.
+    origin
+        ``(y0, x0)`` of ``resid`` in image coordinates.
+    bright_idx
+        Scene-local indices of the anchors to measure. Other entries come back
+        as ``nan`` shift, zero information.
+    alpha
+        Per-template flux seed, aligned to ``templates``. It sets the amplitude
+        of the gradient columns, so it must be the same seed the blocks will be
+        built with, or the weights will not correspond to the information the
+        blocks carry.
+
+    Returns
+    -------
+    tuple
+        ``(eps, info, chi2_red)`` of shapes ``(n, 2)``, ``(n,)``, ``(n,)``.
+    """
+    n = len(templates)
+    y0, x0 = origin
+    eps = np.full((n, 2), np.nan, dtype=float)
+    info = np.zeros(n, dtype=float)
+    chi2_red = np.full(n, np.nan, dtype=float)
+
+    slices = [t.slices_original for t in templates]
+    anchors = {int(k) for k in bright_idx}
+    grads: dict[int, tuple[np.ndarray, np.ndarray]] = {}
+
+    def _grad(j: int) -> tuple[np.ndarray, np.ndarray] | None:
+        if j not in grads:
+            a_j = templates[j].data.astype(float)
+            if a_j.shape[0] < 2 or a_j.shape[1] < 2:
+                return None
+            gy_j, gx_j = np.gradient(a_j)
+            sc_j = templates[j].slices_cutout
+            grads[j] = (-gx_j[sc_j], -gy_j[sc_j])
+        return grads[j]
+
+    for i in bright_idx:
+        i = int(i)
+        a = float(alpha[i])
+        if not np.isfinite(a) or a == 0.0:
+            continue
+        t = templates[i]
+        arr = t.data.astype(float)
+        if arr.shape[0] < 2 or arr.shape[1] < 2:
+            continue
+
+        # Every template overlapping this anchor joins the local fit, and the
+        # footprint is their union so each one's flux is constrained by all of
+        # its own pixels rather than only the part under the anchor.
+        si = slices[i]
+        nb = [
+            j
+            for j, sj in enumerate(slices)
+            if sj[0].start < si[0].stop
+            and si[0].start < sj[0].stop
+            and sj[1].start < si[1].stop
+            and si[1].start < sj[1].stop
+        ]
+        fy0 = min(slices[j][0].start for j in nb)
+        fy1 = max(slices[j][0].stop for j in nb)
+        fx0 = min(slices[j][1].start for j in nb)
+        fx1 = max(slices[j][1].stop for j in nb)
+
+        w = np.asarray(weights[fy0:fy1, fx0:fx1], dtype=float)
+        r = resid[fy0 - y0 : fy1 - y0, fx0 - x0 : fx1 - x0]
+        shape = (fy1 - fy0, fx1 - fx0)
+
+        def _place(j: int, values: np.ndarray) -> np.ndarray:
+            out = np.zeros(shape, dtype=float)
+            sj = slices[j]
+            out[
+                sj[0].start - fy0 : sj[0].stop - fy0,
+                sj[1].start - fx0 : sj[1].stop - fx0,
+            ] = values
+            return out
+
+        # Columns: a flux for every overlapping template, then a free
+        # displacement for every overlapping *anchor*, with this anchor's own
+        # pair last so its conditional block is the trailing 2x2.
+        cols = [_place(j, templates[j].data[templates[j].slices_cutout]) for j in nb]
+        others = [k for k in nb if k in anchors and k != i]
+        for k in others:
+            g = _grad(k)
+            if g is None:
+                continue
+            cols.append(_place(k, g[0]))
+            cols.append(_place(k, g[1]))
+        g_i = _grad(i)
+        if g_i is None:
+            continue
+        cols.append(_place(i, g_i[0]))
+        cols.append(_place(i, g_i[1]))
+
+        ncol = len(cols)
+        nrest = ncol - 2
+        M = np.empty((ncol, ncol), dtype=float)
+        s = np.empty(ncol, dtype=float)
+        for p_ in range(ncol):
+            cw = cols[p_] * w
+            s[p_] = float(np.sum(cw * r))
+            for q_ in range(p_, ncol):
+                M[p_, q_] = M[q_, p_] = float(np.sum(cw * cols[q_]))
+
+        # A rank-deficient local system (flat template, all-zero weights, two
+        # anchors so blended their displacements are indistinguishable) carries
+        # no usable positional information; leave it at info = 0 for the caller
+        # to drop.
+        try:
+            theta = np.linalg.solve(M, s)
+            rest_inv = np.linalg.solve(M[:nrest, :nrest], M[:nrest, nrest:])
+        except np.linalg.LinAlgError:
+            continue
+        if not (np.all(np.isfinite(theta)) and np.all(np.isfinite(rest_inv))):
+            continue
+
+        schur = M[nrest:, nrest:] - M[nrest:, :nrest] @ rest_inv
+        iso = 0.5 * (schur[0, 0] + schur[1, 1])
+        if not (iso > 0):
+            continue
+
+        eps[i] = theta[nrest:] / a
+        info[i] = a**2 * iso
+
+        # Misfit is judged on the anchor's own stamp, not on the whole local
+        # footprint: the question is whether *this* template fits, and a
+        # neighbour's problems should not be charged to it.
+        model = np.zeros(shape, dtype=float)
+        for c, th in zip(cols, theta):
+            model += th * c
+        own = (
+            slice(slices[i][0].start - fy0, slices[i][0].stop - fy0),
+            slice(slices[i][1].start - fx0, slices[i][1].stop - fx0),
+        )
+        w_own = w[own]
+        dof = int(np.count_nonzero(w_own > 0)) - ncol
+        if dof > 0:
+            left = r[own] - model[own]
+            chi2_red[i] = float(np.sum(left * w_own * left)) / dof
+
+    return eps, info, chi2_red
+
+
 def assemble_scene_system_AB(
     templates: List[Template],
     image: np.ndarray,
@@ -560,6 +818,7 @@ def assemble_scene_system_AB(
     order: int = 1,
     include_y: bool = True,
     leverage_cap: float | None = None,
+    anchor_weights: np.ndarray | None = None,
 ) -> tuple[sp.csr_matrix, sp.csr_matrix, np.ndarray]:
     """
     Build the (A,B) coupling blocks and beta RHS for a *single scene*.
@@ -627,7 +886,23 @@ def assemble_scene_system_AB(
         Note what this does *not* do: it cannot tell which anchor is wrong,
         so it clips the brightest, which are often the best anchors, and it
         does nothing in a scene whose offender is the only bright member.
-        Cross-anchor robustness is the fix for that case (see TODO.md).
+        ``anchor_weights`` is the measured alternative.
+    anchor_weights
+        Per-template multiplier on the same leverage weight, or None. This is
+        where :func:`mophongo.astrom_robust.robust_anchor_weights` delivers its
+        verdict: an anchor that disagrees with the field its neighbours define,
+        or whose own stamp does not fit once it is allowed to move, arrives
+        here scaled down or at zero.
+
+        Entries at exactly zero drop the anchor from the derivative columns
+        altogether, which is both cheaper (it no longer enlarges the dense
+        buffers below) and cleaner. The two-power split above is exact for the
+        shift-only block, but the flux-marginalization term ``AB^T A^-1 AB``
+        ends up scaled as ``c_i c_j`` where the information it corrects scales
+        as ``sqrt(c_i c_j)``; one ``AB`` matrix cannot satisfy both. The
+        mismatch is worst at intermediate weights and vanishes identically at
+        ``c_i = 0``, where the anchor becomes exactly equivalent to one that
+        was never bright.
 
     Returns
     -------
@@ -643,9 +918,28 @@ def assemble_scene_system_AB(
     # One anchor is enough: it contributes two constraints (dx and dy), which
     # exactly determines the default order-0 basis. Higher orders are
     # underdetermined by a single anchor and lean on the shift-block ridge
-    # (FitConfig.reg_astrom, 1e-4 of the diagonal scale), which pulls the
+    # (FitConfig.astrom_reg, 1e-4 of the diagonal scale), which pulls the
     # unconstrained coefficients to zero rather than letting them run.
     bright_idx = [i for i, S in enumerate(basis_vals) if S is not None]
+
+    # A robustly rejected anchor is dropped here rather than carried at zero
+    # weight: it would otherwise still enlarge the dense derivative buffers
+    # below while contributing nothing to them.
+    aw = None
+    if anchor_weights is not None:
+        aw = np.clip(np.asarray(anchor_weights, dtype=float), 0.0, 1.0)
+        if aw.shape != (nA,):
+            raise ValueError(
+                f"anchor_weights must have shape ({nA},), got {aw.shape}"
+            )
+        n_before = len(bright_idx)
+        bright_idx = [i for i in bright_idx if aw[i] > 0]
+        if len(bright_idx) < n_before:
+            logger.debug(
+                "[scenes] %d of %d anchor(s) dropped by anchor_weights",
+                n_before - len(bright_idx), n_before,
+            )
+
     has_shift = len(bright_idx) >= 1
     if not has_shift:
         return sp.csr_matrix((nA, 0)), sp.csr_matrix((0, 0)), np.zeros(0, float)
@@ -709,6 +1003,13 @@ def assemble_scene_system_AB(
                         float(leverage_cap), int(over.sum()), len(bright_idx),
                         float(lev_w[over].min()),
                     )
+
+    # The measured weight composes with the quantile cap: the cap bounds
+    # leverage before any residual is seen, the measured weight acts on
+    # disagreement after. They fail in different places, so neither subsumes
+    # the other.
+    if aw is not None:
+        lev_w = lev_w * aw
 
     # Scene-wide derivative columns B_k = sum_i (-a_i S_ik) grad(T_i),
     # accumulated over the union footprint of the bright anchors. Faint
@@ -792,7 +1093,7 @@ def generate_scenes(
     *,
     coupling_thresh: float = 0.01,
     max_size: int | None = None,
-    snr_thresh_astrom: float = 7.0,
+    astrom_minimum_snr: float = 7.0,
     isolation_thresh: float = 0.0,
     minimum_bright: int | None = None,
     max_merge_radius: float = np.inf,
@@ -826,7 +1127,7 @@ def generate_scenes(
     max_size : int, optional
         Soft per-scene template cap (pipeline passes
         ``FitConfig.scene_max_size``, default 800).
-    snr_thresh_astrom : float
+    astrom_minimum_snr : float
         Bright-anchor cut on the SNR proxy ``b_i / sqrt(A_ii)``.
     isolation_thresh : float
         If positive, a template only counts as a bright anchor when its own
@@ -836,7 +1137,7 @@ def generate_scenes(
     minimum_bright : int, optional
         Minimum bright anchors per scene, forwarded to
         :func:`merge_small_scenes`. Pass an integer (the pipeline passes
-        ``FitConfig.scene_minimum_bright``): the ``None`` default is
+        ``FitConfig.scene_minimum_anchors``): the ``None`` default is
         forwarded unchanged and fails inside ``merge_small_scenes``.
     max_merge_radius : float
         The scene length scale in pixels (pipeline passes
@@ -916,7 +1217,7 @@ def generate_scenes(
     snr_proxy = np.divide(
         ATb, np.sqrt(np.maximum(d, 1e-12)), out=np.zeros_like(ATb, dtype=float), where=d > 0
     )
-    bright_mask = np.asarray(snr_proxy > float(snr_thresh_astrom), dtype=bool)
+    bright_mask = np.asarray(snr_proxy > float(astrom_minimum_snr), dtype=bool)
     if exclude_stars:
         bright_mask &= ~np.array([t.is_star for t in templates], dtype=bool)
     if isolation_thresh > 0:
@@ -1072,6 +1373,9 @@ class Scene:
     astrom_step: float | None = None
     astrom_niter: int = 0
     astrom_converged: bool | None = None
+    # Verdict of the last robust anchor pass (FitConfig.astrom_robust), an
+    # mophongo.astrom_robust.AnchorWeights; None when that pass never ran.
+    anchor_report: object | None = None
 
     def __post_init__(self) -> None:
         pass
@@ -1105,7 +1409,7 @@ class Scene:
         """Solve the scene and return ``(flux, err, shifts, info)``.
 
         Rebuilds ``A``/``b`` from the current band if needed, recomputes the
-        bright mask (SNR proxy above ``config.snr_thresh_astrom``, isolation
+        bright mask (SNR proxy above ``config.astrom_minimum_snr``, isolation
         above ``config.astrom_isolation_thresh``, optional star exclusion),
         then either solves flux-only (when ``config.fit_astrometry_joint``
         is false or ``fit_astrometry_niter <= 0``) or the joint flux+shift
@@ -1144,7 +1448,7 @@ class Scene:
             b, np.sqrt(np.maximum(d, 1e-12)), out=np.zeros_like(b, dtype=float), where=d > 0
         )
         isolated = _astrom_isolation_mask(A, b, float(cfg.astrom_isolation_thresh))
-        self.is_bright = (snr_proxy > float(cfg.snr_thresh_astrom)) & isolated
+        self.is_bright = (snr_proxy > float(cfg.astrom_minimum_snr)) & isolated
         if getattr(cfg, "astrom_exclude_stars", False):
             self.is_bright &= ~np.array([t.is_star for t in self.templates], dtype=bool)
 
@@ -1177,6 +1481,20 @@ class Scene:
             )
             self.shift_basis = [basis, (x0, y0), (Sx, Sy)]
 
+            # The measured weight supersedes the quantile cap rather than
+            # composing with it. Both bound how much one bright anchor can
+            # move the field, but the cap does it blind -- it clips whichever
+            # anchors carry the most information, which are usually the best
+            # ones -- while the robust pass sets the same ceiling from the
+            # anchors' own scatter. Where the robust pass declines to judge,
+            # the cap is still the only protection and stays on.
+            anchor_weights = None
+            leverage_cap = getattr(cfg, "astrom_leverage_cap", None)
+            if getattr(cfg, "astrom_robust", False):
+                anchor_weights = self._robust_anchor_weights(A, b, basis, alpha0, cfg)
+                if anchor_weights is not None:
+                    leverage_cap = None
+
             AB, BB, bB = assemble_scene_system_AB(
                 self.templates,
                 self.image,
@@ -1185,7 +1503,8 @@ class Scene:
                 alpha0=alpha0,
                 order=order,
                 include_y=True,
-                leverage_cap=getattr(cfg, "astrom_leverage_cap", None),
+                leverage_cap=leverage_cap,
+                anchor_weights=anchor_weights,
             )
             # if no valid AB BB solve will fall back to flux-only
             # @@@ scenefitter.solve should not take config but regularization and cg_kwargs
@@ -1245,7 +1564,7 @@ class Scene:
                     "cuts (SNR > %g, isolation >= %g%s); astrometry skipped "
                     "for this scene.",
                     getattr(self, "id", -1),
-                    float(cfg.snr_thresh_astrom),
+                    float(cfg.astrom_minimum_snr),
                     float(cfg.astrom_isolation_thresh),
                     ", stars excluded" if getattr(cfg, "astrom_exclude_stars", False) else "",
                 )
@@ -1260,6 +1579,222 @@ class Scene:
             tmpl.is_bright = bright
 
         return sol.flux, sol.err, sol.shifts, sol.info
+
+    def _robust_anchor_weights(
+        self,
+        A: sp.spmatrix,
+        b: np.ndarray,
+        basis: List[Optional[np.ndarray]],
+        alpha0: np.ndarray,
+        cfg: FitConfig,
+    ) -> np.ndarray | None:
+        """Weight this scene's anchors by their agreement with each other.
+
+        Solves the scene flux-only, measures what displacement each anchor's
+        own residual implies (:func:`measure_anchor_shifts`), and hands the
+        resulting table to
+        :func:`mophongo.astrom_robust.robust_anchor_weights`.
+
+        The flux-only solve is not an approximation of the joint one: after
+        eliminating the fluxes, the shift block's right-hand side is exactly
+        ``B^T W (d - A alpha_hat_0)``, so the flux-only residual is the thing
+        the shift block responds to. Measuring the anchors against it needs no
+        iteration around the joint solve and no lag -- the weights are known
+        before the joint system is assembled.
+
+        Parameters
+        ----------
+        A, b
+            Scene flux block and right-hand side.
+        basis
+            Per-template shift basis from :func:`make_scene_basis`; ``None``
+            marks a non-anchor.
+        alpha0
+            Flux seed the blocks will be built with. The same seed must be
+            used here, or the measured weights will not correspond to the
+            information the blocks carry.
+        cfg
+            Fit configuration; reads ``scene_minimum_anchors`` as the anchor
+            gate. That is the same floor :func:`merge_small_scenes` merges
+            scenes up to, so a scene assembled to support the shift model is
+            by construction large enough for the robust pass to judge, and
+            raising the polynomial order raises both together.
+
+        Returns
+        -------
+        ndarray or None
+            Per-template multiplier for ``assemble_scene_system_AB``, or
+            ``None`` when the robust pass declined to judge (too few anchors,
+            or rejection would have left too few standing). The verdict is
+            kept on :attr:`anchor_report` and on each anchor's
+            ``Template.astrom_weight`` either way.
+        """
+        from .astrom_robust import robust_anchor_weights
+
+        bright_idx = [i for i, S in enumerate(basis) if S is not None]
+        if not bright_idx:
+            return None
+
+        flux0 = SceneFitter.solve(A, b, config=cfg).flux
+        resid, y0, x0 = _scene_residual(self.templates, self.image, flux0)
+        eps, info, chi2_red = measure_anchor_shifts(
+            self.templates, resid, self.weights, (y0, x0), bright_idx, alpha0
+        )
+
+        rows = np.asarray(bright_idx, dtype=int)
+        report = robust_anchor_weights(
+            eps[rows],
+            info[rows],
+            np.asarray([basis[i] for i in bright_idx], dtype=float),
+            chi2_red=chi2_red[rows],
+            min_anchors=int(getattr(cfg, "scene_minimum_anchors", 0) or 0),
+        )
+        self.anchor_report = report
+        for k, i in enumerate(bright_idx):
+            self.templates[i].astrom_weight = float(report.weight[k])
+
+        if not report.applied:
+            logger.debug(
+                "[scenes] Scene %s: robust anchor weighting inactive (%s)",
+                getattr(self, "id", -1), report.reason,
+            )
+            return None
+
+        logger.info(
+            "[scenes] Scene %s: %d/%d anchor(s) rejected, systematic floor "
+            "%.3f px, %.1f effective anchor(s)",
+            getattr(self, "id", -1), report.n_rejected, rows.size,
+            report.sys_floor, report.n_eff,
+        )
+        weights = np.ones(len(self.templates), dtype=float)
+        weights[rows] = report.weight
+        return weights
+
+    def mean_shift(self) -> np.ndarray:
+        """Mean accumulated shift of this scene's templates, in fit pixels.
+
+        The scene's one reported shift, at the centroid of its own templates.
+        Deliberately the plain average of ``Template.shifted`` rather than a
+        Chebyshev field evaluated at the centre: the accumulated shift is a sum
+        of damped increments, each fitted at whatever the previous pass left
+        behind, so at order >= 1 the total is not in general representable by
+        the functional form of any single pass. Refitting the form to it is an
+        approximation of something already known exactly, and the two can
+        differ by ~0.1 px.
+
+        Returns
+        -------
+        ndarray
+            ``(dx, dy)``, or zeros when the scene has no templates with a
+            finite shift.
+        """
+        if not self.templates:
+            return np.zeros(2, dtype=float)
+        sh = np.array([np.asarray(t.shifted, dtype=float)[:2] for t in self.templates])
+        ok = np.isfinite(sh).all(axis=1)
+        return sh[ok].mean(axis=0) if ok.any() else np.zeros(2, dtype=float)
+
+    def shift_error(self) -> float:
+        """Formal 1-sigma on this scene's fitted shift at its centre, in pixels.
+
+        Propagated from the shift block's covariance with the fluxes
+        marginalized out (:meth:`~mophongo.scene_fitter.SceneFitter._shift_covariance`),
+        evaluated at the basis origin and averaged over the two axes. Without
+        it the reported ``dx``, ``dy`` and ``astrom_floor`` have no scale, and
+        a 0.2 px shift cannot be told from zero.
+
+        It is the last pass's number. Passes re-measure the same pixels, so at
+        convergence the accumulated shift is determined about as well as any
+        single pass determines it -- treat it as the scale on the total, not
+        as an error that shrinks with the number of passes.
+
+        Returns
+        -------
+        float
+            NaN when no shift was fitted or the covariance was unavailable.
+        """
+        sol = getattr(self, "solution", None)
+        cov = getattr(sol, "shift_cov", None) if sol is not None else None
+        if cov is None or np.size(cov) == 0 or self.shift_basis is None:
+            return float("nan")
+        cov = np.asarray(cov, dtype=float)
+        p = cov.shape[0] // 2
+        if p < 1:
+            return float("nan")
+        # invert n_terms(order) = (order+1)(order+2)/2 by search: orders are
+        # small and this keeps the mapping in one place
+        order = next((o for o in range(8) if n_terms(o) == p), None)
+        if order is None:
+            return float("nan")
+        phi0 = cheb_basis(0.0, 0.0, order)
+        var = [float(phi0 @ cov[s:s + p, s:s + p] @ phi0) for s in (0, p)]
+        if not all(np.isfinite(v) and v >= 0 for v in var):
+            return float("nan")
+        return float(np.sqrt(0.5 * (var[0] + var[1])))
+
+    def chi2_dof(self, residual: np.ndarray | None = None) -> float:
+        """Reduced chi-square over this scene's bounding box.
+
+        The one number that ranks scenes by how badly they are fitted, which is
+        what finding the next problem scene actually needs.
+
+        Parameters
+        ----------
+        residual
+            Full-frame residual with *every* scene's model subtracted, as
+            :meth:`~mophongo.pipeline.Pipeline.write_outputs` holds it. That is
+            the honest choice: :meth:`residual` subtracts only this scene's
+            model, so neighbours' light still sits in the footprint and
+            inflates the number. Falls back to :meth:`residual` when omitted.
+
+        Returns
+        -------
+        float
+            NaN when the scene has no weights, no solution to count parameters
+            from, or no positive-weight pixels left after the free parameters.
+        """
+        if self.weights is None or self.bbox is None:
+            return float("nan")
+        sl = _slices_from_bbox(self.bbox)
+        r = np.asarray(residual[sl] if residual is not None else self.residual(), float)
+        w = np.asarray(self.weights[sl], dtype=float)
+        if r.shape != w.shape:
+            return float("nan")
+        good = np.isfinite(r) & np.isfinite(w) & (w > 0)
+        # one free amplitude per template, plus the shift coefficients when a
+        # shift was fitted for this scene
+        nfree = len(self.templates) + (
+            len(self.shifts) if self.shifts is not None else 0
+        )
+        dof = int(good.sum()) - nfree
+        if dof <= 0:
+            return float("nan")
+        return float(np.sum(w[good] * r[good] ** 2) / dof)
+
+    def shift_scatter(self) -> float:
+        """RMS spread of the applied shifts about :meth:`mean_shift`, in pixels.
+
+        How much the shift field varied across the scene, as applied. At
+        order 0 every template receives the same offset and this is zero by
+        construction, so a non-zero value at order 0 means the field changed
+        between passes -- the scene walked rather than converged. At higher
+        order it is the amplitude of the gradient the field actually carried,
+        which is the direct way to see whether the extra terms did anything.
+
+        Returns
+        -------
+        float
+            Zero when the scene has fewer than two templates with a finite
+            shift.
+        """
+        if len(self.templates) < 2:
+            return 0.0
+        sh = np.array([np.asarray(t.shifted, dtype=float)[:2] for t in self.templates])
+        ok = np.isfinite(sh).all(axis=1)
+        if ok.sum() < 2:
+            return 0.0
+        d = sh[ok] - sh[ok].mean(axis=0)
+        return float(np.sqrt(np.mean(np.sum(d**2, axis=1))))
 
     def shift_at(self, x: ndarray, y: ndarray) -> Tuple[ndarray, ndarray]:
         """Evaluate the already-applied shift at positions ``(x, y)``.
@@ -1642,9 +2177,10 @@ class Scene:
 
             # Add shift scale indicator
             if max_shift > 0:
-                med_dx = float(np.median(dx_grid))
-                med_dy = float(np.median(dy_grid))
-                shift_text = f"shift dx={med_dx:+.2f}, dy={med_dy:+.2f} pix"
+                # the scene's one number: mean applied shift over its
+                # templates, matching the scene catalog (see mean_shift)
+                mean_dx, mean_dy = self.mean_shift()
+                shift_text = f"shift dx={mean_dx:+.2f}, dy={mean_dy:+.2f} pix"
                 model_ax.text(
                     0.02,
                     0.98,

--- a/src/mophongo/scene_fitter.py
+++ b/src/mophongo/scene_fitter.py
@@ -163,7 +163,7 @@ class SceneFitter:
         applies the adaptive ridge, ``1e-6`` times the median positive
         diagonal of ``A``; ``0.0`` applies none at all; a positive value is
         used as given. When shift blocks are supplied and non-empty, the shift block
-        is regularized by ``config.reg_astrom`` times the median positive
+        is regularized by ``config.astrom_reg`` times the median positive
         diagonal of ``BB`` and solved jointly; empty shift blocks (a scene
         with no bright member) fall back to flux-only.
 
@@ -175,7 +175,7 @@ class SceneFitter:
             Right hand side.
         config
             Solver configuration. ``reg_flux`` regularizes the flux block,
-            and ``reg_astrom`` regularizes only the shift block.
+            and ``astrom_reg`` regularizes only the shift block.
         AB, BB, bB
             Optional blocks coupling the fluxes to shift parameters.
         cg_kwargs
@@ -189,7 +189,7 @@ class SceneFitter:
             ``shifts`` (shift coefficients, ``None`` on the flux-only path)
             and ``info`` (always ``{"cg_info": 0}`` for the direct solver).
         """
-        # Flux regularization must use only the photometric ridge; reg_astrom
+        # Flux regularization must use only the photometric ridge; astrom_reg
         # is reserved for the shift block below. Three-state semantics:
         # None -> adaptive ridge 1e-6 * median positive diagonal (the
         # conditioning default), 0.0 -> genuinely no ridge, >0 -> that value.
@@ -204,18 +204,20 @@ class SceneFitter:
         # empty shift blocks (no bright member at all) fall back to flux-only
         if AB is not None and BB is not None and bB is not None and AB.shape[1] > 0:
             scale_BB = _positive_diagonal_scale(BB)
-            reg_astrom = _finite_nonnegative(getattr(config, "reg_astrom", 1e-4))
-            lam_b = reg_astrom * scale_BB
+            astrom_reg = _finite_nonnegative(getattr(config, "astrom_reg", 1e-4))
+            lam_b = astrom_reg * scale_BB
             BBreg = BB + sp.eye(BB.shape[0], format="csr") * lam_b
 
-            flux, err, shifts, info = SceneFitter._solve_flux_and_shifts(
+            flux, err, shifts, shift_cov, info = SceneFitter._solve_flux_and_shifts(
                 Areg, b, AB, BBreg, bB, config
             )
         else:
             flux, err, info = SceneFitter.solve_flux(Areg, b, config)
-            shifts = None
+            shifts, shift_cov = None, None
 
-        return SimpleNamespace(flux=flux, err=err, shifts=shifts, info=info)
+        return SimpleNamespace(
+            flux=flux, err=err, shifts=shifts, shift_cov=shift_cov, info=info
+        )
 
     @staticmethod
     def solve_flux(
@@ -298,11 +300,61 @@ class SceneFitter:
         else:
             S_w = A_w.toarray() - AB_w @ AB_w.T
         err = SceneFitter._flux_errors(S_w) / d
+        shift_cov = SceneFitter._shift_covariance(A_w, AB_w, Linv)
 
         if cfg.positivity:
             x = np.maximum(0.0, x)
 
-        return x, err, beta, {"cg_info": int(info)}
+        return x, err, beta, shift_cov, {"cg_info": int(info)}
+
+    @staticmethod
+    def _shift_covariance(
+        A_w: sp.spmatrix, AB_w: sp.spmatrix, Linv: np.ndarray
+    ) -> np.ndarray:
+        """Covariance of the unwhitened shift coefficients, fluxes marginalized.
+
+        The counterpart of :meth:`_flux_errors`, for the other block. In
+        whitened variables the joint matrix is ``[[A_w, AB_w], [AB_wᵀ, I]]``,
+        so the shift block of its inverse is
+        ``(I − AB_wᵀ A_w⁻¹ AB_w)⁻¹`` -- the shift information *after* the
+        fluxes have been allowed to absorb what they can. Unwhitening with
+        ``beta = L⁻ᵀ betaw`` gives ``Linvᵀ · cov · Linv``.
+
+        Ignoring the marginalization and taking ``BB⁻¹`` instead would be free
+        (``Linvᵀ Linv``) but wrong by the flux-shift degeneracy, which reaches
+        tens of percent once a neighbour sits about a FWHM from an anchor.
+
+        Cost is one sparse factorization of the flux block plus ``nB``
+        back-solves, and ``nB`` is 2 at the default order 0.
+
+        Parameters
+        ----------
+        A_w
+            Whitened flux block.
+        AB_w
+            Whitened flux-shift coupling, ``(nA, nB)``.
+        Linv
+            Inverse Cholesky factor of the shift block used to whiten it.
+
+        Returns
+        -------
+        ndarray
+            ``(nB, nB)`` covariance, or NaN where the factorization or the
+            inverse fails.
+        """
+        ABd = AB_w.toarray() if sp.issparse(AB_w) else np.asarray(AB_w, dtype=float)
+        nB = ABd.shape[1]
+        if nB == 0:
+            return np.zeros((0, 0), dtype=float)
+        try:
+            factor = splu((A_w.tocsc() if sp.issparse(A_w) else sp.csc_matrix(A_w)))
+            Ainv_AB = np.column_stack([factor.solve(ABd[:, k]) for k in range(nB)])
+            cov_w = np.linalg.inv(np.eye(nB) - ABd.T @ Ainv_AB)
+        except (np.linalg.LinAlgError, RuntimeError, ValueError):
+            logger.debug("[scenes] shift covariance unavailable", exc_info=True)
+            return np.full((nB, nB), np.nan, dtype=float)
+        cov = Linv.T @ cov_w @ Linv
+        return cov if np.all(np.isfinite(cov)) else np.full((nB, nB), np.nan)
 
     @staticmethod
     def _flux_errors(A, dense_threshold: int = 500) -> np.ndarray:

--- a/src/mophongo/templates.py
+++ b/src/mophongo/templates.py
@@ -506,6 +506,12 @@ class Template(Cutout2D):
         # this is the intended shift from base_data to data
         self.to_shift = np.array([0.0, 0.0], dtype=float)  # impending shift
         self.shifted = np.array([0.0, 0.0], dtype=float)  # accumulated shift
+        # Weight this template carried as an astrometric anchor in the last
+        # solve, from `FitConfig.astrom_robust`; 1.0 when the robust pass is
+        # off, did not run, or found nothing to downweight, and 0.0 for a
+        # rejected anchor. Diagnostic only -- the fit reads it from the
+        # weights array, not from here.
+        self.astrom_weight: float = 1.0
 
     def __deepcopy__(self, memo: dict) -> "Template":
         """Deep copy that shares the parent-image WCS instead of duplicating it.
@@ -1548,36 +1554,68 @@ class Templates:
             tmpl.err_pred = pred[i]
         return pred
 
-    def prune_outside_weight(self, weight: np.ndarray, rtol: float = 1e-8) -> List[Template]:
+    def prune_outside_weight(self, weight: np.ndarray, rtol: float = 0.0) -> List[Template]:
         """Remove templates with no overlap with the provided ``weight`` map.
 
         A template is discarded if all pixels belonging to its segmentation
         footprint fall on non-positive weight values. The check is performed in
         the original image coordinates using ``tmpl.slices_original``.
 
+        The test is per-template: the fraction of a template's own squared flux
+        that lands on positive weight, against ``rtol``. It used to be
+        ``wnorm > rtol * median(wnorm)`` over the set being pruned, which made
+        the verdict depend on the *company a template keeps*. Pruning a
+        260-source scene of a COSMOS F770W run on its own dropped 76 templates
+        the full-field run had kept: the scene's members are brighter than the
+        field median, so the threshold rose with them and took the faint edge
+        members with it. Anything that re-solves a subset --
+        :meth:`~mophongo.pipeline.Pipeline.refit_scene` above all, whose whole
+        premise is that a subset extracts identically -- was silently working
+        on a different source set.
+
         Parameters
         ----------
         weight : np.ndarray
             Weight map aligned with ``self.original_shape``.
+        rtol : float
+            Minimum fraction of a template's squared flux that must fall on
+            positive weight for it to be kept. ``0.0``, the default, is the
+            documented rule exactly: a single usable pixel is enough, and only
+            a template with none at all is dropped. The sum is identically zero
+            in that case, so no tolerance is needed.
+
+            Raising it is a real cut, not a numerical guard, and it bites
+            hardest where sources are most marginal. A COSMOS F770W scene on
+            the mosaic edge lost 56 of 236 templates at ``1e-3``: those members
+            genuinely have under a thousandth of themselves on usable pixels,
+            and the fit gives them enormous errors, but they are the run's
+            sources and dropping them silently changes what a refit is
+            comparing. The old default of ``1e-8`` meant something else
+            entirely -- a fraction of the *set's median* weighted norm -- and
+            is not comparable to either.
 
         Returns
         -------
         list[Template]
             Remaining templates after pruning.
         """
-        norms = []
         for tmpl in self._templates:
             sl = tmpl.slices_original
             data = tmpl.data[tmpl.slices_cutout]
             w = weight[sl]
-            wnorm = float(np.sum(data * w * data))
-            tmpl.wnorm = wnorm
-            norms.append(wnorm)
+            tmpl.wnorm = float(np.sum(data * w * data))
+            # Self-normalized coverage: what fraction of this template sits on
+            # usable pixels. Dimensionless, and a property of the template and
+            # the weight map alone.
+            total = float(np.sum(data * data))
+            tmpl.wcover = (
+                float(np.sum(data * data * (w > 0))) / total if total > 0 else 0.0
+            )
 
-        atol = rtol * np.median(norms)
+        atol = float(rtol)
         keep, dropped = [], []
         for tmpl in self._templates:
-            if tmpl.wnorm > atol:
+            if tmpl.wcover > atol:
                 keep.append(tmpl)
             else:
                 # Flag before dropping. The template objects are shared with
@@ -1591,7 +1629,8 @@ class Templates:
         if dropped:
             logger.info(
                 "pruned %d template(s) with no support on this band's weight "
-                "map (weighted L2 norm below %.3g); flagged FLAG_OUTSIDE_WEIGHT",
+                "map (under %.3g of their own flux on positive weight); "
+                "flagged FLAG_OUTSIDE_WEIGHT",
                 len(dropped), atol,
             )
             logger.debug(

--- a/src/mophongo/verification.py
+++ b/src/mophongo/verification.py
@@ -1097,8 +1097,8 @@ def run_pipeline_extension_scenario(
         reg_flux=0.0,
         fit_astrometry_niter=int(fit_astrometry_niter),
         fit_astrometry_joint=True,
-        snr_thresh_astrom=0.0,
-        scene_minimum_bright=10,
+        astrom_minimum_snr=0.0,
+        scene_minimum_anchors=10,
         aperture_diam=0.5,
         template_dilate_segmap=int(template_dilate_segmap),
     )
@@ -1695,7 +1695,7 @@ def save_scene_diagnostics(
             {
                 "id": int(scene.id),
                 "n_templates": int(len(scene.templates)),
-                "n_bright": int(np.sum(scene.is_bright)),
+                "n_anchor": int(np.sum(scene.is_bright)),
                 "bbox_y0": int(scene.bbox[0]),
                 "bbox_y1": int(scene.bbox[1]),
                 "bbox_x0": int(scene.bbox[2]),
@@ -1708,7 +1708,7 @@ def save_scene_diagnostics(
             }
         )
     table = Table(rows=rows)
-    table.sort(["n_bright", "n_templates", "id"], reverse=True)
+    table.sort(["n_anchor", "n_templates", "id"], reverse=True)
     table.write(out_dir / "scene_catalog.csv", overwrite=True)
 
     selected = scenes

--- a/src/mophongo/verification.py
+++ b/src/mophongo/verification.py
@@ -1052,7 +1052,7 @@ def run_pipeline_extension_scenario(
             flagged position-mismatched and excluded from the recovery plots.
         fit_overrides: Extra :class:`~mophongo.fit.FitConfig` keyword overrides
             merged over the scenario defaults, e.g. a per-band
-            ``aperture_diam`` or scene limits matching a production run.
+            ``phot.aperture_diam`` or scene limits matching a production run.
         target_label: Display name of the low-resolution band in plot titles
             and axis labels. The data plumbing keys that band ``f770w``
             internally regardless; this only fixes what the figures say, e.g.
@@ -1099,7 +1099,7 @@ def run_pipeline_extension_scenario(
         fit_astrometry_joint=True,
         astrom_minimum_snr=0.0,
         scene_minimum_anchors=10,
-        aperture_diam=0.5,
+        phot={"aperture_diam": 0.5},
         template_dilate_segmap=int(template_dilate_segmap),
     )
     fit_kwargs.update(fit_overrides or {})

--- a/tests/test_astrom_robust.py
+++ b/tests/test_astrom_robust.py
@@ -1,0 +1,317 @@
+"""Robust anchor weighting, exercised on synthetic anchor tables.
+
+The tables here are what :func:`mophongo.scene.measure_anchor_shifts` produces
+-- implied shift, information and reduced chi-square per anchor -- so the
+weighting can be judged on its own, without a scene, an image or a solve in the
+way.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+import numpy as np
+import pytest
+
+from mophongo.astrom_robust import AnchorWeights, robust_anchor_weights
+from mophongo.astrometry import cheb_basis
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _basis(pos: np.ndarray, order: int) -> np.ndarray:
+    """Chebyshev rows for anchors at normalized positions ``pos`` in [-1, 1]."""
+    return np.array([cheb_basis(x, y, order) for x, y in pos])
+
+
+def _table(
+    rng: np.random.Generator,
+    m: int,
+    order: int,
+    *,
+    coeff: np.ndarray | None = None,
+    sys_floor: float = 0.0,
+    info_lo: float = 1e2,
+    info_hi: float = 1e4,
+):
+    """Anchor table drawn from a known field, formal errors plus a floor.
+
+    Returns ``(eps, info, basis, coeff)`` with ``coeff`` of shape ``(2, p)``.
+    """
+    pos = rng.uniform(-1.0, 1.0, size=(m, 2))
+    B = _basis(pos, order)
+    p = B.shape[1]
+    if coeff is None:
+        coeff = np.zeros((2, p))
+        coeff[:, 0] = [0.20, -0.11]
+        if p > 1:
+            coeff[:, 1:] = rng.uniform(-0.03, 0.03, size=(2, p - 1))
+    info = 10 ** rng.uniform(np.log10(info_lo), np.log10(info_hi), size=m)
+    sigma = np.sqrt(1.0 / info + sys_floor**2)
+    eps = B @ coeff.T + rng.normal(0.0, sigma[:, None], size=(m, 2))
+    return eps, info, B, coeff
+
+
+def _plain_wls(eps: np.ndarray, info: np.ndarray, B: np.ndarray) -> np.ndarray:
+    """Information-weighted least squares -- what the solve does unweighted."""
+    root = np.sqrt(info)[:, None]
+    coeff, *_ = np.linalg.lstsq(B * root, eps * root, rcond=None)
+    return coeff.T
+
+
+# ---------------------------------------------------------------------------
+# clean data must be left alone
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("order", [0, 1, 2])
+def test_clean_anchors_keep_their_weight_and_recover_the_field(order):
+    """No outlier, no systematic: nothing is rejected and the field is right."""
+    rng = np.random.default_rng(11)
+    eps, info, B, coeff = _table(rng, 60, order)
+
+    res = robust_anchor_weights(eps, info, B)
+
+    assert res.applied
+    assert res.n_rejected == 0
+    # Tukey costs efficiency on clean data by design -- with 2m standardized
+    # residuals the largest is a couple of sigma and gets visibly downweighted.
+    # The mean is what must stay near one.
+    assert res.weight.min() > 0.15
+    assert res.weight.mean() > 0.80
+    assert res.sys_floor < 0.01
+    assert np.allclose(res.coeff, coeff, atol=0.01)
+
+
+def test_no_systematic_means_a_floor_well_below_the_formal_errors():
+    """The floor is an excess, so with none present it must be negligible.
+
+    Not identically zero: the estimator is one-sided, so the sampling scatter
+    of the median standardized residual leaks into a small positive floor. That
+    errs toward flatter weights, which is the safe direction.
+    """
+    rng = np.random.default_rng(3)
+    eps, info, B, _ = _table(rng, 80, 0, sys_floor=0.0)
+    res = robust_anchor_weights(eps, info, B)
+    assert res.sys_floor < 0.3 * np.median(1.0 / np.sqrt(info))
+
+
+# ---------------------------------------------------------------------------
+# the systematic floor
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "s_true,rtol",
+    [
+        # A floor below most of the formal errors (which span 0.010-0.098 px
+        # here) is only weakly constrained -- it is buried in the statistical
+        # scatter it has to be separated from -- so it reads low.
+        (0.01, 0.5),
+        (0.03, 0.2),
+        (0.10, 0.2),
+    ],
+)
+def test_systematic_floor_is_recovered(s_true, rtol):
+    """Excess scatter beyond the formal errors comes back as ``sys_floor``."""
+    rng = np.random.default_rng(19)
+    eps, info, B, _ = _table(rng, 200, 0, sys_floor=s_true)
+
+    res = robust_anchor_weights(eps, info, B)
+
+    assert res.applied
+    assert res.sys_floor == pytest.approx(s_true, rel=rtol)
+
+
+def test_floor_caps_the_leverage_of_a_very_bright_anchor():
+    """With a floor, weight saturates at 1/s^2 however bright the anchor is.
+
+    This is the property ``astrom_leverage_cap`` approximates with a quantile:
+    an anchor 10^4 times better determined than the floor allows must not
+    count 10^4 times more.
+    """
+    rng = np.random.default_rng(23)
+    s_true = 0.05
+    eps, info, B, _ = _table(rng, 120, 0, sys_floor=s_true)
+    # one anchor with vastly more formal information than the rest
+    info[0] = 1e8
+    eps[0] = eps[1:].mean(axis=0) + np.array([s_true, -s_true])
+
+    res = robust_anchor_weights(eps, info, B)
+    omega = res.weight * info
+
+    assert res.applied
+    # its post-weight influence is within a factor of a few of the others',
+    # not the 10^4 its raw information would buy
+    assert omega[0] < 5.0 * np.median(omega[1:])
+    assert res.weight[0] < 1e-4
+
+
+# ---------------------------------------------------------------------------
+# outlier rejection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("order", [0, 1, 2])
+def test_one_dominant_outlier_is_rejected_at_any_order(order):
+    """The failure this module exists for: brightest anchor, wrong shift."""
+    rng = np.random.default_rng(5)
+    m = 40
+    eps, info, B, coeff = _table(rng, m, order, info_lo=1e3, info_hi=1e4)
+    # a bright, extended source with a colour gradient: 30x the information of
+    # its neighbours and a half-pixel pseudo-shift that is pure morphology
+    info[0] = 30.0 * info.max()
+    eps[0] = B[0] @ coeff.T + np.array([0.5, -0.4])
+
+    naive = _plain_wls(eps, info, B)
+    res = robust_anchor_weights(eps, info, B)
+
+    assert res.applied
+    assert res.weight[0] == 0.0, "the offending anchor must be rejected outright"
+    # naive fit is dragged toward the outlier; robust fit is not
+    err_naive = np.abs(naive[:, 0] - coeff[:, 0]).max()
+    err_robust = np.abs(res.coeff[:, 0] - coeff[:, 0]).max()
+    assert err_naive > 0.05
+    assert err_robust < 0.01
+    assert err_robust < 0.1 * err_naive
+
+
+def test_a_genuinely_offset_scene_is_not_rejected():
+    """A real offset is coherent, so no anchor disagrees and none is cut.
+
+    The discriminator is disagreement with the neighbours, not shift size --
+    a scene that really has moved a long way must keep all of its anchors.
+    """
+    rng = np.random.default_rng(29)
+    eps, info, B, coeff = _table(rng, 50, 0)
+    eps += np.array([1.7, -2.3])  # whole scene displaced
+
+    res = robust_anchor_weights(eps, info, B)
+
+    assert res.applied
+    assert res.n_rejected == 0
+    assert np.allclose(res.coeff[:, 0], coeff[:, 0] + np.array([1.7, -2.3]), atol=0.01)
+
+
+def test_a_minority_of_outliers_does_not_capture_the_fit():
+    """Three bright liars against thirty honest anchors lose."""
+    rng = np.random.default_rng(31)
+    eps, info, B, coeff = _table(rng, 33, 0, info_lo=1e3, info_hi=3e3)
+    for i in (0, 1, 2):
+        info[i] = 50.0 * info.max()
+        eps[i] = coeff[:, 0] + np.array([0.6, 0.6])
+
+    res = robust_anchor_weights(eps, info, B)
+
+    assert res.n_rejected >= 3
+    assert np.allclose(res.coeff[:, 0], coeff[:, 0], atol=0.02)
+
+
+# ---------------------------------------------------------------------------
+# chi2 inflation
+# ---------------------------------------------------------------------------
+
+
+def test_chi2_inflation_downweights_a_stamp_that_does_not_fit():
+    """An anchor whose own stamp misfits is trusted less, outlier or not."""
+    rng = np.random.default_rng(37)
+    eps, info, B, _ = _table(rng, 40, 0)
+    chi2 = np.ones(40)
+    chi2[0] = 25.0  # unmodelled structure after its private shift is removed
+
+    plain = robust_anchor_weights(eps, info, B)
+    inflated = robust_anchor_weights(eps, info, B, chi2_red=chi2)
+
+    assert inflated.weight[0] < 0.1 * plain.weight[0]
+    # everyone else is untouched
+    assert np.allclose(inflated.weight[1:], plain.weight[1:], rtol=0.2)
+
+
+def test_chi2_inflation_stands_down_when_everything_fits_absurdly_well():
+    """Ratios between numbers far inside the noise are roundoff, not evidence."""
+    rng = np.random.default_rng(83)
+    eps, info, B, _ = _table(rng, 40, 0)
+    chi2 = rng.uniform(1e-30, 1e-28, size=40)  # noiseless-model roundoff
+
+    plain = robust_anchor_weights(eps, info, B)
+    tiny = robust_anchor_weights(eps, info, B, chi2_red=chi2)
+
+    assert np.allclose(plain.weight, tiny.weight)
+
+
+def test_chi2_inflation_is_relative_so_a_global_offset_does_nothing():
+    """Correlated pixels bias every reduced chi-square the same way."""
+    rng = np.random.default_rng(41)
+    eps, info, B, _ = _table(rng, 40, 0)
+    chi2 = rng.uniform(0.8, 1.2, size=40)
+
+    a = robust_anchor_weights(eps, info, B, chi2_red=chi2)
+    b = robust_anchor_weights(eps, info, B, chi2_red=7.5 * chi2)
+
+    assert np.allclose(a.weight, b.weight)
+
+
+# ---------------------------------------------------------------------------
+# gates
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("order,m", [(0, 4), (1, 5), (2, 10)])
+def test_gate_leaves_small_scenes_alone(order, m):
+    """Below 2p anchors (or ``min_anchors``) there is nothing to judge.
+
+    The gate is ``max(min_anchors, 2p)``: 5, 6 and 12 for orders 0, 1 and 2.
+    """
+    rng = np.random.default_rng(43)
+    eps, info, B, _ = _table(rng, m, order)
+
+    res = robust_anchor_weights(eps, info, B, min_anchors=5)
+
+    assert not res.applied
+    assert np.all(res.weight == 1.0)
+    assert "required" in res.reason
+
+
+def test_single_anchor_is_a_no_op():
+    """One anchor: the weight is a global scale and cannot move the field."""
+    res = robust_anchor_weights(
+        np.array([[0.2, -0.1]]), np.array([1e4]), np.ones((1, 1))
+    )
+    assert not res.applied
+    assert res.weight == pytest.approx(1.0)
+
+
+def test_non_finite_anchors_are_dropped_not_propagated():
+    rng = np.random.default_rng(47)
+    eps, info, B, coeff = _table(rng, 30, 0)
+    eps[0] = np.nan
+    info[1] = 0.0
+    info[2] = -1.0
+
+    res = robust_anchor_weights(eps, info, B)
+
+    assert res.applied
+    assert np.all(res.weight[:3] == 0.0)
+    assert np.all(np.isfinite(res.weight))
+    assert np.allclose(res.coeff[:, 0], coeff[:, 0], atol=0.02)
+
+
+def test_shape_mismatch_raises():
+    with pytest.raises(ValueError, match="anchor count"):
+        robust_anchor_weights(np.zeros((5, 2)), np.ones(4), np.ones((5, 1)))
+
+
+def test_weights_never_exceed_unity():
+    """``lev_w`` is a downweight; it must never amplify an anchor."""
+    rng = np.random.default_rng(53)
+    for seed_order in (0, 1, 2):
+        eps, info, B, _ = _table(rng, 60, seed_order, sys_floor=0.02)
+        res = robust_anchor_weights(eps, info, B)
+        assert res.weight.max() <= 1.0
+        assert res.weight.min() >= 0.0

--- a/tests/test_astrometry.py
+++ b/tests/test_astrometry.py
@@ -60,8 +60,8 @@ def _run_scenes(templates, science, weight, cfg):
         science,
         weight,
         coupling_thresh=cfg.scene_coupling_thresh,
-        snr_thresh_astrom=cfg.snr_thresh_astrom,
-        minimum_bright=cfg.scene_minimum_bright,
+        astrom_minimum_snr=cfg.astrom_minimum_snr,
+        minimum_bright=cfg.scene_minimum_anchors,
     )
     for scene in scenes:
         scene.set_band(science, weight, config=cfg)
@@ -237,8 +237,8 @@ def test_scene_solver_recovers_known_shift():
 
     cfg = FitConfig(
         fit_astrometry_joint=True,
-        snr_thresh_astrom=3.0,
-        scene_minimum_bright=2,
+        astrom_minimum_snr=3.0,
+        scene_minimum_anchors=2,
         scene_coupling_thresh=0.01,
         astrom_kwargs={"poly": {"order": 0}, "gp": {"length_scale": 400}},
         # synthetic data with a known shift: measure the solver undamped, so the
@@ -297,8 +297,8 @@ def test_scene_shift_uncertainty_scales_with_psf_width():
 
     cfg = FitConfig(
         fit_astrometry_joint=True,
-        snr_thresh_astrom=3.0,
-        scene_minimum_bright=2,
+        astrom_minimum_snr=3.0,
+        scene_minimum_anchors=2,
         scene_coupling_thresh=0.01,
         astrom_kwargs={"poly": {"order": 0}, "gp": {"length_scale": 400}},
         # synthetic data with a known shift: measure the solver undamped, so the
@@ -341,7 +341,7 @@ def test_scene_shift_depends_on_alpha0_scale():
     The shift signal is bB ∝ alpha0 × image_gradient and the gradient information
     matrix BB ∝ alpha0².  Their ratio shift ≈ bB/BB ∝ 1/alpha0.  When alpha0 is
     scaled by factor k, the recovered shift should scale by 1/k.  This confirms
-    that the old reg_astrom flux bias (alpha0 ≈ 0.57×) was inflating shifts by ~1.75×.
+    that the old astrom_reg flux bias (alpha0 ≈ 0.57×) was inflating shifts by ~1.75×.
     """
     images, segmap, catalog, psfs, truth, wht = make_simple_data(
         nsrc=10, size=101, peak_snr=30, seed=55
@@ -360,8 +360,8 @@ def test_scene_shift_depends_on_alpha0_scale():
 
     cfg = FitConfig(
         fit_astrometry_joint=True,
-        snr_thresh_astrom=0.0,
-        scene_minimum_bright=1,
+        astrom_minimum_snr=0.0,
+        scene_minimum_anchors=1,
         scene_coupling_thresh=0.005,
         astrom_kwargs={"poly": {"order": 0}, "gp": {"length_scale": 400}},
     )
@@ -452,8 +452,8 @@ def test_scene_shift_iteration_converges():
 
     cfg = FitConfig(
         fit_astrometry_joint=True,
-        snr_thresh_astrom=3.0,
-        scene_minimum_bright=2,
+        astrom_minimum_snr=3.0,
+        scene_minimum_anchors=2,
         scene_coupling_thresh=0.01,
         astrom_kwargs={"poly": {"order": 0}, "gp": {"length_scale": 400}},
         # synthetic data with a known shift: measure the solver undamped, so the

--- a/tests/test_moffat_recovery.py
+++ b/tests/test_moffat_recovery.py
@@ -366,7 +366,7 @@ def test_moffat_flux_recovery(tmp_path, scenario, ndilate, extend):
         catalog=catalog, weights=fit_wht, kernels=fit_kernels,
         psfs=fit_psfs,
         extend_templates=extend or "none",
-        config=FitConfig(snr_thresh_astrom=0.0),
+        config=FitConfig(astrom_minimum_snr=0.0),
     )
     table["flux_true"] = catalog["flux_true"]
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -689,7 +689,7 @@ def test_pipeline_prebuilt_native_templates_recover_scalar_fluxes():
             fit_astrometry_niter=0,
             fit_astrometry_joint=False,
             aperture_diam=None,
-            snr_thresh_astrom=0.0,
+            astrom_minimum_snr=0.0,
         ),
     )
 
@@ -838,8 +838,8 @@ def test_scene_results_do_not_depend_on_scene_order(monkeypatch):
     wcs.wcs.cdelt = [-1e-5, 1e-5]
     wcs.wcs.ctype = ["RA---TAN", "DEC--TAN"]
     config = FitConfig(
-        fit_astrometry_niter=5, astrom_shift_tol=0.004, snr_thresh_astrom=5.0,
-        astrom_isolation_thresh=0.0, scene_minimum_bright=2,
+        fit_astrometry_niter=5, astrom_shift_tol=0.004, astrom_minimum_snr=5.0,
+        astrom_isolation_thresh=0.0, scene_minimum_anchors=2,
     )
 
     def fit():
@@ -979,7 +979,7 @@ def _shift_field_pipeline(tmp_path, order, nsrc=24, size=161, offset=(0.0, 0.0))
         fit_astrometry_niter=2,
         astrom_model="poly",
         astrom_kwargs={"poly": {"order": order}, "gp": {"length_scale": 400}},
-        snr_thresh_astrom=0.0,
+        astrom_minimum_snr=0.0,
         astrom_isolation_thresh=0.0,
     )
     pipe = pipeline.Pipeline(
@@ -1160,7 +1160,7 @@ def test_shift_field_arrow_points_from_template_to_measured(tmp_path):
         config=FitConfig(
             fit_astrometry_niter=8, astrom_model="poly",
             astrom_kwargs={"poly": {"order": 0}, "gp": {"length_scale": 400}},
-            snr_thresh_astrom=0.0, astrom_isolation_thresh=0.0,
+            astrom_minimum_snr=0.0, astrom_isolation_thresh=0.0,
         ),
     )
     pipe.run_config = pipeline.RunConfig(
@@ -1216,6 +1216,104 @@ def test_scene_catalog_carries_total_shift(tmp_path):
         assert not np.allclose(by_id[int(s.id)], last, atol=1e-3)
         checked += 1
     assert checked, "no scene had non-trivial applied shifts"
+
+
+def test_scenes_extension_reconstructs_the_anchor_solution(tmp_path):
+    """``write_outputs`` stores the solved shift field, exactly, in the fit table.
+
+    The catalog's dx, dy is the applied-shift field sampled at a scene centre,
+    which is a summary. The SCENES extension carries the coefficients the
+    anchors produced, so a later reconstruction evaluates the same field the
+    fit used rather than a refit of it -- and it is written before the figure
+    loop, which is where a band dies.
+    """
+    import matplotlib
+    matplotlib.use("Agg")
+    from astropy.io import fits
+    from astropy.table import Table as _Table
+
+    from mophongo.astrometry import AstroCorrect
+
+    out = tmp_path / "scn"
+    out.mkdir()
+    pipe = _shift_field_pipeline(out, 0, offset=(0.6, -0.4))
+    fits.writeto(out / "hi.fits", np.asarray(pipe.images[0], np.float32), overwrite=True)
+    pipe.run_config.sci_hi = str(out / "hi.fits")
+    pipe.run_config.save_stamps = False
+    pipe.run_config.scene_plots = False
+    pipe.write_outputs()
+
+    path = out / "t_fit_table.fits"
+    with fits.open(path) as hdul:
+        assert "SCENES" in [h.name for h in hdul]
+    # the fit table itself is still the first table HDU
+    assert "id" in _Table.read(path, hdu=1).colnames
+
+    scenes = _Table.read(path, hdu="SCENES")
+    assert len(scenes) == len(pipe.scenes)
+
+    checked = 0
+    for row, s in zip(scenes, pipe.scenes):
+        if row["shift_order"] < 0:
+            assert s.shifts is None or len(s.shifts) < 2
+            continue
+        rebuilt = AstroCorrect.build_poly_predictor(
+            np.asarray(row["shift_coeff"][: row["n_coeff"]]),
+            row["shift_x0"], row["shift_y0"], int(row["shift_order"]),
+            row["shift_sx"], row["shift_sy"],
+        )
+        live = AstroCorrect.build_poly_predictor(
+            np.asarray(s.shifts, float), *s.shift_basis[1],
+            int(row["shift_order"]), *s.shift_basis[2],
+        )
+        xs = np.array([5.0, 40.0, 95.0])
+        ys = np.array([12.0, 55.0, 88.0])
+        np.testing.assert_allclose(np.array(rebuilt(xs, ys)),
+                                   np.array(live(xs, ys)), atol=0, rtol=0)
+        checked += 1
+    assert checked, "no scene solved shifts, so nothing was reconstructed"
+
+
+def test_scene_catalog_link_takes_the_viewer_root_from_the_config(tmp_path):
+    """Fields disagree on whether the release is in the FITSMap path.
+
+    COSMOS serves from ``/cosmos`` and UDS from ``/uds/DR0``, so the root is
+    config, not something the code can assemble from the field name.
+    """
+    import matplotlib
+    matplotlib.use("Agg")
+    from astropy.io import fits
+    from astropy.table import Table as _Table
+
+    def _link(viewer):
+        out = tmp_path / f"v{abs(hash(viewer)) % 10000}"
+        out.mkdir()
+        pipe = _shift_field_pipeline(out, 0, offset=(0.1, 0.0))
+        fits.writeto(out / "hi.fits", np.asarray(pipe.images[0], np.float32),
+                     overwrite=True)
+        pipe.run_config.sci_hi = str(out / "hi.fits")
+        pipe.run_config.save_stamps = False
+        pipe.run_config.scene_plots = False
+        pipe.run_config.minerva_viewer = viewer
+        pipe.write_outputs()
+        cat = _Table.read(out / "t_scene_catalog.csv", format="ascii.csv")
+        return cat["minerva_link"][0] if "minerva_link" in cat.colnames else None
+
+    full = _link("https://minerva.colorado.edu/uds/DR0")
+    assert full.startswith("https://minerva.colorado.edu/uds/DR0/?ra=")
+
+    # a bare path is the pre-URL spelling and still resolves against FITSMAP_URL
+    bare = _link("cosmos")
+    assert bare.startswith("https://minerva.colorado.edu/cosmos/?ra=")
+
+    # a different host is honoured rather than rewritten
+    other = _link("https://example.org/maps/uds")
+    assert other.startswith("https://example.org/maps/uds/?ra=")
+
+    # unset drops the column: a guessed URL is worse than no URL, since the
+    # fields disagree on whether the release belongs in the path
+    assert _link(None) is None
+    assert _link("") is None
 
 
 def test_astrometry_passes_skip_converged_scenes(monkeypatch):
@@ -1485,7 +1583,7 @@ def test_refit_scene_freezes_membership_and_restores_state(tmp_path):
     assert same.changed == {} and same.baseline is None and same.dchi2 == 0.0
 
     # a full config replacement is the other way in; the two are exclusive
-    cfg = dc_replace(pipe.config, snr_thresh_astrom=99.0)
+    cfg = dc_replace(pipe.config, astrom_minimum_snr=99.0)
     assert pipe.refit_scene(scene_id, config=cfg).changed
     with pytest.raises(ValueError, match="either config="):
         pipe.refit_scene(scene_id, config=cfg, extend_mode="none")
@@ -1503,3 +1601,87 @@ def test_refit_scene_freezes_membership_and_restores_state(tmp_path):
     plt.close(fig)
     with pytest.raises(ValueError, match="no baseline solve"):
         same.plot_scene("baseline")
+
+
+def test_upsampled_band_keeps_its_weight_on_the_same_grid(tmp_path):
+    """Image and weight must stay on one grid across repeated band passes.
+
+    ``_convolved_templates`` upsamples the band onto the reference grid and
+    sets ``wcs[ifilt] = wcs[0]``. The upsampled weight used to stay in a local,
+    so afterwards the instance held a reference-grid image beside a native-grid
+    weight -- and the collapsed WCS hid it, because the next call computes
+    ``k = 1`` and upsamples neither. Slicing that weight with reference-grid
+    coordinates is not an error in numpy; it clips and returns the wrong
+    region, so templates over covered sky were pruned as uncovered and scene
+    residuals were masked over valid pixels.
+    """
+    from astropy.wcs import WCS
+
+    from mophongo.fit import FitConfig
+    from mophongo import utils as mutils
+
+    images, segmap, catalog, psfs, _truth, wht = make_simple_data(
+        seed=3, nsrc=12, size=120, ndilate=2, peak_snr=30.0
+    )
+    kernel = mutils.matching_kernel(psfs[0], psfs[1])
+
+    def _wcs(scale):
+        w = WCS(naxis=2)
+        w.wcs.crpix = [1.0, 1.0]
+        w.wcs.crval = [150.0, 2.0]
+        w.wcs.cdelt = [-scale, scale]
+        w.wcs.ctype = ["RA---TAN", "DEC--TAN"]
+        return w
+
+    # band on a 2x coarser grid, so the upsample path runs
+    wcs_hi, wcs_lo = _wcs(1e-5), _wcs(2e-5)
+    lo = images[1][::2, ::2].copy()
+    wht_lo = wht[1][::2, ::2].copy()
+
+    pipe = pipeline.Pipeline(
+        [images[0], lo], segmap, catalog=catalog,
+        weights=[wht[0], wht_lo], kernels=[None, kernel], psfs=psfs,
+        wcs=[wcs_hi, wcs_lo], config=FitConfig(fit_astrometry_niter=0),
+    )
+    pipe.fit_bin_factors = []
+    pipe._prepare_hi_templates(pipe.catalog, pipe.config)
+    _, weights_i = pipe._convolved_templates(1, pipe.config)
+
+    assert weights_i.shape == pipe.images[1].shape
+    assert pipe.weights[1].shape == pipe.images[1].shape
+
+    # a second pass over the same band -- what a refit does -- must not now
+    # pair a native weight with an upsampled image
+    _, weights_again = pipe._convolved_templates(1, pipe.config)
+    assert weights_again.shape == pipe.images[1].shape
+
+
+def test_convolved_templates_rejects_a_weight_on_the_wrong_grid(tmp_path):
+    """The pairing is checked, not trusted."""
+    import pytest as _pytest
+    from astropy.wcs import WCS
+
+    from mophongo.fit import FitConfig
+    from mophongo import utils as mutils
+
+    images, segmap, catalog, psfs, _truth, wht = make_simple_data(
+        seed=3, nsrc=12, size=120, ndilate=2, peak_snr=30.0
+    )
+    kernel = mutils.matching_kernel(psfs[0], psfs[1])
+    w = WCS(naxis=2)
+    w.wcs.crpix = [1.0, 1.0]
+    w.wcs.crval = [150.0, 2.0]
+    w.wcs.cdelt = [-1e-5, 1e-5]
+    w.wcs.ctype = ["RA---TAN", "DEC--TAN"]
+
+    pipe = pipeline.Pipeline(
+        [images[0], images[1]], segmap, catalog=catalog,
+        weights=[wht[0], wht[1]], kernels=[None, kernel], psfs=psfs,
+        wcs=[w, w], config=FitConfig(fit_astrometry_niter=0),
+    )
+    pipe.fit_bin_factors = []
+    pipe._prepare_hi_templates(pipe.catalog, pipe.config)
+    pipe.weights[1] = pipe.weights[1][::2, ::2].copy()  # wrong grid
+
+    with _pytest.raises(RuntimeError, match="same grid"):
+        pipe._convolved_templates(1, pipe.config)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -688,7 +688,7 @@ def test_pipeline_prebuilt_native_templates_recover_scalar_fluxes():
             reg_flux=0.0,
             fit_astrometry_niter=0,
             fit_astrometry_joint=False,
-            aperture_diam=None,
+            phot={"aperture_diam": None},
             astrom_minimum_snr=0.0,
         ),
     )

--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -34,10 +34,10 @@ def _write_config(tmp_path, extra=None):
 def test_config_roundtrip_with_comments(tmp_path):
     trial = {"center": [34.4, -5.26], "radius": 0.5}
     cfg = RunConfig.from_json(
-        _write_config(tmp_path, {"psf_size": None, "trial": trial})
+        _write_config(tmp_path, {"psf": {"size": None}, "trial": trial})
     )
     assert cfg.name == "test_run"
-    assert cfg.psf_size is None
+    assert cfg.psf.size is None
     assert cfg.trial_geometry() == ((34.4, -5.26), 0.5, 60.0)
     out = tmp_path / "echo.json"
     cfg.to_json(out)
@@ -49,6 +49,30 @@ def test_retired_trial_keys_raise(tmp_path):
     for extra in ({"r_trial": 0.5}, {"trial_center": [34.4, -5.26]}):
         with pytest.raises(ValueError, match="replaced by a single `trial`"):
             RunConfig.from_json(_write_config(tmp_path, extra))
+
+
+def test_retired_psf_keys_raise(tmp_path):
+    """The flat psf_* keys moved into `psf`, and expect_frames is gone."""
+    for extra in ({"psf_dir": "PSF"}, {"psf_size": 4.0},
+                  {"expect_frames": [297, 229]}):
+        with pytest.raises(ValueError, match='"psf" block|expect_frames'):
+            RunConfig.from_json(_write_config(tmp_path, extra))
+
+
+def test_psf_block_parses_and_round_trips(tmp_path):
+    """A `psf` object becomes a PsfConfig and survives to_json/from_json."""
+    from mophongo.pipeline import PsfConfig
+
+    psf = {"dir": "PSF", "pattern_hi": "A", "size": None, "workers": 4}
+    cfg = RunConfig.from_json(_write_config(tmp_path, {"psf": psf}))
+    assert isinstance(cfg.psf, PsfConfig)
+    assert (cfg.psf.dir, cfg.psf.size, cfg.psf.workers) == ("PSF", None, 4)
+    assert cfg.psf.date_mode == "all"  # defaults fill the rest
+    out = tmp_path / "echo.json"
+    cfg.to_json(out)
+    assert RunConfig.from_json(out) == cfg
+    with pytest.raises(ValueError, match="unknown psf config keys"):
+        RunConfig.from_json(_write_config(tmp_path, {"psf": {"psf_dir": "PSF"}}))
 
 
 def test_trial_geometry_validates():
@@ -78,12 +102,12 @@ def test_blur_resolution_modes(tmp_path):
 
     assert pipe._blur_fwhm() == DEFAULT_PSF_GAUSSIAN_FWHM_ARCSEC["f770w"]
 
-    pipe.run_config.psf_blur_fwhm = 0.1
+    pipe.run_config.psf.blur_fwhm = 0.1
     assert pipe._blur_fwhm() == 0.1
-    pipe.run_config.psf_blur_fwhm = None
+    pipe.run_config.psf.blur_fwhm = None
     assert pipe._blur_fwhm() is None
     # unknown filter with "default" -> no broadening
-    pipe.run_config.psf_blur_fwhm = "default"
+    pipe.run_config.psf.blur_fwhm = "default"
     pipe.run_config.filter_lo = "f9999w"
     assert pipe._blur_fwhm() is None
 
@@ -107,9 +131,9 @@ def test_run_all_calls_steps_in_order(tmp_path, monkeypatch):
 
 
 def test_size_kw_native_vs_arcsec(tmp_path):
-    pipe = Pipeline.from_config(_write_config(tmp_path, {"psf_size": 4.0}))
+    pipe = Pipeline.from_config(_write_config(tmp_path, {"psf": {"size": 4.0}}))
     assert pipe._size_kw() == {"size": 4.0}
-    pipe.run_config.psf_size = None
+    pipe.run_config.psf.size = None
     assert pipe._size_kw() == {"size": None, "ee_fraction": None}
 
 
@@ -148,7 +172,7 @@ def test_save_config_writes_full_snapshot(tmp_path):
     from mophongo.fit import FitConfig
 
     pipe = Pipeline.from_config(
-        _write_config(tmp_path, {"fit": {"scene_minimum_bright": 3}})
+        _write_config(tmp_path, {"fit": {"scene_minimum_anchors": 3}})
     )
     out = pipe.save_config()
     assert out == pipe.f_config == pipe.out_dir / "test_run.json"
@@ -170,7 +194,7 @@ def test_save_config_writes_full_snapshot(tmp_path):
     }
     assert unused  # guard: the pruning groups exist in FitConfig
     assert set(cfg2.fit) == {f.name for f in dc_fields(FitConfig)} - unused
-    assert cfg2.fit["scene_minimum_bright"] == 3
+    assert cfg2.fit["scene_minimum_anchors"] == 3
     FitConfig(**cfg2.fit)
 
 
@@ -511,10 +535,10 @@ def _stdpsf(path, mjd=None):
                  detector="NRCA1", filt="F444W", overwrite=True)
 
 
-def _pipe_with(tmp_path, psf_dir, csv, **extra):
+def _pipe_with(tmp_path, psf_dir, csv, **psf_extra):
     return Pipeline.from_config(_write_config(tmp_path, {
-        "psf_dir": str(psf_dir), "psf_date_mode": "all",
-        "csv_hi": str(csv), **extra}))
+        "psf": {"dir": str(psf_dir), "date_mode": "all", **psf_extra},
+        "csv_hi": str(csv)}))
 
 
 def _csv(path, mjds):
@@ -553,7 +577,7 @@ def test_missing_psf_dates_is_the_set_difference(tmp_path):
     assert pipe._missing_psf_dates(PATTERN, str(csv)) == [60003.0]
 
     assert _pipe_with(tmp_path, psf_dir, csv,
-                      psf_provenance="off")._missing_psf_dates(PATTERN, str(csv)) == []
+                      provenance="off")._missing_psf_dates(PATTERN, str(csv)) == []
 
 
 def test_a_single_epoch_set_is_seen_as_incomplete(tmp_path):
@@ -625,12 +649,12 @@ def test_missing_epochs_without_autobuild_warn_or_raise(tmp_path, caplog):
             def load_jwst_stdpsf(**kw):
                 return None
 
-    warned = _pipe_with(tmp_path, psf_dir, csv, psf_autobuild=False)
+    warned = _pipe_with(tmp_path, psf_dir, csv, autobuild=False)
     with caplog.at_level(logging.WARNING):
         warned._load_epsf(_Dpsf(), PATTERN, str(csv), "hi")
     assert "MJD60001" in caplog.text
 
     strict = _pipe_with(tmp_path, psf_dir, csv,
-                        psf_autobuild=False, psf_provenance="error")
+                        autobuild=False, provenance="error")
     with pytest.raises(FileNotFoundError, match="MJD60001"):
         strict._load_epsf(_Dpsf(), PATTERN, str(csv), "hi")

--- a/tests/test_pipeline_provenance.py
+++ b/tests/test_pipeline_provenance.py
@@ -166,7 +166,7 @@ def test_psf_size_larger_than_grid_fov_warns(caplog):
     obj.run_config = RunConfig(
         name="x", out_dir="x", sci_hi="a.fits", segmap="s.fits",
         catalog="c.fits", sci_lo="lo.fits", wht_lo="w.fits",
-        csv_hi="h.csv", csv_lo="l.csv", psf_size=4.0,
+        csv_hi="h.csv", csv_lo="l.csv", psf={"size": 4.0},
     )
     meta = {"UDS_MIRI_F770W_MJD59790_FOV11_GRID9_OS4": {"fov": 11.2},
             "UDS_MIRI_F770W_MJD59949_FOV3_GRID9_OS4": {"fov": 3.1},
@@ -178,12 +178,12 @@ def test_psf_size_larger_than_grid_fov_warns(caplog):
     assert "exceeds the field of view of 1 of 3" in caplog.text
     assert "FOV=3.1" in caplog.text
 
-    # every grid wide enough, and an unset psf_size, say nothing
+    # every grid wide enough, and an unset psf.size, say nothing
     caplog.clear()
     with caplog.at_level(logging.WARNING, logger="mophongo.pipeline"):
-        obj.run_config.psf_size = 2.0
+        obj.run_config.psf.size = 2.0
         obj._check_psf_size_fits_grids(dpsf, "lo")
-        obj.run_config.psf_size = None
+        obj.run_config.psf.size = None
         obj._check_psf_size_fits_grids(dpsf, "lo")
     assert caplog.text == ""
 
@@ -196,11 +196,11 @@ def test_repair_halo_pattern_derivation():
         name="x", out_dir="x", sci_hi="a.fits", segmap="s.fits",
         catalog="c.fits", sci_lo="lo.fits", wht_lo="w.fits",
         csv_hi="h.csv", csv_lo="l.csv",
-        pattern_hi=r"UDS_NRC.._F444W_MJD\d+_GRID25_OS4",
+        psf={"pattern_hi": r"UDS_NRC.._F444W_MJD\d+_GRID25_OS4"},
     )
     assert obj._repair_halo_pattern() == \
         r"UDS_NRC.._F444W_MJD\d+_FOV30_GRID1_OS4"
-    obj.run_config.pattern_hi = "garbage"
+    obj.run_config.psf.pattern_hi = "garbage"
     assert obj._repair_halo_pattern() == ""
 
 
@@ -412,8 +412,8 @@ def test_psf_factory_parallel_defaults_and_job_uniqueness(tmp_path, monkeypatch)
 
 
 def test_psf_workers_and_provenance_reach_the_factory(tmp_path, monkeypatch):
-    """``RunConfig.psf_workers``/``psf_provenance`` are wired, not decorative."""
-    from mophongo.pipeline import RunConfig
+    """``PsfConfig.workers``/``PsfConfig.provenance`` are wired, not decorative."""
+    from mophongo.pipeline import PsfConfig
 
-    assert RunConfig.psf_workers == 1
-    assert RunConfig.psf_provenance == "warn"
+    assert PsfConfig.workers == 1
+    assert PsfConfig.provenance == "warn"

--- a/tests/test_scene_astrometry_blocks.py
+++ b/tests/test_scene_astrometry_blocks.py
@@ -425,7 +425,7 @@ def test_a_single_anchor_still_solves_the_order_zero_shift():
     )
     assert AB.shape[1] == 2, "one anchor must still open the two shift columns"
 
-    flux, _err, shifts, _info = SceneFitter._solve_flux_and_shifts(
+    flux, _err, shifts, _cov, _info = SceneFitter._solve_flux_and_shifts(
         A.tocsr(), b, AB, BB, bB, FitConfig(),
     )
     assert shifts is not None and len(shifts) == 2

--- a/tests/test_scene_astrometry_robust.py
+++ b/tests/test_scene_astrometry_robust.py
@@ -1,0 +1,891 @@
+"""Per-anchor shift measurement and robust weighting, at scene level.
+
+Two things are checked here that the pure-numpy tests in
+``test_astrom_robust.py`` cannot see:
+
+* :func:`~mophongo.scene.measure_anchor_shifts` measures what it claims to --
+  the implied displacement, its information, and the part of the residual that
+  a displacement cannot explain;
+* a scene whose brightest anchor lies gets the right shift with
+  ``FitConfig.astrom_robust`` on, and the wrong one with it off.
+
+Scenes are noiseless and built from the exact linearized model, so any error is
+the estimator's own.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+import numpy as np
+import pytest
+
+from mophongo.fit import FitConfig
+from mophongo.scene import (
+    Scene,
+    _bbox_union,
+    _scene_residual,
+    assemble_scene_system_AB,
+    make_scene_basis,
+    measure_anchor_shifts,
+)
+from mophongo.scene_fitter import SceneFitter, build_normal
+from mophongo.templates import Template
+
+NY = NX = 320
+HALF = 12
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _stamp(xc: float, yc: float, sigma: float, skew: float = 0.0) -> np.ndarray:
+    n = 2 * HALF + 1
+    x0, y0 = int(round(xc)) - HALF, int(round(yc)) - HALF
+    yy, xx = np.mgrid[y0 : y0 + n, x0 : x0 + n]
+    r2 = ((xx - xc) / sigma) ** 2 + ((yy - yc) / sigma) ** 2
+    g = np.clip(np.exp(-0.5 * r2) * (1.0 + skew * (xx - xc) / sigma), 0.0, None)
+    return g / g.sum()
+
+
+def _tmpl(xc: float, yc: float, sigma: float, label: int, skew: float = 0.0) -> Template:
+    x0, y0 = int(round(xc)) - HALF, int(round(yc)) - HALF
+    return Template.from_stamp(
+        _stamp(xc, yc, sigma, skew), (x0, y0), (xc, yc), (NY, NX), label=label
+    )
+
+
+def _shifted(stamp: np.ndarray, shift: tuple[float, float]) -> np.ndarray:
+    """First-order displacement of ``stamp`` -- the exact model of the solve."""
+    gy, gx = np.gradient(stamp.astype(float))
+    return stamp - shift[0] * gx - shift[1] * gy
+
+
+def _grid(n: int = 12, sigma: float = 2.5) -> list[Template]:
+    """``n`` well-separated Gaussians on a coarse grid."""
+    out = []
+    k = 0
+    for row in range(3):
+        for col in range(4):
+            if k >= n:
+                break
+            out.append(
+                _tmpl(45.0 + 75.0 * col, 45.0 + 100.0 * row, sigma, label=k + 1)
+            )
+            k += 1
+    return out
+
+
+def _paint(
+    templates: list[Template],
+    fluxes: np.ndarray,
+    shifts: list[tuple[float, float]],
+    stamps: list[np.ndarray] | None = None,
+) -> np.ndarray:
+    """Image from per-source flux, shift and (optionally) a different profile.
+
+    ``stamps`` lets a source be *painted* with a profile the template does not
+    have, which is how a colour gradient shows up: the residual then holds
+    structure no displacement can absorb.
+    """
+    img = np.zeros((NY, NX), dtype=float)
+    for i, (t, f, sh) in enumerate(zip(templates, fluxes, shifts)):
+        src = t.data if stamps is None else stamps[i]
+        img[t.slices_original] += f * _shifted(src, sh)[t.slices_cutout]
+    return img
+
+
+def _cfg(**kw) -> FitConfig:
+    base = dict(
+        reg_flux=0.0,
+        astrom_reg=0.0,
+        positivity=False,
+        fit_astrometry_joint=True,
+        fit_astrometry_niter=1,
+        astrom_minimum_snr=0.0,
+        astrom_isolation_thresh=0.0,
+        astrom_leverage_cap=None,
+        astrom_damping=1.0,
+    )
+    base.update(kw)
+    return FitConfig(**base)
+
+
+def _solve_scene(templates, image, weights, cfg):
+    scn = Scene(
+        id=1,
+        templates=templates,
+        fitter=SceneFitter(),
+        bbox=_bbox_union(templates),
+    )
+    scn.set_band(image, weights, config=cfg)
+    scn.solve(config=cfg, apply_shifts=False)
+    return scn
+
+
+# ---------------------------------------------------------------------------
+# measure_anchor_shifts
+# ---------------------------------------------------------------------------
+
+
+def test_anchor_shift_is_recovered_exactly_for_isolated_anchors():
+    """Noiseless, isolated, exact model: eps is the injected shift."""
+    shift = (0.17, -0.09)
+    tm = _grid(6)
+    f = np.array([100.0, 60.0, 40.0, 30.0, 20.0, 15.0])
+    img = _paint(tm, f, [shift] * len(tm))
+    W = np.ones((NY, NX))
+
+    resid, y0, x0 = _scene_residual(tm, img, np.zeros(len(tm)))
+    assert np.allclose(resid, img[y0 : y0 + resid.shape[0], x0 : x0 + resid.shape[1]])
+
+    A, b, _ = build_normal(tm, img, W)
+    flux0 = SceneFitter.solve(A, b, config=_cfg()).flux
+    resid, y0, x0 = _scene_residual(tm, img, flux0)
+    eps, info, chi2 = measure_anchor_shifts(
+        tm, resid, W, (y0, x0), range(len(tm)), flux0
+    )
+
+    assert np.allclose(eps, np.array(shift), atol=1e-6)
+    assert np.all(info > 0)
+    # a pure displacement lives entirely in the gradient span, so nothing is
+    # left once it is projected out
+    assert np.all(chi2 < 1e-12)
+
+
+def test_information_scales_as_flux_squared():
+    """The leverage problem in one assertion."""
+    tm = _grid(2)
+    f = np.array([100.0, 10.0])
+    img = _paint(tm, f, [(0.1, 0.1)] * 2)
+    W = np.ones((NY, NX))
+
+    A, b, _ = build_normal(tm, img, W)
+    flux0 = SceneFitter.solve(A, b, config=_cfg()).flux
+    resid, y0, x0 = _scene_residual(tm, img, flux0)
+    _, info, _ = measure_anchor_shifts(tm, resid, W, (y0, x0), range(2), flux0)
+
+    assert info[0] / info[1] == pytest.approx(100.0, rel=0.05)
+
+
+def test_chi2_separates_a_wrong_profile_from_a_real_displacement():
+    """The discriminator: what is left after the anchor's own shift is removed.
+
+    Source 0 has genuinely moved; source 1 has not moved at all but is painted
+    with a profile its template does not have. Both leave a large residual;
+    only the second leaves one a displacement cannot explain.
+    """
+    tm = _grid(2)
+    f = np.array([100.0, 100.0])
+    stamps = [tm[0].data, _stamp(120.0, 45.0, 2.5, skew=0.8)]
+    img = _paint(tm, f, [(0.25, -0.15), (0.0, 0.0)], stamps=stamps)
+    W = np.ones((NY, NX))
+
+    A, b, _ = build_normal(tm, img, W)
+    flux0 = SceneFitter.solve(A, b, config=_cfg()).flux
+    resid, y0, x0 = _scene_residual(tm, img, flux0)
+    eps, _, chi2 = measure_anchor_shifts(tm, resid, W, (y0, x0), range(2), flux0)
+
+    assert np.allclose(eps[0], (0.25, -0.15), atol=1e-6)
+    assert chi2[0] < 1e-12
+    assert chi2[1] > 1e3 * max(chi2[0], 1e-15)
+
+
+def _blend(neighbour_shift):
+    """Bright anchor with a faint blended neighbour, plus an isolated twin.
+
+    Index 0 is the blended anchor, 1 its neighbour (which fails the isolation
+    cut), 2 an identical but isolated copy of 0 -- the control.
+    """
+    shift = (0.20, -0.12)
+    tm = [
+        _tmpl(60.0, 100.0, 2.5, 1),
+        _tmpl(64.0, 100.0, 2.0, 2),
+        _tmpl(200.0, 100.0, 2.5, 3),
+        _tmpl(200.0, 220.0, 2.5, 4),
+    ]
+    f = np.array([100.0, 12.0, 100.0, 60.0])
+    img = _paint(tm, f, [shift, neighbour_shift, shift, shift])
+    W = np.ones((NY, NX))
+
+    A, b, _ = build_normal(tm, img, W)
+    d = np.asarray(A.diagonal(), dtype=float)
+    alpha0 = np.divide(b, d, out=np.zeros_like(b), where=d > 0)
+    flux0 = SceneFitter.solve(A, b, config=_cfg()).flux
+    resid, y0, x0 = _scene_residual(tm, img, flux0)
+    eps, info, chi2 = measure_anchor_shifts(
+        tm, resid, W, (y0, x0), [0, 2, 3], alpha0
+    )
+    return shift, eps, info, chi2
+
+
+def test_a_blended_anchor_is_measured_conditionally_on_its_neighbour():
+    """A neighbour's free flux must not be allowed to eat the anchor's dipole.
+
+    The anchor's shift is measured against a residual whose fluxes are already
+    fitted, and a neighbour sitting to one side can absorb part of a dipole by
+    adjusting its own brightness. Measured marginally -- projecting out only
+    the anchor's own flux -- this anchor read 0.095 px against a true 0.20,
+    while its isolated twin read 0.20 exactly. Every flux overlapping the
+    anchor has to be in the local system, or blended anchors report
+    systematically small shifts and the robust pass rejects them for
+    disagreeing.
+    """
+    truth, eps, info, chi2 = _blend(neighbour_shift=(0.0, 0.0))
+
+    assert np.abs(eps[2] - np.array(truth)).max() < 1e-9  # isolated twin
+    assert np.abs(eps[0] - np.array(truth)).max() < 0.02  # blended anchor
+    # the blend does cost information, and that is reported rather than hidden
+    assert 0.5 < info[0] / info[2] < 1.0
+    # ...but it is not a misfit: nothing is unexplained
+    assert chi2[0] < 1e-20
+
+
+def test_an_unmodelled_neighbour_shift_shows_up_as_misfit():
+    """A non-anchor that has also moved leaves structure behind.
+
+    Its displacement is not in the model -- only anchors get derivative
+    columns -- so its dipole cannot be absorbed by any flux and lands in the
+    anchor's misfit instead. That is the honest place for it: the anchor's
+    stamp genuinely no longer explains its own footprint.
+    """
+    truth, eps, info, chi2 = _blend(neighbour_shift=(0.20, -0.12))
+
+    assert chi2[0] > 1e6 * chi2[2]
+    # the shift is still recovered far better than the marginal estimate gave
+    assert np.abs(eps[0] - np.array(truth)).max() < 0.05
+
+
+def _blended_pair(sep, f_neighbour, anchors):
+    """A blended pair at (60, 100) plus six isolated anchors.
+
+    ``anchors`` selects which templates get a free displacement, so the same
+    scene can be measured with the neighbour treated as an anchor or not.
+    """
+    shift = (0.20, -0.12)
+    tm = [_tmpl(60.0, 100.0, 2.5, 1), _tmpl(60.0 + sep, 100.0, 2.5, 2)]
+    tm += [_tmpl(150.0 + 70 * (k % 3), 100.0 + 90 * (k // 3), 2.5, 10 + k)
+           for k in range(6)]
+    f = np.array([100.0, f_neighbour] + [60.0] * 6)
+    img = _paint(tm, f, [shift] * 8)
+    W = np.ones((NY, NX))
+
+    A, b, _ = build_normal(tm, img, W)
+    d = np.asarray(A.diagonal(), dtype=float)
+    alpha0 = np.divide(b, d, out=np.zeros_like(b), where=d > 0)
+    flux0 = SceneFitter.solve(A, b, config=_cfg()).flux
+    resid, y0, x0 = _scene_residual(tm, img, flux0)
+    eps, info, chi2 = measure_anchor_shifts(
+        tm, resid, W, (y0, x0), anchors, alpha0
+    )
+    return shift, eps, info, chi2
+
+
+@pytest.mark.parametrize("sep,f_n", [(6.0, 80.0), (6.0, 12.0), (3.0, 80.0)])
+def test_two_blended_anchors_are_measured_against_each_other(sep, f_n):
+    """When the neighbour is an anchor too, its displacement must be free.
+
+    Two overlapping sources that have both moved leave overlapping dipoles.
+    Fitting only one anchor's gradient columns splits that badly: with the
+    neighbour's flux free but its *shift* held at zero, a pair at 6 px read
+    0.089 and 0.039 px against a true 0.20 -- both low, both agreeing with
+    each other, and both carrying more information than the honest anchors
+    they disagreed with. Giving every overlapping anchor its own free
+    displacement is what makes each estimate conditional rather than a
+    one-at-a-time guess.
+    """
+    truth, eps, info, chi2 = _blended_pair(sep, f_n, anchors=list(range(8)))
+
+    assert np.abs(eps[2] - np.array(truth)).max() < 1e-9  # isolated control
+    for i in (0, 1):
+        bias = np.abs(eps[i] - np.array(truth)).max()
+        sigma = 1.0 / np.sqrt(info[i])
+        # The invariant that matters: whatever bias survives must sit inside
+        # the anchor's own error bar, or the robust pass would read a blend as
+        # a liar and reject a perfectly good anchor.
+        assert bias < sigma, f"anchor {i}: bias {bias:.3f} >= sigma {sigma:.3f}"
+        assert bias < 0.15
+
+
+def test_a_degenerate_blend_reports_its_own_uncertainty():
+    """Heavier blending buys a larger error bar, not a more confident wrong answer."""
+    _, _, info_wide, _ = _blended_pair(8.0, 80.0, anchors=list(range(8)))
+    _, _, info_tight, _ = _blended_pair(2.0, 80.0, anchors=list(range(8)))
+
+    assert info_tight[0] < info_wide[0]
+    assert info_wide[0] > info_wide[2]  # still brighter than the isolated ones
+
+
+def test_non_anchors_come_back_blank():
+    tm = _grid(3)
+    img = _paint(tm, np.array([50.0, 50.0, 50.0]), [(0.1, 0.0)] * 3)
+    W = np.ones((NY, NX))
+    resid, y0, x0 = _scene_residual(tm, img, np.zeros(3))
+
+    eps, info, chi2 = measure_anchor_shifts(tm, resid, W, (y0, x0), [0, 2], np.ones(3))
+
+    assert np.all(np.isnan(eps[1]))
+    assert info[1] == 0.0
+    assert np.isnan(chi2[1])
+    assert np.all(np.isfinite(eps[[0, 2]]))
+
+
+# ---------------------------------------------------------------------------
+# anchor_weights plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_zero_weight_anchor_is_identical_to_never_being_bright():
+    """Hard rejection is exact -- that is why the module rejects rather than
+    tapers. Compare zeroing an anchor's weight against dropping it from the
+    bright mask, which is the same thing the blocks should see."""
+    tm = _grid(4)
+    f = np.array([100.0, 50.0, 40.0, 30.0])
+    img = _paint(tm, f, [(0.2, -0.1)] * 4)
+    W = np.ones((NY, NX))
+
+    bright_all = np.array([True, True, True, True])
+    bright_drop = np.array([False, True, True, True])
+    basis_all, _, _ = make_scene_basis(tm, bright_all, order=0)
+    basis_drop, _, _ = make_scene_basis(tm, bright_drop, order=0)
+
+    kw = dict(alpha0=f, order=0, include_y=True, leverage_cap=None)
+    AB_w, BB_w, bB_w = assemble_scene_system_AB(
+        tm, img, W, basis_all, anchor_weights=np.array([0.0, 1.0, 1.0, 1.0]), **kw
+    )
+    AB_d, BB_d, bB_d = assemble_scene_system_AB(tm, img, W, basis_drop, **kw)
+
+    assert np.allclose(AB_w.toarray(), AB_d.toarray())
+    assert np.allclose(BB_w.toarray(), BB_d.toarray())
+    assert np.allclose(bB_w, bB_d)
+
+
+def test_unit_anchor_weights_change_nothing():
+    tm = _grid(4)
+    f = np.array([100.0, 50.0, 40.0, 30.0])
+    img = _paint(tm, f, [(0.2, -0.1)] * 4)
+    W = np.ones((NY, NX))
+    basis, _, _ = make_scene_basis(tm, np.ones(4, bool), order=0)
+
+    kw = dict(alpha0=f, order=0, include_y=True, leverage_cap=None)
+    a0 = assemble_scene_system_AB(tm, img, W, basis, **kw)
+    a1 = assemble_scene_system_AB(tm, img, W, basis, anchor_weights=np.ones(4), **kw)
+
+    assert np.allclose(a0[0].toarray(), a1[0].toarray())
+    assert np.allclose(a0[1].toarray(), a1[1].toarray())
+    assert np.allclose(a0[2], a1[2])
+
+
+def test_anchor_weights_shape_is_checked():
+    tm = _grid(3)
+    img = _paint(tm, np.ones(3) * 50, [(0.1, 0.0)] * 3)
+    W = np.ones((NY, NX))
+    basis, _, _ = make_scene_basis(tm, np.ones(3, bool), order=0)
+    with pytest.raises(ValueError, match="anchor_weights"):
+        assemble_scene_system_AB(
+            tm, img, W, basis, alpha0=np.ones(3), order=0,
+            anchor_weights=np.ones(2),
+        )
+
+
+# ---------------------------------------------------------------------------
+# end to end
+# ---------------------------------------------------------------------------
+
+
+def test_a_dominant_liar_pulls_the_scene_and_robust_weighting_stops_it():
+    """One bright anchor displaced differently from the other eleven.
+
+    This is the colour-gradient case in its purest form: the offending source's
+    residual *is* a clean dipole, so nothing about its own stamp gives it away
+    -- only the eleven anchors that disagree with it do.
+    """
+    truth = (0.20, -0.12)
+    tm = _grid(12)
+    f = np.full(12, 20.0)
+    f[0] = 400.0  # 20x brighter -> 400x the leverage
+    shifts = [truth] * 12
+    shifts[0] = (0.90, 0.70)  # its dipole is morphology, not motion
+    img = _paint(tm, f, shifts)
+    W = np.ones((NY, NX))
+
+    naive = _solve_scene(tm, img, W, _cfg(astrom_robust=False))
+    robust = _solve_scene(tm, img, W, _cfg(astrom_robust=True))
+
+    err_naive = np.abs(naive.shifts - np.array(truth)).max()
+    err_robust = np.abs(robust.shifts - np.array(truth)).max()
+
+    assert err_naive > 0.3, "the liar should dominate without robust weighting"
+    assert err_robust < 0.02
+    assert robust.anchor_report.applied
+    assert robust.anchor_report.n_rejected >= 1
+    assert tm[0].astrom_weight == 0.0
+    assert min(t.astrom_weight for t in tm[1:]) > 0.3
+
+
+def test_a_wrong_profile_anchor_is_caught_too():
+    """Same setup, but the offender's residual is not a clean dipole.
+
+    Here the per-anchor chi-square sees it directly, without needing the
+    neighbours -- the two layers cover different failures.
+    """
+    truth = (0.18, -0.10)
+    tm = _grid(12)
+    f = np.full(12, 20.0)
+    f[0] = 400.0
+    stamps = [t.data for t in tm]
+    stamps[0] = _stamp(45.0, 45.0, 2.5, skew=1.5)
+    img = _paint(tm, f, [truth] * 12, stamps=stamps)
+    W = np.ones((NY, NX))
+
+    naive = _solve_scene(tm, img, W, _cfg(astrom_robust=False))
+    robust = _solve_scene(tm, img, W, _cfg(astrom_robust=True))
+
+    err_naive = np.abs(naive.shifts - np.array(truth)).max()
+    err_robust = np.abs(robust.shifts - np.array(truth)).max()
+
+    assert err_naive > 5.0 * err_robust
+    assert err_robust < 0.02
+    assert tm[0].astrom_weight < 0.5
+
+
+def test_robust_weighting_leaves_an_honest_scene_where_it_was():
+    """No liar: turning it on must not move the answer appreciably."""
+    truth = (0.22, -0.14)
+    tm = _grid(12)
+    f = np.linspace(20.0, 200.0, 12)
+    img = _paint(tm, f, [truth] * 12)
+    W = np.ones((NY, NX))
+
+    naive = _solve_scene(tm, img, W, _cfg(astrom_robust=False))
+    robust = _solve_scene(tm, img, W, _cfg(astrom_robust=True))
+
+    assert np.abs(naive.shifts - np.array(truth)).max() < 0.01
+    assert np.abs(robust.shifts - np.array(truth)).max() < 0.01
+    assert robust.anchor_report.n_rejected == 0
+
+
+@pytest.mark.parametrize("liar", [True, False])
+def test_behaviour_survives_realistic_noise(liar):
+    """With noise the honest anchors no longer agree exactly.
+
+    Both directions matter: the liar must still be caught when the majority
+    only agrees to within its errors, and the majority must not start
+    rejecting each other when there is no liar to find.
+    """
+    rng = np.random.default_rng(101)
+    truth = (0.20, -0.12)
+    tm = _grid(12)
+    f = np.full(12, 300.0)
+    if liar:
+        f[0] = 3000.0
+    shifts = [truth] * 12
+    if liar:
+        shifts[0] = (0.85, 0.65)
+    sigma = 0.02
+    img = _paint(tm, f, shifts) + rng.normal(0.0, sigma, (NY, NX))
+    W = np.full((NY, NX), 1.0 / sigma**2)
+
+    naive = _solve_scene(tm, img, W, _cfg(astrom_robust=False))
+    robust = _solve_scene(tm, img, W, _cfg(astrom_robust=True))
+    err_naive = np.abs(naive.shifts - np.array(truth)).max()
+    err_robust = np.abs(robust.shifts - np.array(truth)).max()
+
+    assert robust.anchor_report.applied
+    if liar:
+        assert err_naive > 0.2
+        assert err_robust < 0.03
+        assert tm[0].astrom_weight == 0.0
+        # the honest eleven survive
+        assert sum(t.astrom_weight > 0 for t in tm[1:]) >= 10
+    else:
+        assert err_naive < 0.03
+        assert err_robust < 0.03
+        assert robust.anchor_report.n_rejected == 0
+
+
+def test_small_scene_is_left_alone_and_reports_why():
+    """Below the anchor gate the pass declines rather than guessing."""
+    truth = (0.15, -0.05)
+    tm = _grid(2)
+    f = np.array([100.0, 50.0])
+    img = _paint(tm, f, [truth] * 2)
+    W = np.ones((NY, NX))
+
+    naive = _solve_scene(tm, img, W, _cfg(astrom_robust=False))
+    robust = _solve_scene(tm, img, W, _cfg(astrom_robust=True))
+
+    assert np.allclose(naive.shifts, robust.shifts)
+    assert not robust.anchor_report.applied
+    assert "required" in robust.anchor_report.reason
+    assert all(t.astrom_weight == 1.0 for t in tm)
+
+
+def test_the_gate_is_scene_minimum_anchors():
+    """The robust gate and the scene-merging floor are one number.
+
+    A scene merged up to ``scene_minimum_anchors`` anchors is by construction
+    large enough for the robust pass to judge, so the two must not drift
+    apart.
+    """
+    truth = (0.15, -0.05)
+    tm = _grid(6)
+    f = np.linspace(100.0, 25.0, 6)
+    img = _paint(tm, f, [truth] * 6)
+    W = np.ones((NY, NX))
+
+    under = _solve_scene(tm, img, W, _cfg(astrom_robust=True, scene_minimum_anchors=9))
+    over = _solve_scene(tm, img, W, _cfg(astrom_robust=True, scene_minimum_anchors=4))
+
+    assert not under.anchor_report.applied
+    assert "9 required" in under.anchor_report.reason
+    assert over.anchor_report.applied
+
+
+def test_scene_minimum_anchors_defaults_from_the_polynomial_order():
+    """One more anchor than the field has free parameters."""
+    assert FitConfig().scene_minimum_anchors == 3
+    assert (
+        FitConfig(
+            astrom_kwargs={"poly": {"order": 1}, "gp": {"length_scale": 400}}
+        ).scene_minimum_anchors
+        == 7
+    )
+    assert FitConfig(scene_minimum_anchors=11).scene_minimum_anchors == 11
+
+
+def test_robust_weighting_supersedes_the_leverage_cap():
+    """Where the measured weight applies, the blind quantile stands down.
+
+    Both bound one anchor's pull. Leaving the cap on as well would keep
+    clipping the brightest anchors -- usually the best ones -- on top of a
+    ceiling already set from the data.
+    """
+    truth = (0.20, -0.12)
+    tm = _grid(12)
+    f = np.linspace(20.0, 400.0, 12)
+    img = _paint(tm, f, [truth] * 12)
+    W = np.ones((NY, NX))
+
+    with_cap = _solve_scene(tm, img, W, _cfg(astrom_robust=True, astrom_leverage_cap=0.5))
+    no_cap = _solve_scene(tm, img, W, _cfg(astrom_robust=True, astrom_leverage_cap=None))
+
+    assert with_cap.anchor_report.applied
+    assert np.allclose(with_cap.shifts, no_cap.shifts)
+
+    # ...but a scene the robust pass declines still gets the cap. The two
+    # anchors must disagree for any weighting to show, so give them
+    # different shifts.
+    small = _grid(2)
+    fs = np.array([400.0, 20.0])
+    img_s = _paint(small, fs, [truth, (0.6, 0.4)])
+    capped = _solve_scene(small, img_s, W, _cfg(astrom_robust=True, astrom_leverage_cap=0.5))
+    uncapped = _solve_scene(small, img_s, W, _cfg(astrom_robust=True, astrom_leverage_cap=None))
+    assert not capped.anchor_report.applied
+    assert not np.allclose(capped.shifts, uncapped.shifts)
+
+
+def _mixed_field(n_iso, n_pair, seed, sep=4.0, liar=False, sigma=0.02):
+    """``n_pair`` blended pairs at random orientation plus ``n_iso`` singletons."""
+    rng = np.random.default_rng(seed)
+    slots = [(50.0 + 80.0 * (i % 3), 50.0 + 85.0 * (i // 3)) for i in range(9)]
+    rng.shuffle(slots)
+    tm, f, sh, k = [], [], [], 0
+    truth = (0.20, -0.12)
+    for i in range(n_pair):
+        x, y = slots[i]
+        th = rng.uniform(0, 2 * np.pi)
+        tm += [
+            _tmpl(x, y, 2.5, k + 1),
+            _tmpl(x + sep * np.cos(th), y + sep * np.sin(th), 2.5, k + 2),
+        ]
+        k += 2
+        f += [300.0, 240.0]
+        sh += [truth, truth]
+    for i in range(n_iso):
+        x, y = slots[n_pair + i]
+        tm.append(_tmpl(x, y, 2.5, k + 1))
+        k += 1
+        f.append(300.0)
+        sh.append(truth)
+    f = np.array(f, dtype=float)
+    if liar:
+        f[0] = 3000.0
+        sh[0] = (0.85, 0.65)
+    img = _paint(tm, f, sh) + rng.normal(0.0, sigma, (NY, NX))
+    return truth, tm, img, np.full((NY, NX), 1.0 / sigma**2)
+
+
+def _beta_err(tm, img, W, iso, robust):
+    truth = (0.20, -0.12)
+    scn = _solve_scene(
+        tm, img, W,
+        _cfg(astrom_isolation_thresh=iso, astrom_minimum_snr=0.0,
+             astrom_robust=robust),
+    )
+    return np.abs(scn.shifts - np.array(truth)).max(), scn
+
+
+def test_robust_weighting_does_not_replace_the_isolation_cut():
+    """The two guard against different failures and neither subsumes the other.
+
+    A blended anchor's residual shift is *shrunk* toward zero by what remains
+    approximate in the local system -- and shrinkage is coherent, so every
+    blended anchor in the field is biased the same way whatever its pair's
+    orientation. They therefore agree with each other. Robust weighting is
+    majority rule: when the blended anchors outnumber the clean ones it
+    follows them, and the systematic floor it fits to their scatter shifts
+    weight further toward them. Only the isolation cut can remove that
+    population, because there is no disagreement for the robust pass to see.
+    """
+    truth, tm, img, W = _mixed_field(n_iso=3, n_pair=3, seed=11)
+
+    admitted, scn_a = _beta_err(tm, img, W, iso=0.0, robust=True)
+    admitted_off, _ = _beta_err(tm, img, W, iso=0.0, robust=False)
+    excluded, scn_e = _beta_err(tm, img, W, iso=0.7, robust=True)
+
+    # the cut is what buys the accuracy, by a wide margin
+    assert excluded < 0.02
+    assert admitted > 10 * excluded
+    # and with the blends admitted the robust pass does not rescue it -- it
+    # makes it worse, because the biased anchors are the majority
+    assert admitted > admitted_off
+    assert scn_a.anchor_report.applied
+    assert scn_a.anchor_report.n_rejected == 0
+
+
+def test_robust_weighting_is_what_catches_a_minority_outlier():
+    """The complementary half: one liar, which no isolation cut can see."""
+    truth, tm, img, W = _mixed_field(n_iso=3, n_pair=3, seed=11, liar=True)
+
+    off, _ = _beta_err(tm, img, W, iso=0.5, robust=False)
+    on, scn = _beta_err(tm, img, W, iso=0.5, robust=True)
+
+    assert off > 0.4
+    assert on < 0.2
+    assert on < 0.25 * off
+    assert scn.anchor_report.n_rejected >= 1
+
+
+def _ab_pipeline(robust: bool):
+    """Run the same mock field twice, with the flag on and off."""
+    from astropy.wcs import WCS
+    from scipy.ndimage import shift as nd_shift
+
+    from mophongo import pipeline
+    from mophongo import utils as mutils
+    from utils import make_simple_data
+
+    images, segmap, catalog, psfs, _truth, wht = make_simple_data(
+        seed=7, nsrc=40, size=201, ndilate=2, peak_snr=50.0
+    )
+    kernel = mutils.matching_kernel(psfs[0], psfs[1])
+    images = [images[0], nd_shift(images[1], (0.95, -0.75), order=3)]
+
+    wcs = WCS(naxis=2)
+    wcs.wcs.crpix = [100.0, 100.0]
+    wcs.wcs.crval = [150.0, 2.0]
+    wcs.wcs.cdelt = [-1e-5, 1e-5]
+    wcs.wcs.ctype = ["RA---TAN", "DEC--TAN"]
+
+    cfg = FitConfig(
+        fit_astrometry_niter=5,
+        astrom_shift_tol=0.004,
+        astrom_minimum_snr=5.0,
+        astrom_isolation_thresh=0.0,
+        scene_minimum_anchors=2,
+        astrom_robust=robust,
+    )
+    pipe = pipeline.Pipeline(
+        [im.copy() for im in images], segmap, catalog=catalog,
+        weights=[w.copy() for w in wht], kernels=[None, kernel], psfs=psfs,
+        wcs=[wcs, wcs], config=cfg,
+    )
+    table, _ = pipe.run()
+    return pipe, table
+
+
+def test_the_flag_reaches_the_solve_and_off_is_the_old_behaviour():
+    """A/B handle: one flag, and `False` must reproduce the previous run.
+
+    The point of keeping this switchable is that two runs of the same field
+    differ only in this flag, so the comparison is attributable. That only
+    holds if `False` touches nothing.
+    """
+    off, tab_off = _ab_pipeline(robust=False)
+    on, tab_on = _ab_pipeline(robust=True)
+
+    scenes_off = sorted(off.all_scenes[0], key=lambda s: s.id)
+    scenes_on = sorted(on.all_scenes[0], key=lambda s: s.id)
+
+    # off: the pass never runs, and every source keeps unit weight
+    assert all(s.anchor_report is None for s in scenes_off)
+    assert all(t.astrom_weight == 1.0 for s in scenes_off for t in s.templates)
+    assert np.all(tab_off["astrom_weight_1"] == 1.0)
+
+    # on: it ran, and the verdict is recorded per source
+    assert any(s.anchor_report is not None for s in scenes_on)
+    assert np.all(np.isfinite(tab_on["astrom_weight_1"]))
+    assert tab_on["astrom_weight_1"].min() >= 0.0
+    assert tab_on["astrom_weight_1"].max() <= 1.0
+
+    # the schema is the same either way, so an A/B pair differs in values
+    # rather than in columns
+    assert set(tab_off.colnames) == set(tab_on.colnames)
+
+
+@pytest.mark.parametrize("order", [0, 1])
+def test_robust_weighting_works_at_higher_order(order):
+    """Order enters only through the basis width, so both orders behave."""
+    tm = _grid(12)
+    f = np.full(12, 20.0)
+    f[0] = 400.0
+    # a genuine linear gradient across the field, plus one liar
+    pos = np.array([t.position_original for t in tm], dtype=float)
+    true_shift = [
+        (0.10 + 4e-4 * (x - NX / 2), -0.05 - 3e-4 * (y - NY / 2)) for x, y in pos
+    ]
+    shifts = list(true_shift)
+    shifts[0] = (1.0, 0.8)
+    img = _paint(tm, f, shifts)
+    W = np.ones((NY, NX))
+
+    kw = dict(astrom_kwargs={"poly": {"order": order}, "gp": {"length_scale": 400}})
+    naive = _solve_scene(tm, img, W, _cfg(astrom_robust=False, **kw))
+    robust = _solve_scene(tm, img, W, _cfg(astrom_robust=True, **kw))
+
+    # compare the field at the honest anchors, not the coefficients
+    def _at(scn):
+        from mophongo.astrometry import AstroCorrect
+
+        _, (x0, y0), (sx, sy) = scn.shift_basis
+        predict = AstroCorrect.build_poly_predictor(scn.shifts, x0, y0, order, sx, sy)
+        dx, dy = predict(pos[1:, 0], pos[1:, 1])
+        return np.stack([dx, dy], axis=1)
+
+    want = np.array(true_shift[1:])
+    err_naive = np.abs(_at(naive) - want).max()
+    err_robust = np.abs(_at(robust) - want).max()
+
+    assert robust.anchor_report.applied
+    assert err_robust < 0.05
+    assert err_robust < 0.3 * err_naive
+
+
+def test_scene_shift_is_the_mean_of_applied_template_shifts():
+    """The reported scene shift is what was applied, not a refit of it.
+
+    Accumulated shifts are a sum of damped increments, each fitted at whatever
+    the previous pass left behind, so at order >= 1 the total is not in general
+    representable by the functional form of any one pass. Fitting the form back
+    to it approximates something already known exactly.
+    """
+    tm = _grid(6)
+    for i, t in enumerate(tm):
+        t.shifted = np.array([0.1 * i, -0.05 * i], dtype=float)
+    scn = Scene(id=1, templates=tm, fitter=SceneFitter(), bbox=_bbox_union(tm))
+
+    want = np.mean([[0.1 * i, -0.05 * i] for i in range(6)], axis=0)
+    assert np.allclose(scn.mean_shift(), want)
+
+
+def test_scene_shift_ignores_templates_without_a_finite_shift():
+    tm = _grid(4)
+    for t in tm:
+        t.shifted = np.array([0.2, -0.1], dtype=float)
+    tm[0].shifted = np.array([np.nan, np.nan], dtype=float)
+    scn = Scene(id=1, templates=tm, fitter=SceneFitter(), bbox=_bbox_union(tm))
+
+    assert np.allclose(scn.mean_shift(), [0.2, -0.1])
+
+
+def test_scene_shift_is_zero_without_templates():
+    scn = Scene(id=1, templates=[], fitter=SceneFitter())
+    assert np.allclose(scn.mean_shift(), [0.0, 0.0])
+
+
+def test_shift_error_scales_with_the_noise():
+    """The formal 1-sigma on a scene's shift, so `dx`/`dy` have a scale.
+
+    Without it a 0.2 px shift cannot be told from zero, and `astrom_floor` --
+    an *excess* over exactly this -- cannot be read at all.
+    """
+    truth = (0.20, -0.12)
+    tm = _grid(12)
+    f = np.full(12, 300.0)
+
+    errs = []
+    for sigma in (0.02, 0.08):
+        rng = np.random.default_rng(5)
+        img = _paint(tm, f, [truth] * 12) + rng.normal(0.0, sigma, (NY, NX))
+        W = np.full((NY, NX), 1.0 / sigma**2)
+        scn = _solve_scene(tm, img, W, _cfg())
+        e = scn.shift_error()
+        assert np.isfinite(e) and e > 0
+        errs.append(e)
+
+    # 4x the noise, 4x the positional uncertainty
+    assert errs[1] / errs[0] == pytest.approx(4.0, rel=0.25)
+
+
+def test_shift_error_is_nan_without_a_shift_fit():
+    tm = _grid(6)
+    img = _paint(tm, np.full(6, 100.0), [(0.1, -0.05)] * 6)
+    scn = _solve_scene(tm, img, np.ones((NY, NX)), _cfg(fit_astrometry_niter=0))
+    assert np.isnan(scn.shift_error())
+
+
+def test_shift_error_brackets_the_actual_error():
+    """A formal sigma that does not contain the truth is not worth writing."""
+    truth = (0.20, -0.12)
+    tm = _grid(12)
+    f = np.full(12, 300.0)
+    sigma = 0.03
+    inside = 0
+    for seed in range(8):
+        rng = np.random.default_rng(seed)
+        img = _paint(tm, f, [truth] * 12) + rng.normal(0.0, sigma, (NY, NX))
+        W = np.full((NY, NX), 1.0 / sigma**2)
+        scn = _solve_scene(tm, img, W, _cfg())
+        miss = np.abs(np.asarray(scn.shifts) - np.array(truth)).max()
+        inside += miss < 3.0 * scn.shift_error()
+    assert inside >= 7
+
+
+def test_chi2_dof_is_near_one_for_a_good_fit_and_large_for_a_bad_one():
+    """Ranks scenes by how badly they are fitted, which is the point."""
+    truth = (0.15, -0.08)
+    tm = _grid(9)
+    f = np.full(9, 200.0)
+    sigma = 0.05
+    rng = np.random.default_rng(17)
+    noise = rng.normal(0.0, sigma, (NY, NX))
+    W = np.full((NY, NX), 1.0 / sigma**2)
+
+    good = _solve_scene(tm, _paint(tm, f, [truth] * 9) + noise, W, _cfg())
+    assert good.chi2_dof() == pytest.approx(1.0, rel=0.15)
+
+    # same scene, but one source painted with a profile its template lacks
+    stamps = [t.data for t in tm]
+    stamps[0] = _stamp(45.0, 45.0, 2.5, skew=1.5)
+    bad = _solve_scene(
+        tm, _paint(tm, f, [truth] * 9, stamps=stamps) + noise, W, _cfg()
+    )
+    assert bad.chi2_dof() > 2.0 * good.chi2_dof()
+
+
+def test_chi2_dof_prefers_the_global_residual():
+    """Passed a residual, it uses it rather than the scene's own."""
+    tm = _grid(6)
+    img = _paint(tm, np.full(6, 100.0), [(0.1, -0.05)] * 6)
+    W = np.ones((NY, NX))
+    scn = _solve_scene(tm, img, W, _cfg())
+
+    perfect = np.zeros((NY, NX))
+    assert scn.chi2_dof(perfect) == pytest.approx(0.0, abs=1e-12)
+    assert scn.chi2_dof() > 0.0

--- a/tests/test_scene_fit_table.py
+++ b/tests/test_scene_fit_table.py
@@ -1,0 +1,244 @@
+"""The SCENES extension of the fit table, and what it is for.
+
+A band that dies drawing its scene figures has already solved everything; the
+point of this extension is that the solution survives that. The tests that
+matter are therefore about reconstruction: the stored coefficients have to
+reproduce the anchor-solved shift field exactly, not approximately, because
+refitting a polynomial to the applied shifts is what they exist to replace.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from astropy.io import fits
+from astropy.table import Table
+
+from mophongo.astrometry import AstroCorrect, cheb_basis, n_terms
+from mophongo.pipeline import Pipeline, _cheb_order_from_coeffs
+
+
+# ----------------------------------------------------------------- helpers
+class _Template:
+    def __init__(self, x: float, y: float) -> None:
+        self.position_original = (x, y)
+        self.shifted = np.zeros(2, dtype=float)
+
+
+class _Scene:
+    """Only the attributes ``_scene_fit_table`` reads."""
+
+    def __init__(self, sid, shifts, order, *, n=6, x0=100.0, y0=200.0,
+                 sx=50.0, sy=50.0, report=None):
+        rng = np.random.default_rng(sid)
+        self.id = sid
+        self.templates = [_Template(*p) for p in rng.uniform(0, 300, size=(n, 2))]
+        self.shifts = shifts
+        self.shift_basis = None if shifts is None else [None, (x0, y0), (sx, sy)]
+        self.is_bright = np.zeros(n, dtype=bool)
+        self.is_bright[: max(1, n // 3)] = True
+        self.astrom_niter = 3
+        self.astrom_converged = True
+        self.astrom_step = 0.02
+        self.anchor_report = report
+        self.order = order
+
+    def shift_error(self):
+        """Real ``Scene`` method the table reads; no covariance on the stub."""
+        return float("nan")
+
+    def chi2_dof(self, residual=None):
+        """Real ``Scene`` method the table reads; no pixels on the stub."""
+        return float("nan")
+
+    def shift_scatter(self):
+        """Real ``Scene`` method the table reads; stubbed with the same rule."""
+        sh = np.array([np.asarray(t.shifted, float)[:2] for t in self.templates])
+        if len(sh) < 2:
+            return 0.0
+        d = sh - sh.mean(axis=0)
+        return float(np.sqrt(np.mean(np.sum(d ** 2, axis=1))))
+
+
+class _WCS:
+    @staticmethod
+    def wcs_pix2world(xy, origin):
+        (x, y), = xy
+        return [(150.0 + x / 3600.0, 2.0 + y / 3600.0)]
+
+
+def _pipeline(scenes, damping: float = 0.8) -> Pipeline:
+    pipe = Pipeline.__new__(Pipeline)
+    pipe.all_scenes = [scenes]      # `scenes` is a read-only view of band 0
+    pipe.wcs = [_WCS()]
+    pipe.config = SimpleNamespace(astrom_damping=damping)
+    return pipe
+
+
+def _coeffs(order: int, seed: int = 0) -> np.ndarray:
+    return np.random.default_rng(seed).normal(0, 0.3, size=2 * n_terms(order))
+
+
+# ------------------------------------------------------------------- order
+@pytest.mark.parametrize("order", [0, 1, 2, 3])
+def test_order_round_trips_through_coefficient_length(order):
+    assert _cheb_order_from_coeffs(_coeffs(order)) == order
+
+
+@pytest.mark.parametrize("bad", [None, np.zeros(0), np.zeros(1), np.zeros(8)])
+def test_uninterpretable_coefficients_are_none(bad):
+    # 8 is 2x4, and 4 is not n_terms of any order
+    assert _cheb_order_from_coeffs(bad) is None
+
+
+# -------------------------------------------------------------- the table
+def test_scene_fit_table_stores_the_solution_not_a_refit():
+    """The stored field must equal the anchor solution at arbitrary points.
+
+    This is the distinction the extension exists for: sampling the applied
+    shifts of every template gives a similar but different field, so a test
+    that only compared scene centres would pass on the wrong data.
+    """
+    order = 2
+    coeffs = _coeffs(order, seed=7)
+    scene = _Scene(1, coeffs, order, x0=120.0, y0=240.0, sx=64.0, sy=48.0)
+    tab = _pipeline([scene])._scene_fit_table()
+
+    row = tab[0]
+    assert row["shift_order"] == order
+    assert row["n_coeff"] == 2 * n_terms(order)
+
+    want = AstroCorrect.build_poly_predictor(coeffs, 120.0, 240.0, order, 64.0, 48.0)
+    got = AstroCorrect.build_poly_predictor(
+        np.asarray(row["shift_coeff"][: row["n_coeff"]]),
+        row["shift_x0"], row["shift_y0"], int(row["shift_order"]),
+        row["shift_sx"], row["shift_sy"],
+    )
+    probe_x = np.array([0.0, 55.0, 120.0, 400.0])
+    probe_y = np.array([10.0, 300.0, 240.0, 90.0])
+    assert np.allclose(np.column_stack(got(probe_x, probe_y)),
+                       np.column_stack(want(probe_x, probe_y)), rtol=0, atol=1e-12)
+
+
+def test_mixed_orders_pad_to_the_widest_and_cut_back_by_n_coeff():
+    """Order is per scene: a saturated scene is forced to 0 beside an order-2."""
+    scenes = [_Scene(1, _coeffs(0, 1), 0), _Scene(2, _coeffs(2, 2), 2),
+              _Scene(3, _coeffs(1, 3), 1)]
+    tab = _pipeline(scenes)._scene_fit_table()
+
+    assert list(tab["shift_order"]) == [0, 2, 1]
+    assert tab["shift_coeff"].shape[1] == 2 * n_terms(2)
+    for row, scene in zip(tab, scenes):
+        kept = np.asarray(row["shift_coeff"][: row["n_coeff"]])
+        assert np.allclose(kept, scene.shifts)
+        # everything past n_coeff is padding, never a silent zero
+        assert np.isnan(np.asarray(row["shift_coeff"][row["n_coeff"]:])).all()
+
+
+def test_scene_without_a_shift_solution_is_flagged_not_faked():
+    tab = _pipeline([_Scene(1, None, None)])._scene_fit_table()
+    assert tab["shift_order"][0] == -1
+    assert tab["n_coeff"][0] == 0
+    assert np.isnan(tab["shift_x0"][0])
+    assert np.isnan(np.asarray(tab["shift_coeff"][0])).all()
+
+
+def test_robust_pass_columns_follow_the_report():
+    rep = SimpleNamespace(applied=True, n_rejected=4, sys_floor=0.011, n_eff=17.5)
+    tab = _pipeline([_Scene(1, _coeffs(1), 1, report=rep),
+                     _Scene(2, _coeffs(1), 1, report=None)])._scene_fit_table()
+    assert list(tab["astrom_robust"]) == [1, 0]
+    assert list(tab["astrom_nreject"]) == [4, -1]
+    assert tab["astrom_floor"][0] == pytest.approx(0.011)
+    assert np.isnan(tab["astrom_floor"][1])
+
+
+# ---------------------------------------------------------------- on disk
+def test_extension_round_trips_beside_the_fit_table(tmp_path):
+    """Written as a second HDU, read back by EXTNAME, fit table untouched."""
+    scenes = [_Scene(1, _coeffs(0, 1), 0), _Scene(2, _coeffs(2, 2), 2)]
+    path = tmp_path / "band_fit_table.fits"
+    Table({"id": [1, 2, 3], "flux_1": [1.0, 2.0, 3.0]}).write(path)
+
+    hdu = fits.BinTableHDU(_pipeline(scenes)._scene_fit_table().as_array(),
+                           name="SCENES")
+    fits.append(path, hdu.data, hdu.header)
+
+    with fits.open(path) as hdul:
+        assert [h.name for h in hdul] == ["PRIMARY", "", "SCENES"]
+    assert Table.read(path, hdu=1).colnames == ["id", "flux_1"]
+
+    back = Table.read(path, hdu="SCENES")
+    assert list(back["shift_order"]) == [0, 2]
+    for row, scene in zip(back, scenes):
+        assert np.allclose(np.asarray(row["shift_coeff"][: row["n_coeff"]]),
+                           scene.shifts)
+
+
+def test_damping_travels_with_the_coefficients():
+    """The stored field is undamped; the applied shift is ``damping`` times it.
+
+    Without the factor beside them the coefficients cannot be turned back into
+    what the sources actually moved, and the config in force at read time is
+    not necessarily the one that produced the run.
+    """
+    tab = _pipeline([_Scene(1, _coeffs(1), 1), _Scene(2, None, None)],
+                    damping=0.8)._scene_fit_table()
+    assert tab["astrom_damping"][0] == pytest.approx(0.8)
+    assert np.isnan(tab["astrom_damping"][1])   # nothing solved, nothing applied
+
+
+def test_restore_scene_fit_puts_the_solution_back(tmp_path):
+    """The read side: regrouped scenes get their solver state back by id."""
+    scenes = [_Scene(1, _coeffs(0, 1), 0), _Scene(2, _coeffs(2, 2), 2),
+              _Scene(3, None, None)]
+    pipe = _pipeline(scenes)
+    table = pipe._scene_fit_table()
+
+    # fresh scenes, as regrouped from id_scene: no solver state at all
+    bare = [_Scene(1, None, None), _Scene(2, None, None), _Scene(3, None, None)]
+    reader = _pipeline(bare)
+    reader.scene_fit = table
+    assert reader.restore_scene_fit(bare) == 3
+
+    assert np.allclose(bare[0].shifts, scenes[0].shifts)
+    assert np.allclose(bare[1].shifts, scenes[1].shifts)
+    assert bare[2].shifts is None            # never solved, stays unsolved
+    _, (x0, y0), (sx, sy) = bare[1].shift_basis
+    assert (x0, y0, sx, sy) == (100.0, 200.0, 50.0, 50.0)
+    assert bare[0].astrom_niter == 3
+    assert bare[0].astrom_converged is True
+
+
+def test_restore_is_a_no_op_without_the_extension():
+    """A run written before SCENES existed reloads exactly as it used to."""
+    bare = [_Scene(1, None, None)]
+    pipe = _pipeline(bare)
+    pipe.scene_fit = None
+    assert pipe.restore_scene_fit(bare) == 0
+    assert bare[0].shifts is None
+
+
+def test_stored_field_differs_from_a_refit_on_applied_shifts():
+    """Why the coefficients are stored rather than recovered from the shifts.
+
+    A curved field sampled at the sources and refitted does not come back the
+    same, so a reconstruction that refits is not the solution the fit used.
+    """
+    order = 2
+    coeffs = _coeffs(order, seed=11)
+    x0, y0, sx, sy = 120.0, 240.0, 64.0, 48.0
+    predict = AstroCorrect.build_poly_predictor(coeffs, x0, y0, order, sx, sy)
+
+    rng = np.random.default_rng(3)
+    pos = rng.uniform(0, 300, size=(30, 2))
+    applied = np.column_stack(predict(pos[:, 0], pos[:, 1]))
+    # the sources only sample the field where they happen to sit, so a lower
+    # order refit -- what a rebuild would guess without the stored order --
+    # cannot reproduce it
+    design = np.vstack([cheb_basis((px - x0) / sx, (py - y0) / sy, 1)
+                        for px, py in pos])
+    beta, *_ = np.linalg.lstsq(design, applied, rcond=None)
+    refit = design @ beta
+    assert not np.allclose(refit, applied, atol=1e-6)

--- a/tests/test_scene_fitter.py
+++ b/tests/test_scene_fitter.py
@@ -22,10 +22,10 @@ def test_scene_fitter_flux_only():
     assert np.all(np.isfinite(sol.err))
 
 
-def test_scene_fitter_reg_astrom_does_not_regularize_flux():
+def test_scene_fitter_astrom_reg_does_not_regularize_flux():
     A = sp.csr_matrix([[1e-3]])
     b = np.array([1e-3])
-    sol = SceneFitter.solve(A, b, config=FitConfig(reg_flux=0.0, reg_astrom=1e-2))
+    sol = SceneFitter.solve(A, b, config=FitConfig(reg_flux=0.0, astrom_reg=1e-2))
     np.testing.assert_allclose(sol.flux, [1.0], rtol=1e-5)
 
 
@@ -35,7 +35,7 @@ def test_scene_fitter_with_shift_block():
     AB = sp.csr_matrix([[1.0], [2.0]])
     BB = sp.csr_matrix([[3.0]])
     bB = np.array([0.5])
-    cfg = FitConfig(reg_flux=1e-12, reg_astrom=0.0, positivity=False)
+    cfg = FitConfig(reg_flux=1e-12, astrom_reg=0.0, positivity=False)
     sol = SceneFitter.solve(A, b, AB=AB, BB=BB, bB=bB, config=cfg)
     M = np.block([[A.toarray(), AB.toarray()], [AB.T.toarray(), BB.toarray()]])
     M[: A.shape[0], : A.shape[0]] += np.eye(A.shape[0]) * cfg.reg_flux

--- a/tests/test_scene_saturated.py
+++ b/tests/test_scene_saturated.py
@@ -239,7 +239,7 @@ def test_isolation_thresh_counts_only_isolated_toward_floor():
     # Without isolation: pair members count as bright -> pair scene stands alone.
     _, labels = generate_scenes(
         tmpls.templates, image, weight,
-        coupling_thresh=1e-3, minimum_bright=1, snr_thresh_astrom=1.0,
+        coupling_thresh=1e-3, minimum_bright=1, astrom_minimum_snr=1.0,
     )
     assert labels[0] == labels[1]  # blended pair coupled into one scene
     n_without = np.unique(labels).size
@@ -248,7 +248,7 @@ def test_isolation_thresh_counts_only_isolated_toward_floor():
     # scene is under the floor and merges toward the isolated source.
     _, labels_iso = generate_scenes(
         tmpls.templates, image, weight,
-        coupling_thresh=1e-3, minimum_bright=1, snr_thresh_astrom=1.0,
+        coupling_thresh=1e-3, minimum_bright=1, astrom_minimum_snr=1.0,
         isolation_thresh=0.95,
     )
     assert np.unique(labels_iso).size < n_without

--- a/tests/test_sed_estimator_experiment.py
+++ b/tests/test_sed_estimator_experiment.py
@@ -3,12 +3,20 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
-from scratch.minerva_sed_estimator_experiment import (
-    ESTIMATORS,
-    estimate_cell,
-    split_half_cell,
+# The module under test lives in `scratch/`, which is gitignored, so it is
+# absent from a fresh checkout and from CI. Skip rather than fail collection:
+# the experiment is exploratory and its test is only meaningful where the
+# scratch tree exists.
+sed_experiment = pytest.importorskip(
+    "scratch.minerva_sed_estimator_experiment",
+    reason="scratch/ is gitignored and absent from this checkout",
 )
+
+ESTIMATORS = sed_experiment.ESTIMATORS
+estimate_cell = sed_experiment.estimate_cell
+split_half_cell = sed_experiment.split_half_cell
 
 
 def test_estimator_experiment_retains_signed_values_and_exposes_ivw_bias():

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -125,3 +125,83 @@ def test_pruned_templates_carry_the_outside_weight_flag(caplog):
     dropped = [t for t in kept_before if int(t.id) == 2][0]
     assert dropped.flag & Template.FLAG_OUTSIDE_WEIGHT
     assert not kept[0].flag & Template.FLAG_OUTSIDE_WEIGHT
+
+
+def test_prune_outside_weight_is_subset_invariant():
+    """A template's verdict must not depend on the company it keeps.
+
+    The threshold used to be ``rtol * median(wnorm)`` over the set being
+    pruned, so pruning a subset applied a different cut than pruning the whole
+    field. Re-solving one scene of a COSMOS F770W run dropped 76 of its 260
+    templates for that reason alone: the scene's members are brighter than the
+    field median, the threshold rose with them, and the faint edge members went
+    with it. Anything that re-extracts a subset -- ``Pipeline.refit_scene``
+    above all -- was silently working on a different source set.
+    """
+    import numpy as np
+
+    from mophongo.templates import Template, Templates
+
+    ny = nx = 320
+    half = 12
+
+    def _tmpl(xc, yc, sigma, label, scale):
+        n = 2 * half + 1
+        x0, y0 = int(round(xc)) - half, int(round(yc)) - half
+        yy, xx = np.mgrid[y0 : y0 + n, x0 : x0 + n]
+        g = np.exp(-0.5 * (((xx - xc) / sigma) ** 2 + ((yy - yc) / sigma) ** 2))
+        g = scale * g / g.sum()
+        return Template.from_stamp(g, (x0, y0), (xc, yc), (ny, nx), label=label)
+
+    weight = np.ones((ny, nx))
+
+    def _at(i, scale):
+        return _tmpl(40.0 + 9 * (i % 30), 40.0 + 9 * (i // 30), 2.0, i + 1, scale)
+
+    bright = [_at(i, 1.0) for i in range(3)]        # the scene's bright members
+    faint = [_at(100 + i, 3e-6) for i in range(3)]  # its faint edge members
+    rest = [_at(200 + i, 1e-7) for i in range(20)]  # the rest of the field
+
+    def survivors(templates):
+        ts = Templates()
+        ts.original_shape = (ny, nx)
+        ts._templates = list(templates)
+        return {int(t.id) for t in ts.prune_outside_weight(weight)}
+
+    full = survivors(bright + faint + rest)
+    subset = survivors(bright + faint)
+
+    assert {int(t.id) for t in faint} <= full
+    assert {int(t.id) for t in faint} <= subset
+    # the verdict on the shared templates is identical either way
+    assert full & {int(t.id) for t in bright + faint} == subset
+
+
+def test_prune_outside_weight_drops_templates_off_the_weight_map():
+    """The documented behaviour still holds: no usable pixels, no template."""
+    import numpy as np
+
+    from mophongo.templates import Template, Templates
+
+    ny = nx = 200
+    half = 12
+    weight = np.ones((ny, nx))
+    weight[:, 120:] = 0.0
+
+    def _tmpl(xc, label):
+        n = 2 * half + 1
+        x0, y0 = int(round(xc)) - half, 100 - half
+        yy, xx = np.mgrid[y0 : y0 + n, x0 : x0 + n]
+        g = np.exp(-0.5 * (((xx - xc) / 2.0) ** 2 + ((yy - 100.0) / 2.0) ** 2))
+        return Template.from_stamp(g / g.sum(), (x0, y0), (xc, 100.0), (ny, nx),
+                                   label=label)
+
+    inside, outside = _tmpl(60.0, 1), _tmpl(160.0, 2)
+    ts = Templates()
+    ts.original_shape = (ny, nx)
+    ts._templates = [inside, outside]
+
+    kept = ts.prune_outside_weight(weight)
+
+    assert [int(t.id) for t in kept] == [1]
+    assert outside.flag & Template.FLAG_OUTSIDE_WEIGHT


### PR DESCRIPTION
## Summary

Anchor leverage in the joint shift solve grows as flux squared, so a single bright extended source can carry a scene's astrometry on its own. If that source has an asymmetric colour gradient its residual dipole is indistinguishable from a displacement, and it drags the fitted field with it. This branch adds a robust weighting that catches it, reports how well each scene's shift was actually determined, and tidies the astrometry config namespace.

## Logic

**`astrom_robust.py`** — an MM-type estimator over a scene's anchor table (implied shift, Fisher information, basis row). A leverage-blind high-breakdown start, then redescending Tukey steps that put the information back. Both halves are needed: without the blind start the reweighting *masks*, since the dominant anchor is the least-squares answer, so the honest anchors carry the large residuals and get cut instead. A Huber warm-up does not substitute — its weights decay as `1/u`, so against an anchor with 400x its neighbours' leverage a tenfold downweight still leaves it holding most of the vote.

Rejection is hard rather than a decaying tail for a reason specific to how the weight is consumed: it enters `assemble_scene_system_AB` through `lev_w`, whose two-power split is exact for the shift-only block but leaves the flux-marginalization term scaled as `c_i c_j` where the information scales as `sqrt(c_i c_j)`. That mismatch is worst at intermediate weights and vanishes identically at `c_i = 0`.

The pass also estimates `astrom_floor`, the extra per-anchor scatter needed before the anchors' disagreement with the fitted field is statistically consistent. Median-based, so one wild anchor cannot set it.

**On by default.** The estimator costs a few percent of efficiency on clean anchors, which is the cheaper of the two errors. Gated on `scene_minimum_anchors`, below which it declines and `astrom_leverage_cap` remains the only protection. It does *not* replace `astrom_isolation_thresh` — a blended anchor's implied shift is shrunk toward zero coherently, so blended anchors agree with each other and majority rule follows them rather than rejecting them.

**Shift quality is now reported.** `sigma_shift` comes from the shift block of the joint inverse, after the fluxes absorb what they can. Taking `BB^-1` instead would be free but wrong by the flux-shift degeneracy, measured at tens of percent when a neighbour sits about a FWHM from an anchor. Alongside it `shift_rms`, `chi2_dof` and the robust verdict (`astrom_floor`, `astrom_nreject`, `astrom_neff`).

**Config namespace.** `reg_astrom` → `astrom_reg`, `snr_thresh_astrom` → `astrom_minimum_snr`, `scene_minimum_bright` → `scene_minimum_anchors` (now `None` by default, derived from the shift model order as `(order+1)(order+2)+1`). `astrom_isolation_thresh` 0.6 → 0.7. `astrom_model` defaults to `"poly"`: the joint path takes its basis order straight from `astrom_kwargs["poly"]["order"]` and never branches on the model, so `"gp"` described a run that was not happening.

## Modules

- **Added**: `src/mophongo/astrom_robust.py` — a leaf, plain arrays in and weights out, no imports from `scene`, `fit` or `templates`. The measurement that builds the table lives in `scene`, where the template geometry is; keeping the statistics separable is what lets the non-joint path in `astrometry.py` reuse them.
- **Modified**: `fit.py`, `scene.py`, `scene_fitter.py`, `pipeline.py`, `templates.py`, `astrometry.py`, `verification.py`.

Also carried on this branch from concurrent work: a refit is refined exactly as the run refined it (both through `_refine_scene_astrometry`) and `_solve_frozen_scene` refuses to rebuild a scene it cannot rebuild whole; an upsampled band keeps its weight on the same grid as its image; the solved shift field survives the figure loop; `Templates.prune_outside_weight` no longer depends on the set it is called with and flags what it drops; PSF settings moved into a `psf` config block.

## Validation

`poetry run pytest` — **480 passed**.

New: `tests/test_astrom_robust.py`, `tests/test_scene_astrometry_robust.py`, `tests/test_scene_fit_table.py`. The refit path was validated against the run on COSMOS F770W scene 1313.

`SCENES` carries `astrom_robust`, `astrom_nreject` and `astrom_neff` so an A/B pair of runs differs in the values rather than in the schema — comparing them is the intended way to judge whether the weighting earned its place on a given field.

## Notes

`STATUS.md` records the completed work; `TODO.md` gains two entries for the global shift field the per-scene fit cannot give — fitting one field across all scenes by summing per-scene Schur complements, and an interim pass that hands badly determined scenes the shift their neighbours define.

https://claude.ai/code/session_01Ut5iQHWqMr8TVACX28yvJj
