### PR TITLE
Assemble anchor local systems from slice intersections

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -3,6 +3,36 @@
 This file records completed implementations, validation runs, and the current work state.
 
 ## Current Work
+- [x] Anchor local systems assembled from slice intersections (2026-08-18).
+  The rest of the `astrom_robust` slowdown. `measure_anchor_shifts` gave every
+  anchor a local least-squares system over the union footprint of its
+  neighbours, with each column zero-padded onto that footprint and the Gram
+  formed there: `ncol^2 / 2` products over ~80k pixels per anchor, for columns
+  supported on one ~10k-pixel stamp each. Both factors grow with crowding,
+  since `ncol` counts every template whose bbox touches the anchor.
+
+  Columns are now keys `(template, kind)` carrying no padding, and every inner
+  product runs over the intersection of the two templates' slices -- zero, and
+  untouched, where they do not overlap. The entries are cached across anchors
+  as well: `<c_p, W, c_q>` depends on the two columns and the weight map, not
+  on whose system it appears in, and neighbouring anchors share most of their
+  neighbourhoods. The `chi2_red` model is built on the anchor's own stamp,
+  which is the only place it was ever read.
+
+  Neither is an approximation, and the numbers say so: against the padded
+  version on synthetic scenes at MINERVA density, `max |d eps| <= 4e-17 px`,
+  `max rel d info <= 1e-14`, `d chi2_red` exactly zero, and the NaN/zero masks
+  identical. 1456 -> 184 ms at 320 templates, 1308 -> 197 ms at 920, 13249 ->
+  1965 ms at 920 with 151-px stamps: 6.7-7.9x throughout.
+  `test_local_systems_match_the_padded_reference` keeps a padded reference in
+  the test file and checks the two agree on overlapping templates of different
+  sizes, one clipped by the frame, over a weight map with a dead strip.
+
+  With the two changes below, the robust pass on the 920-template benchmark
+  goes from 1489 ms to ~74 ms, i.e. ~5% of what it cost. TODO carries the one
+  remaining step: the flux-flux block is `A` and its RHS is `b - A @ flux0`,
+  so ~95% of a crowded local system need not be integrated at all.
+
 - [x] The robust anchor pass stops paying for work it discards (2026-08-18).
   `astrom_robust` (on by default since `6e0f27a`) took the astrometry phase of
   a cosmos_f770w run from 6m23s to 29m02s. Profiling a synthetic scene at

--- a/STATUS.md
+++ b/STATUS.md
@@ -3,6 +3,24 @@
 This file records completed implementations, validation runs, and the current work state.
 
 ## Current Work
+- [x] `scene_minimum_anchors` is a flat 10, and the campaign configs stopped
+  setting it (2026-08-18). The default derived the floor from the astrometric
+  polynomial order, `(order+1)(order+2)+1`, which is 3 at the default order 0
+  -- an algebraic count of the field's free parameters, not a number of
+  anchors a scatter can be measured from. Every campaign config overrode it by
+  hand anyway (5 on CANFAR and OzStar, 7 and 10 in the MINERVA runs), so the
+  derivation only ever described runs nobody launched.
+
+  It is now `scene_minimum_anchors: int = 10` with the `__post_init__`
+  derivation removed, and the hand-set values are gone from
+  `examples/minerva`, `examples/canfar` and `examples/ozstar` (and from
+  `make_minerva_configs.py`, which writes them) so those runs take the
+  default. A wider astrometric basis still raises the floor where it needs to:
+  `astrom_robust.anchor_gate` takes `max(scene_minimum_anchors, 2p)`.
+
+  `_beta_err` in `tests/test_scene_astrometry_robust.py` pins the floor at 3:
+  its nine-template field is about the weighting, not the gate.
+
 - [x] Anchor local systems assembled from slice intersections (2026-08-18).
   The rest of the `astrom_robust` slowdown. `measure_anchor_shifts` gave every
   anchor a local least-squares system over the union footprint of its

--- a/TODO.md
+++ b/TODO.md
@@ -251,6 +251,32 @@ This file tracks future desired features, checks, and investigations.
   Both variants still linearize `T(x + d) ~ T + d . grad T`, so the outer
   `fit_astrometry_niter` loop stays.
 
+- [ ] Take the flux-flux block of the anchor local systems from `A` and `b`
+  (2026-08-18). `measure_anchor_shifts` now assembles each anchor's local
+  system from slice intersections rather than from padded buffers, which is
+  7x. Most of what is left is still the flux-flux block, and it does not need
+  computing at all: `<T_j, W, T_k>` *is* `A[j, k]`, and `<T_j, W, resid>` *is*
+  `(b - A @ flux0)_j`, both already built for the scene's flux solve. In a
+  crowded scene the flux columns are ~95% of a local system -- 134 of 138
+  columns on the 920-template benchmark -- so the remaining integrals would be
+  the gradient rows only. Measured at 40-129x against the padded version
+  (`scratch/bench_anchor_fast.py::measure_anchor_shifts_fastest`), against 7x
+  for intersections alone.
+
+  Two things to weigh before doing it. The signature grows `A`, `b`, `flux0`,
+  and with them an invariant that is currently implicit: the matrix passed
+  must be the one the residual was built from. Both come out of
+  `Scene._robust_anchor_weights` three lines apart, so it holds today, but it
+  would break silently rather than loudly. And `build_normal` forms
+  `cut * w * cut` in float32 before widening the accumulator, so reusing `A`
+  moves the flux-flux block by ~1e-7 relative where the intersection version
+  matches the padded one to ~1e-14; `test_local_systems_match_the_padded_reference`
+  would need a tolerance rather than staying exact.
+
+  Only worth it if the astrometry phase is still the run's bottleneck after
+  the three changes already made. On the 920-template benchmark it would take
+  the robust pass from ~74 ms to ~50 ms against a scene solve of ~440 ms.
+
 - [ ] Accumulate the shift coefficients across astrometric passes
   (2026-08-16). `Scene.solve` overwrites `self.shifts` on every pass
   (`scene.py:1512`), so a scene that took two passes keeps only the second,

--- a/docs/fitting.md
+++ b/docs/fitting.md
@@ -447,9 +447,9 @@ solve leaves the fitted shifts alone and costs one pass.
 
 The tolerance is a stopping rule, not an accuracy claim, and `0.1` fit-grid
 pixels is chosen against the noise rather than against the arithmetic. The
-weakest scene the anchor cuts admit — `scene_minimum_anchors` = 3 members at
+weakest scene the anchor cuts admit — `scene_minimum_anchors` = 10 members at
 `astrom_minimum_snr` = 15 — has a centroid good to roughly
-$\sigma_{\rm PSF}/({\rm SNR}\sqrt{N}) \approx 0.10$ fit pixels, so iterating
+$\sigma_{\rm PSF}/({\rm SNR}\sqrt{N}) \approx 0.05$ fit pixels, so iterating
 below that measures nothing; and the systematic floor from PSF and kernel
 mismatch is a bias, which no number of passes removes. Tightening the
 tolerance buys passes, not precision. Because the fit grid is the
@@ -547,7 +547,7 @@ page.
 | `astrom_kwargs` | `dict` | `{"poly": {"order": 0}, "gp": {"length_scale": 400}}` | Per-model options; the joint scene fit reads `astrom_kwargs["poly"]["order"]`. |
 | `multi_resolution_method` | `str` | `"upsample"` | Multi-resolution handling (see {doc}`pipeline`). |
 | `normal` | `str` | `"tree"` | Normal-matrix builder; only `"tree"` is implemented. |
-| `scene_minimum_anchors` | `int \| None` | `None` | Minimum bright anchors per scene; smaller scenes are merged. `None` derives it from the polynomial order as `(order+1)(order+2)+1` — 3 at order 0, 7 at order 1. Also the gate for `astrom_robust`. |
+| `scene_minimum_anchors` | `int` | `10` | Minimum bright anchors per scene; smaller scenes are merged. Also the gate for `astrom_robust`, which raises it to `max(scene_minimum_anchors, 2p)` for a `p`-term shift field. |
 | `run_scene_solver` | `bool` | `True` | Must remain `True`; the scene solver is the only fitting path and `False` raises. |
 | `scene_coupling_thresh` | `float` | `1e-3` | Leakage score above which templates share a scene. |
 | `scene_max_size` | `int \| None` | `800` | Soft cap on templates per scene, enforced by local threshold-raising. `None` disables. |

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -684,11 +684,11 @@ Scenes:
   partner, and a merge that would leave the scene wider than this is refused.
   `np.inf` disables all three. The size cap above bounds a scene's template
   count and leaves its shape free; this bounds the shape.
-- `scene_minimum_anchors` (*int | None*, default `None`) — minimum number of
-  bright anchors per scene, derived by default from the astrometric
-  polynomial order as `(order + 1) * (order + 2) + 1`, i.e. one more anchor
-  than the shift field has free parameters. Set an int to override. Also the
-  gate below which `astrom_robust` declines to judge a scene.
+- `scene_minimum_anchors` (*int*, default `10`) — minimum number of bright
+  anchors per scene. Also the gate below which `astrom_robust` declines to
+  judge a scene, which raises it to `max(scene_minimum_anchors, 2p)` for a
+  `p`-term shift field, so a wider astrometric basis does not need this
+  changed with it.
 - `generate_scene_catalog` (*bool*, default `False`) — write a scene catalog
   (`scene_catalog_<i>.ecsv`) and exit without fitting.
 

--- a/examples/make_minerva_configs.py
+++ b/examples/make_minerva_configs.py
@@ -328,7 +328,6 @@ def band_configs(rel: Release) -> list[dict]:
                 "bg_filter_sigma": 64.0,
                 "fit": {
                     "fit_astrometry_joint": True,
-                    "scene_minimum_anchors": 5,
                     # larger scenes before the local threshold bisection kicks
                     # in, and no long-range gluing of underfilled scenes
                     # (radius in 40 mas reference pixels; 1000 px = 40").

--- a/src/mophongo/fit.py
+++ b/src/mophongo/fit.py
@@ -117,9 +117,9 @@ class FitConfig:
     # drops below this tolerance (fit-grid pixels). The linearized shift solve
     # only captures part of a large offset per pass, so set
     # fit_astrometry_niter to the maximum passes allowed and let this tol stop.
-    # 0.1 sits just above the statistical floor of the weakest scene the
-    # anchor cuts admit -- 5 bright members (scene_minimum_anchors) at
-    # astrom_minimum_snr = 15 give a scene centroid good to ~0.08 fit pixels --
+    # 0.1 sits above the statistical floor of the weakest scene the anchor cuts
+    # admit -- 10 bright members (scene_minimum_anchors) at
+    # astrom_minimum_snr = 15 give a scene centroid good to ~0.05 fit pixels --
     # and well below PSF-matching centroid systematics, which are a bias no
     # tolerance can iterate away. The increment tested is the applied (damped)
     # one, so the last sub-tolerance step is on the templates, not discarded.
@@ -188,11 +188,14 @@ class FitConfig:
     normal: str = "tree"  # 'loop' or 'tree'
     # Minimum bright anchors per scene: the floor `merge_small_scenes` merges
     # toward, and the gate below which `astrom_robust` declines to judge a
-    # scene. None (the default) derives it from the astrometric model order in
-    # __post_init__ as (order+1)(order+2) + 1 -- one more anchor than the field
-    # has free parameters -- so raising the order raises the floor with it
-    # instead of leaving a hand-set number behind. Set an int to override.
-    scene_minimum_anchors: int | None = None
+    # scene. 10 is what the MINERVA campaign configs set by hand, and it is a
+    # statistical floor rather than an algebraic one: the default order-0 field
+    # has two free parameters, so three anchors would determine it but leave
+    # nothing to measure the scatter of. The robust pass raises the floor where
+    # the basis is wider (`astrom_robust.anchor_gate` takes
+    # `max(scene_minimum_anchors, 2p)`), so a higher polynomial order does not
+    # need this changed with it.
+    scene_minimum_anchors: int = 10
 
     # Aperture photometry and the catalog columns it compares against, as one
     # block (see PhotConfig). Nothing in the linear solve reads these.
@@ -282,17 +285,6 @@ class FitConfig:
                 f"fit_method must be 'lls', 'clip' or 'nnls', got "
                 f"{self.fit_method!r}"
             )
-
-        # Derive scene_minimum_anchors from astrometric polynomial order if not provided
-        if self.scene_minimum_anchors is None:
-            try:
-                # fallback matches the astrom_kwargs default above: order 0
-                poly_order = int(self.astrom_kwargs.get("poly", {}).get("order", 0))
-            except Exception:
-                poly_order = 0
-            # default to 2x # of Chebyshev terms + 1
-            n_poly = (poly_order + 1) * (poly_order + 2)
-            self.scene_minimum_anchors = n_poly + 1
 
         # Coerce a JSON `phot` object into a PhotConfig, as RunConfig does for
         # `psf`. Unknown keys raise rather than being ignored: a misspelled

--- a/src/mophongo/scene.py
+++ b/src/mophongo/scene.py
@@ -8,7 +8,7 @@ import scipy.sparse as sp
 
 from .templates import Template, Templates
 from .fit import FitConfig
-from .scene_fitter import SceneFitter
+from .scene_fitter import SceneFitter, _slice_intersection
 from .astrometry import cheb_basis, n_terms, AstroCorrect
 from scipy.sparse.csgraph import connected_components
 from .templates import _slices_from_bbox
@@ -590,6 +590,21 @@ def _scene_residual(
     return resid, y0, x0
 
 
+def _local_slice(
+    outer: tuple[slice, slice], inner: tuple[slice, slice]
+) -> tuple[slice, slice]:
+    """``inner`` re-expressed as offsets into an array laid out over ``outer``.
+
+    Both are slices in image coordinates and ``inner`` must lie inside
+    ``outer``, which is what :func:`~mophongo.scene_fitter._slice_intersection`
+    guarantees for the intersections it returns.
+    """
+    return (
+        slice(inner[0].start - outer[0].start, inner[0].stop - outer[0].start),
+        slice(inner[1].start - outer[1].start, inner[1].stop - outer[1].start),
+    )
+
+
 def measure_anchor_shifts(
     templates: Sequence[Template],
     resid: np.ndarray,
@@ -649,6 +664,16 @@ def measure_anchor_shifts(
     information divided by that has to be marginalized over everything local
     and free.
 
+    The local system is assembled from slice intersections, and its entries
+    are cached across anchors. Both are bookkeeping, not approximations: a
+    column is zero off its own template's slice, so integrating it over the
+    neighbourhood's union footprint adds only zeros, and ``<c_p, w, c_q>``
+    depends on the two columns and the weight map rather than on whose system
+    it is part of. What that avoids is a cost of ``ncol^2 / 2`` products over
+    the whole footprint per anchor, for columns each supported on one stamp;
+    on a 920-template scene at MINERVA density it is the difference between
+    1.3 s and 0.2 s (``scratch/bench_anchor_shifts.py``).
+
     Two approximations remain, both bounded by construction. Neighbours of
     neighbours are not included, and the union footprint stands in for the
     global flux constraint. What survives of them is smaller than the anchor's
@@ -690,31 +715,80 @@ def measure_anchor_shifts(
 
     slices = [t.slices_original for t in templates]
     anchors = {int(k) for k in bright_idx}
-    grads: dict[int, tuple[np.ndarray, np.ndarray]] = {}
 
-    def _grad(j: int) -> tuple[np.ndarray, np.ndarray] | None:
+    # A column is a key ``(template, kind)``: FLUX is the template itself, GX
+    # and GY its negated gradients. Nothing is ever laid out on the union
+    # footprint, because a column is zero everywhere off its own template's
+    # slice -- so every inner product below runs over the intersection of two
+    # slices, and a pair that does not overlap is zero without being touched.
+    #
+    # The keys are what makes the cache possible as well. ``<c_p, W, c_q>``
+    # depends on the two columns and the weight map, not on which anchor's
+    # system it appears in, and neighbouring anchors share most of their
+    # neighbourhoods -- so a scene's anchors share most of their entries.
+    FLUX, GX, GY = 0, 1, 2
+    grads: dict[int, tuple[np.ndarray, np.ndarray] | None] = {}
+
+    def _col(key: tuple[int, int]) -> np.ndarray | None:
+        """Column ``key`` over its own template's slice, or None if degenerate."""
+        j, kind = key
+        t = templates[j]
+        if kind == FLUX:
+            return t.data[t.slices_cutout]
         if j not in grads:
-            a_j = templates[j].data.astype(float)
-            if a_j.shape[0] < 2 or a_j.shape[1] < 2:
-                return None
-            gy_j, gx_j = np.gradient(a_j)
-            sc_j = templates[j].slices_cutout
-            grads[j] = (-gx_j[sc_j], -gy_j[sc_j])
-        return grads[j]
+            arr = np.asarray(t.data, dtype=float)
+            if arr.shape[0] < 2 or arr.shape[1] < 2:
+                grads[j] = None
+            else:
+                gy_j, gx_j = np.gradient(arr)
+                sc_j = t.slices_cutout
+                grads[j] = (-gx_j[sc_j], -gy_j[sc_j])
+        g = grads[j]
+        return None if g is None else g[kind - GX]
+
+    gram: dict[tuple[tuple[int, int], tuple[int, int]], float] = {}
+    rhs: dict[tuple[int, int], float] = {}
+
+    def _gram(ka: tuple[int, int], kb: tuple[int, int]) -> float:
+        key = (ka, kb) if ka <= kb else (kb, ka)
+        if key in gram:
+            return gram[key]
+        ja, jb = key[0][0], key[1][0]
+        inter = _slice_intersection(slices[ja], slices[jb])
+        if inter is None:
+            val = 0.0
+        else:
+            # float64 on the left so the products are taken in float64 whatever
+            # the stamps are stored as, which is what the padded buffers this
+            # replaced did by construction.
+            ca = np.asarray(_col(key[0])[_local_slice(slices[ja], inter)], dtype=float)
+            cb = _col(key[1])[_local_slice(slices[jb], inter)]
+            val = float(np.sum(ca * weights[inter] * cb))
+        gram[key] = val
+        return val
+
+    def _rhs(key: tuple[int, int]) -> float:
+        if key in rhs:
+            return rhs[key]
+        sl = slices[key[0]]
+        r = resid[
+            sl[0].start - y0 : sl[0].stop - y0, sl[1].start - x0 : sl[1].stop - x0
+        ]
+        c = np.asarray(_col(key), dtype=float)
+        rhs[key] = float(np.sum(c * weights[sl] * r))
+        return rhs[key]
 
     for i in bright_idx:
         i = int(i)
         a = float(alpha[i])
         if not np.isfinite(a) or a == 0.0:
             continue
-        t = templates[i]
-        arr = t.data.astype(float)
-        if arr.shape[0] < 2 or arr.shape[1] < 2:
+        if _col((i, GX)) is None:
             continue
 
-        # Every template overlapping this anchor joins the local fit, and the
-        # footprint is their union so each one's flux is constrained by all of
-        # its own pixels rather than only the part under the anchor.
+        # Every template overlapping this anchor joins the local fit, so each
+        # one's flux is constrained by all of its own pixels rather than only
+        # the part under the anchor.
         si = slices[i]
         nb = [
             j
@@ -724,50 +798,23 @@ def measure_anchor_shifts(
             and sj[1].start < si[1].stop
             and si[1].start < sj[1].stop
         ]
-        fy0 = min(slices[j][0].start for j in nb)
-        fy1 = max(slices[j][0].stop for j in nb)
-        fx0 = min(slices[j][1].start for j in nb)
-        fx1 = max(slices[j][1].stop for j in nb)
-
-        w = np.asarray(weights[fy0:fy1, fx0:fx1], dtype=float)
-        r = resid[fy0 - y0 : fy1 - y0, fx0 - x0 : fx1 - x0]
-        shape = (fy1 - fy0, fx1 - fx0)
-
-        def _place(j: int, values: np.ndarray) -> np.ndarray:
-            out = np.zeros(shape, dtype=float)
-            sj = slices[j]
-            out[
-                sj[0].start - fy0 : sj[0].stop - fy0,
-                sj[1].start - fx0 : sj[1].stop - fx0,
-            ] = values
-            return out
-
         # Columns: a flux for every overlapping template, then a free
         # displacement for every overlapping *anchor*, with this anchor's own
         # pair last so its conditional block is the trailing 2x2.
-        cols = [_place(j, templates[j].data[templates[j].slices_cutout]) for j in nb]
-        others = [k for k in nb if k in anchors and k != i]
-        for k in others:
-            g = _grad(k)
-            if g is None:
-                continue
-            cols.append(_place(k, g[0]))
-            cols.append(_place(k, g[1]))
-        g_i = _grad(i)
-        if g_i is None:
-            continue
-        cols.append(_place(i, g_i[0]))
-        cols.append(_place(i, g_i[1]))
+        cols: list[tuple[int, int]] = [(j, FLUX) for j in nb]
+        for k in nb:
+            if k in anchors and k != i and _col((k, GX)) is not None:
+                cols += [(k, GX), (k, GY)]
+        cols += [(i, GX), (i, GY)]
 
         ncol = len(cols)
         nrest = ncol - 2
         M = np.empty((ncol, ncol), dtype=float)
         s = np.empty(ncol, dtype=float)
         for p_ in range(ncol):
-            cw = cols[p_] * w
-            s[p_] = float(np.sum(cw * r))
+            s[p_] = _rhs(cols[p_])
             for q_ in range(p_, ncol):
-                M[p_, q_] = M[q_, p_] = float(np.sum(cw * cols[q_]))
+                M[p_, q_] = M[q_, p_] = _gram(cols[p_], cols[q_])
 
         # A rank-deficient local system (flat template, all-zero weights, two
         # anchors so blended their displacements are indistinguishable) carries
@@ -791,18 +838,24 @@ def measure_anchor_shifts(
 
         # Misfit is judged on the anchor's own stamp, not on the whole local
         # footprint: the question is whether *this* template fits, and a
-        # neighbour's problems should not be charged to it.
-        model = np.zeros(shape, dtype=float)
-        for c, th in zip(cols, theta):
-            model += th * c
-        own = (
-            slice(slices[i][0].start - fy0, slices[i][0].stop - fy0),
-            slice(slices[i][1].start - fx0, slices[i][1].stop - fx0),
+        # neighbour's problems should not be charged to it. So the model is
+        # only ever built there.
+        model = np.zeros(
+            (si[0].stop - si[0].start, si[1].stop - si[1].start), dtype=float
         )
-        w_own = w[own]
+        for key, th in zip(cols, theta):
+            inter = _slice_intersection(si, slices[key[0]])
+            if inter is None:
+                continue
+            model[_local_slice(si, inter)] += (
+                th * _col(key)[_local_slice(slices[key[0]], inter)]
+            )
+        w_own = np.asarray(weights[si], dtype=float)
         dof = int(np.count_nonzero(w_own > 0)) - ncol
         if dof > 0:
-            left = r[own] - model[own]
+            left = resid[
+                si[0].start - y0 : si[0].stop - y0, si[1].start - x0 : si[1].stop - x0
+            ] - model
             chi2_red[i] = float(np.sum(left * w_own * left)) / dof
 
     return eps, info, chi2_red

--- a/tests/test_scene_astrometry_robust.py
+++ b/tests/test_scene_astrometry_robust.py
@@ -133,6 +133,151 @@ def _solve_scene(templates, image, weights, cfg):
 # ---------------------------------------------------------------------------
 
 
+def _measure_anchor_shifts_padded(templates, resid, weights, origin, bright_idx, alpha):
+    """Reference: every column laid out on the neighbourhood's union footprint.
+
+    The obvious way to write the local system, and the way it was written
+    before the columns were reduced to slice intersections. Kept here so the
+    shipped version has something to be equal to -- the slice arithmetic is
+    where a rewrite like that goes wrong, and it goes wrong quietly.
+    """
+    n = len(templates)
+    y0, x0 = origin
+    eps = np.full((n, 2), np.nan)
+    info = np.zeros(n)
+    chi2_red = np.full(n, np.nan)
+    slices = [t.slices_original for t in templates]
+    anchors = {int(k) for k in bright_idx}
+
+    def _grad(j):
+        arr = np.asarray(templates[j].data, dtype=float)
+        if min(arr.shape) < 2:
+            return None
+        gy, gx = np.gradient(arr)
+        sc = templates[j].slices_cutout
+        return -gx[sc], -gy[sc]
+
+    for i in map(int, bright_idx):
+        a = float(alpha[i])
+        if not np.isfinite(a) or a == 0.0 or _grad(i) is None:
+            continue
+        si = slices[i]
+        nb = [j for j, sj in enumerate(slices)
+              if sj[0].start < si[0].stop and si[0].start < sj[0].stop
+              and sj[1].start < si[1].stop and si[1].start < sj[1].stop]
+        fy0 = min(slices[j][0].start for j in nb)
+        fy1 = max(slices[j][0].stop for j in nb)
+        fx0 = min(slices[j][1].start for j in nb)
+        fx1 = max(slices[j][1].stop for j in nb)
+        w = np.asarray(weights[fy0:fy1, fx0:fx1], dtype=float)
+        r = resid[fy0 - y0 : fy1 - y0, fx0 - x0 : fx1 - x0]
+
+        def _place(j, values):
+            out = np.zeros((fy1 - fy0, fx1 - fx0))
+            sj = slices[j]
+            out[sj[0].start - fy0 : sj[0].stop - fy0,
+                sj[1].start - fx0 : sj[1].stop - fx0] = values
+            return out
+
+        cols = [_place(j, templates[j].data[templates[j].slices_cutout]) for j in nb]
+        for k in nb:
+            if k in anchors and k != i and _grad(k) is not None:
+                g = _grad(k)
+                cols += [_place(k, g[0]), _place(k, g[1])]
+        g_i = _grad(i)
+        cols += [_place(i, g_i[0]), _place(i, g_i[1])]
+
+        ncol = len(cols)
+        nrest = ncol - 2
+        M = np.empty((ncol, ncol))
+        s = np.empty(ncol)
+        for p_ in range(ncol):
+            cw = cols[p_] * w
+            s[p_] = float(np.sum(cw * r))
+            for q_ in range(p_, ncol):
+                M[p_, q_] = M[q_, p_] = float(np.sum(cw * cols[q_]))
+
+        try:
+            theta = np.linalg.solve(M, s)
+            rest_inv = np.linalg.solve(M[:nrest, :nrest], M[:nrest, nrest:])
+        except np.linalg.LinAlgError:
+            continue
+        if not (np.all(np.isfinite(theta)) and np.all(np.isfinite(rest_inv))):
+            continue
+        schur = M[nrest:, nrest:] - M[nrest:, :nrest] @ rest_inv
+        iso = 0.5 * (schur[0, 0] + schur[1, 1])
+        if not (iso > 0):
+            continue
+        eps[i] = theta[nrest:] / a
+        info[i] = a**2 * iso
+
+        model = sum(th * c for c, th in zip(cols, theta))
+        own = (slice(si[0].start - fy0, si[0].stop - fy0),
+               slice(si[1].start - fx0, si[1].stop - fx0))
+        w_own = w[own]
+        dof = int(np.count_nonzero(w_own > 0)) - ncol
+        if dof > 0:
+            left = r[own] - model[own]
+            chi2_red[i] = float(np.sum(left * w_own * left)) / dof
+    return eps, info, chi2_red
+
+
+def _ragged_scene(seed: int = 3):
+    """Overlapping templates of different sizes, some clipped by the frame.
+
+    Equal-sized stamps on a regular grid would let a wrong offset cancel. The
+    sizes differ, the centres are off-pixel, two sit close enough to overlap
+    heavily, and one runs off the edge so its ``slices_cutout`` is a strict
+    sub-slice of its own data.
+    """
+    rng = np.random.default_rng(seed)
+    spec = [
+        (40.3, 60.7, 9, 3.0), (46.9, 63.1, 14, 4.0), (58.2, 57.4, 7, 2.0),
+        (95.6, 61.2, 18, 5.0), (101.1, 66.8, 11, 3.5), (8.4, 62.5, 20, 4.5),
+        (150.7, 60.1, 12, 3.0), (156.3, 55.9, 16, 4.0),
+    ]
+    templates = []
+    for label, (xc, yc, half, sigma) in enumerate(spec, start=1):
+        nn = 2 * half + 1
+        ix, iy = int(round(xc)) - half, int(round(yc)) - half
+        yy, xx = np.mgrid[iy : iy + nn, ix : ix + nn]
+        g = np.exp(-0.5 * (((xx - xc) / sigma) ** 2 + ((yy - yc) / sigma) ** 2))
+        templates.append(
+            Template.from_stamp(g / g.sum(), (ix, iy), (xc, yc), (NY, NX), label=label)
+        )
+    flux = np.array([120.0, 60.0, 25.0, 200.0, 45.0, 90.0, 150.0, 70.0])
+    img = _paint(templates, flux, [(0.18, -0.09)] * len(templates))
+    img += rng.normal(0.0, 1e-4, img.shape)
+    weights = rng.uniform(0.4, 1.6, img.shape)
+    weights[:, :6] = 0.0  # a strip with no exposure, as a real weight map has
+    return templates, img, weights, flux
+
+
+def test_local_systems_match_the_padded_reference():
+    """The intersection assembly is bookkeeping, not a new estimator.
+
+    Columns are zero off their own template's slice, so restricting every
+    inner product to a slice intersection can only drop zeros. Checked against
+    the padded reference on overlapping templates of different sizes, one of
+    them clipped by the frame, over a weight map with a dead strip.
+    """
+    templates, img, weights, flux = _ragged_scene()
+    A, b, _ = build_normal(templates, img, weights)
+    resid, y0, x0 = _scene_residual(templates, img, flux)
+    alpha = np.asarray(b / np.maximum(A.diagonal(), 1e-12))
+    bright = [0, 1, 3, 5, 6]
+
+    want = _measure_anchor_shifts_padded(
+        templates, resid, weights, (y0, x0), bright, alpha
+    )
+    got = measure_anchor_shifts(templates, resid, weights, (y0, x0), bright, alpha)
+
+    for name, w_, g_ in zip(("eps", "info", "chi2_red"), want, got):
+        assert np.array_equal(np.isnan(w_), np.isnan(g_)), name
+        np.testing.assert_allclose(g_, w_, rtol=1e-10, atol=1e-14, err_msg=name)
+    assert np.isfinite(want[0][bright]).all(), "reference measured nothing"
+
+
 def test_anchor_shift_is_recovered_exactly_for_isolated_anchors():
     """Noiseless, isolated, exact model: eps is the injected shift."""
     shift = (0.17, -0.09)

--- a/tests/test_scene_astrometry_robust.py
+++ b/tests/test_scene_astrometry_robust.py
@@ -692,16 +692,27 @@ def test_the_gate_is_scene_minimum_anchors():
     assert over.anchor_report.applied
 
 
-def test_scene_minimum_anchors_defaults_from_the_polynomial_order():
-    """One more anchor than the field has free parameters."""
-    assert FitConfig().scene_minimum_anchors == 3
+def test_scene_minimum_anchors_is_a_flat_floor_the_basis_can_raise():
+    """One number, whatever the astrometric model.
+
+    The floor used to be derived from the polynomial order. It is a
+    statistical floor rather than an algebraic one, so it does not follow the
+    order; where a wider basis does need more anchors, ``anchor_gate`` is what
+    raises it.
+    """
+    from mophongo.astrom_robust import anchor_gate
+
+    assert FitConfig().scene_minimum_anchors == 10
     assert (
         FitConfig(
             astrom_kwargs={"poly": {"order": 1}, "gp": {"length_scale": 400}}
         ).scene_minimum_anchors
-        == 7
+        == 10
     )
     assert FitConfig(scene_minimum_anchors=11).scene_minimum_anchors == 11
+
+    assert anchor_gate(10, 1) == 10  # order 0: the floor binds
+    assert anchor_gate(10, 6) == 12  # order 2: the basis binds
 
 
 def test_a_scene_below_the_gate_is_never_measured(monkeypatch):
@@ -803,8 +814,10 @@ def _beta_err(tm, img, W, iso, robust):
     truth = (0.20, -0.12)
     scn = _solve_scene(
         tm, img, W,
+        # a nine-template field cannot clear the default anchor floor, and
+        # these two tests are about the weighting rather than the gate
         _cfg(astrom_isolation_thresh=iso, astrom_minimum_snr=0.0,
-             astrom_robust=robust),
+             astrom_robust=robust, scene_minimum_anchors=3),
     )
     return np.abs(scn.shifts - np.array(truth)).max(), scn
 


### PR DESCRIPTION
## Summary

The rest of the `astrom_robust` slowdown. `FitConfig.astrom_robust` has been on by default since `6e0f27a` and took the astrometry phase of a cosmos_f770w run from 6m23s to 29m02s. `bba78e3` on main removed the two cheap wastes (measuring scenes that could only be declined, computing flux errors nobody reads); this branch removes the expensive one.

`measure_anchor_shifts` gave every anchor a local least-squares system over the union footprint of its neighbours, with each column zero-padded onto that footprint and the Gram formed there — `ncol^2 / 2` products over ~80k pixels per anchor, for columns supported on one ~10k-pixel stamp each. Both factors grow with crowding, since `ncol` counts every template whose bbox touches the anchor.

A column is now a key `(template, kind)` carrying no padding, and every inner product runs over the intersection of the two templates' slices — zero, and untouched, where they do not overlap. Entries are cached across anchors as well: `<c_p, W, c_q>` depends on the two columns and the weight map, not on whose system it appears in, and neighbouring anchors share most of their neighbourhoods. The `chi2_red` model is built on the anchor's own stamp, which is the only place it was ever read.

Neither change is an approximation, and the numbers say so — against the padded version on synthetic scenes at MINERVA density:

| scene | before | after | |
|---|---|---|---|
| 320 templates, 12 anchors, 101² stamps | 1456 ms | 184 ms | 7.9x |
| 920 templates, 14 anchors, 101² stamps | 1308 ms | 197 ms | 6.7x |
| 920 templates, 14 anchors, 151² stamps | 13249 ms | 1965 ms | 6.7x |

`max |Δeps| ≤ 4e-17` px, `max rel Δinfo ≤ 1e-14`, `Δchi2_red` exactly zero, NaN and zero-information masks identical.

With `bba78e3` the robust pass on the 920-template benchmark costs ~74 ms against ~1489 ms before.

Also on this branch, from concurrent work on the same tree: `scene_minimum_anchors` becomes a flat `int = 10` instead of being derived from the polynomial order as `(order+1)(order+2)+1`. That derivation gave 3 at the default order 0 — an algebraic count of the field's free parameters, not a number of anchors a scatter can be measured from — and every campaign config overrode it by hand anyway. A wider basis still raises the floor through `anchor_gate`'s `max(scene_minimum_anchors, 2p)`.

## Modules

- `src/mophongo/scene.py` — `measure_anchor_shifts` rewritten; new `_local_slice` helper; `_slice_intersection` reused from `scene_fitter`
- `src/mophongo/fit.py` — `scene_minimum_anchors: int = 10`, `__post_init__` derivation removed
- `examples/make_minerva_configs.py`, `docs/fitting.md`, `docs/pipeline.md` — follow the default
- `tests/test_scene_astrometry_robust.py` — equivalence test and gate updates

## Validation

- Full suite: 490 passed.
- `test_local_systems_match_the_padded_reference` keeps a padded reference implementation in the test file and checks the two agree on overlapping templates of different sizes, one clipped by the frame, over a weight map with a dead strip. The slice arithmetic is where a rewrite like this goes wrong and it goes wrong quietly, so the reference earns its lines: a one-pixel offset in `_local_slice` fails it.
- Benchmarks in `scratch/bench_anchor_shifts.py` (profile) and `scratch/bench_anchor_fast.py` (prototypes), gitignored.

## Notes

`STATUS.md` carries both entries. `TODO.md` carries the remaining step: the flux-flux block of a local system is `A` and its RHS is `b - A @ flux0`, both already built for the scene's flux solve, so ~95% of a crowded system need not be integrated at all — measured at 40-129x, against a signature that grows `A`, `b`, `flux0` and an invariant that would break silently rather than loudly.

https://claude.ai/code/session_01UbyPvD7nZaAAf2KNx2y2As